### PR TITLE
Add getting-started-with-earl agent skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ irm https://raw.githubusercontent.com/brwse/earl/main/scripts/install.ps1 | iex
 
 > **Using a coding agent?** Prompt it to fetch and follow the getting-started skill for an interactive, guided setup:
 >
-> _Fetch https://raw.githubusercontent.com/brwse/earl/main/skills/getting-started-with-earl/SKILL.md and follow it to help me get started with Earl._
+> _Fetch https://raw.githubusercontent.com/brwse/earl/main/skills/getting-started-with-earl/SKILL.md and any files it references under https://raw.githubusercontent.com/brwse/earl/main/skills/getting-started-with-earl/references/ — then follow the skill to help me get started with Earl._
 
 ```bash
 # Import a template

--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ irm https://raw.githubusercontent.com/brwse/earl/main/scripts/install.ps1 | iex
 
 ## Quick start
 
+> **Using a coding agent?** Prompt it to fetch and follow the getting-started skill for an interactive, guided setup:
+>
+> _Fetch https://raw.githubusercontent.com/brwse/earl/main/skills/getting-started-with-earl/SKILL.md and follow it to help me get started with Earl._
+
 ```bash
 # Import a template
 earl templates import ./examples/bash/system.hcl

--- a/site/content/docs/quick-start.mdx
+++ b/site/content/docs/quick-start.mdx
@@ -6,6 +6,13 @@ icon: Rocket
 
 This guide walks through two examples: a local Bash command (no secrets needed) and a GitHub API call. Earl must already be [installed](/docs/installation).
 
+<Callout type="info">
+**Using a coding agent?** Prompt it to fetch and follow the getting-started skill for an interactive, guided setup:
+
+_Fetch https://raw.githubusercontent.com/brwse/earl/main/skills/getting-started-with-earl/SKILL.md and follow it to help me get started with Earl._
+
+</Callout>
+
 ## Part 1: Local Command (No Secrets)
 
 <Steps>

--- a/site/content/docs/quick-start.mdx
+++ b/site/content/docs/quick-start.mdx
@@ -9,7 +9,7 @@ This guide walks through two examples: a local Bash command (no secrets needed) 
 <Callout type="info">
 **Using a coding agent?** Prompt it to fetch and follow the getting-started skill for an interactive, guided setup:
 
-_Fetch https://raw.githubusercontent.com/brwse/earl/main/skills/getting-started-with-earl/SKILL.md and follow it to help me get started with Earl._
+_Fetch https://raw.githubusercontent.com/brwse/earl/main/skills/getting-started-with-earl/SKILL.md and any files it references under https://raw.githubusercontent.com/brwse/earl/main/skills/getting-started-with-earl/references/ — then follow the skill to help me get started with Earl._
 
 </Callout>
 

--- a/skills/getting-started-with-earl/SKILL.md
+++ b/skills/getting-started-with-earl/SKILL.md
@@ -1,0 +1,140 @@
+---
+name: getting-started-with-earl
+description: Guides developers through installing Earl, running a quick demo, and creating their first API template. Use when someone is new to Earl, wants to set up Earl, or needs help creating their first template.
+---
+
+# Getting Started with Earl
+
+Earl is a CLI tool for calling APIs, databases, and shell commands through HCL template files. This skill guides a developer from zero to a working template.
+
+## Process
+
+1. **Install** — get Earl running
+2. **Demo** — show a working example immediately
+3. **Discover** — ask what the user wants to build
+4. **Build** — create their first custom template
+5. **Next steps** — contextual suggestions
+
+## Phase 1: Install
+
+Check if Earl is already installed:
+
+```bash
+earl --version
+```
+
+If not installed, detect the OS and install:
+
+**macOS / Linux:**
+```bash
+curl -fsSL https://raw.githubusercontent.com/brwse/earl/main/scripts/install.sh | bash
+```
+
+**Windows (PowerShell):**
+```powershell
+irm https://raw.githubusercontent.com/brwse/earl/main/scripts/install.ps1 | iex
+```
+
+**Alternative (requires Rust toolchain):**
+```bash
+cargo install earl
+```
+
+After install, verify:
+
+```bash
+earl doctor
+```
+
+If `earl doctor` succeeds, move on silently. If it fails, diagnose the specific error before continuing.
+
+## Phase 2: Quick Demo
+
+Import a ready-made template and run it so the user sees Earl work before making any decisions:
+
+```bash
+earl templates import https://raw.githubusercontent.com/brwse/earl/main/examples/bash/system.hcl
+```
+
+Run it:
+
+```bash
+earl call system.list_files --path .
+```
+
+This lists files in the current directory. The user now has a mental model of how Earl works: templates define commands, `earl call` runs them.
+
+Show what templates are available:
+
+```bash
+earl templates list
+```
+
+## Phase 3: Discover Intent
+
+Ask the user ONE question:
+
+> "What do you want to build with Earl? For example: call a REST API, query a database, run shell commands, call a GraphQL API, or call a gRPC service."
+
+Infer the protocol from their answer:
+
+| User mentions | Protocol | Reference file |
+|---|---|---|
+| REST, HTTP, API, endpoint, webhook, JSON API | HTTP | [http-templates.md](references/http-templates.md) |
+| GraphQL, query/mutation (in API context) | GraphQL | [graphql-templates.md](references/graphql-templates.md) |
+| gRPC, protobuf, service mesh | gRPC | [grpc-templates.md](references/grpc-templates.md) |
+| shell, bash, CLI, script, command line | Bash | [bash-templates.md](references/bash-templates.md) |
+| SQL, database, postgres, mysql, sqlite, query (in DB context) | SQL | [sql-templates.md](references/sql-templates.md) |
+
+Only ask a follow-up if the answer is genuinely ambiguous. If the user says "I want to call the GitHub API," infer HTTP with bearer auth — do not ask "which protocol?"
+
+### SSRF Warning
+
+If the user mentions `localhost`, `127.0.0.1`, `10.x.x.x`, `172.16-31.x.x`, `192.168.x.x`, or any private/loopback IP, warn them immediately:
+
+> Earl blocks requests to private and loopback IP addresses for security (SSRF protection). This is hard-coded and cannot be bypassed. You will need to use a publicly accessible URL, or use the `bash` protocol to call local services via curl.
+
+## Phase 4: Build First Template
+
+1. Read the reference file for the chosen protocol
+2. Walk the user through creating an HCL template file
+3. Save to `./templates/<provider>.hcl` (local) or `~/.config/earl/templates/<provider>.hcl` (global)
+4. If auth is needed, set up the secret: `earl secrets set <key>` (or `earl secrets set <key> --stdin` for piping)
+5. Run the template: `earl call <provider>.<command> --param value`
+6. Verify the template is listed: `earl templates list`
+
+### On Failure
+
+Categorize the error before suggesting a fix:
+
+| Error type | Symptoms | Fix |
+|---|---|---|
+| HCL parse error | "expected ...", "unexpected token" | File structure or syntax issue. Check HCL syntax. |
+| Jinja render error | "undefined variable", "template error" | Expression issue. Check `{{ args.* }}` references match param names. |
+| Auth error | HTTP 401 or 403 | Secret not set or expired. Run `earl secrets set <key>`. |
+| SSRF block | "address not allowed", connection refused to private IP | URL points to private/loopback IP. Use a public URL. |
+| API error (4xx/5xx) | HTTP status in response body | Earl ran successfully. The API itself returned an error. Check URL, params, and API docs. |
+
+After suggesting a fix, offer to re-run automatically.
+
+### Important Rules
+
+- **CLI flag order:** `--yes` and `--json` must come BEFORE the command args:
+  ```bash
+  earl call --yes --json provider.command --param value
+  ```
+- **Template directory:** Verify with `earl templates list` after creating a template
+- **HCL parses before Jinja:** All `{{ }}` expressions must be inside valid HCL string values. Never use bare expressions outside of strings.
+
+## Phase 5: What's Next
+
+Suggest next steps based on what the user built. Do not give a generic list.
+
+**Common suggestions:**
+
+- **JSON output for scripting:** `earl call --json provider.command | jq .`
+- **Shell completions:** `earl completion bash >> ~/.bashrc` (or zsh/fish equivalent)
+- **Add more commands:** Add another `command` block to the same template file
+- **MCP integration:** See [mcp-integration.md](references/mcp-integration.md) to expose templates as tools for Claude Desktop or Claude Code
+- **Advanced auth:** See [secrets-and-auth.md](references/secrets-and-auth.md) for OAuth, API keys, and advanced auth flows
+- **Template schema reference:** See [template-quick-ref.md](references/template-quick-ref.md) for all protocol shapes and field options

--- a/skills/getting-started-with-earl/SKILL.md
+++ b/skills/getting-started-with-earl/SKILL.md
@@ -26,16 +26,19 @@ earl --version
 If not installed, detect the OS and install:
 
 **macOS / Linux:**
+
 ```bash
 curl -fsSL https://raw.githubusercontent.com/brwse/earl/main/scripts/install.sh | bash
 ```
 
 **Windows (PowerShell):**
+
 ```powershell
 irm https://raw.githubusercontent.com/brwse/earl/main/scripts/install.ps1 | iex
 ```
 
 **Alternative (requires Rust toolchain):**
+
 ```bash
 cargo install earl
 ```
@@ -78,13 +81,13 @@ Ask the user ONE question:
 
 Infer the protocol from their answer:
 
-| User mentions | Protocol | Reference file |
-|---|---|---|
-| REST, HTTP, API, endpoint, webhook, JSON API | HTTP | [http-templates.md](references/http-templates.md) |
-| GraphQL, query/mutation (in API context) | GraphQL | [graphql-templates.md](references/graphql-templates.md) |
-| gRPC, protobuf, service mesh | gRPC | [grpc-templates.md](references/grpc-templates.md) |
-| shell, bash, CLI, script, command line | Bash | [bash-templates.md](references/bash-templates.md) |
-| SQL, database, postgres, mysql, sqlite, query (in DB context) | SQL | [sql-templates.md](references/sql-templates.md) |
+| User mentions                                                 | Protocol | Reference file                                          |
+| ------------------------------------------------------------- | -------- | ------------------------------------------------------- |
+| REST, HTTP, API, endpoint, webhook, JSON API                  | HTTP     | [http-templates.md](references/http-templates.md)       |
+| GraphQL, query/mutation (in API context)                      | GraphQL  | [graphql-templates.md](references/graphql-templates.md) |
+| gRPC, protobuf, service mesh                                  | gRPC     | [grpc-templates.md](references/grpc-templates.md)       |
+| shell, bash, CLI, script, command line                        | Bash     | [bash-templates.md](references/bash-templates.md)       |
+| SQL, database, postgres, mysql, sqlite, query (in DB context) | SQL      | [sql-templates.md](references/sql-templates.md)         |
 
 Only ask a follow-up if the answer is genuinely ambiguous. If the user says "I want to call the GitHub API," infer HTTP with bearer auth — do not ask "which protocol?"
 
@@ -107,13 +110,13 @@ If the user mentions `localhost`, `127.0.0.1`, `10.x.x.x`, `172.16-31.x.x`, `192
 
 Categorize the error before suggesting a fix:
 
-| Error type | Symptoms | Fix |
-|---|---|---|
-| HCL parse error | "expected ...", "unexpected token" | File structure or syntax issue. Check HCL syntax. |
-| Jinja render error | "undefined variable", "template error" | Expression issue. Check `{{ args.* }}` references match param names. |
-| Auth error | HTTP 401 or 403 | Secret not set or expired. Run `earl secrets set <key>`. |
-| SSRF block | "address not allowed", connection refused to private IP | URL points to private/loopback IP. Use a public URL. |
-| API error (4xx/5xx) | HTTP status in response body | Earl ran successfully. The API itself returned an error. Check URL, params, and API docs. |
+| Error type          | Symptoms                                                | Fix                                                                                       |
+| ------------------- | ------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
+| HCL parse error     | "expected ...", "unexpected token"                      | File structure or syntax issue. Check HCL syntax.                                         |
+| Jinja render error  | "undefined variable", "template error"                  | Expression issue. Check `{{ args.* }}` references match param names.                      |
+| Auth error          | HTTP 401 or 403                                         | Secret not set or expired. Run `earl secrets set <key>`.                                  |
+| SSRF block          | "address not allowed", connection refused to private IP | URL points to private/loopback IP. Use a public URL.                                      |
+| API error (4xx/5xx) | HTTP status in response body                            | Earl ran successfully. The API itself returned an error. Check URL, params, and API docs. |
 
 After suggesting a fix, offer to re-run automatically.
 

--- a/skills/getting-started-with-earl/references/bash-templates.md
+++ b/skills/getting-started-with-earl/references/bash-templates.md
@@ -45,18 +45,19 @@ command "disk_usage" {
 
 ## Key Fields
 
-| Field | Required | Description |
-|---|---|---|
-| `bash.script` | Yes | Shell command to execute (supports `{{ args.* }}`) |
-| `bash.sandbox.network` | No | Allow network access (default: false) |
-| `bash.sandbox.max_time_ms` | No | Timeout in milliseconds (default: from config) |
-| `bash.sandbox.max_output_bytes` | No | Max output size (default: from config) |
+| Field                           | Required | Description                                        |
+| ------------------------------- | -------- | -------------------------------------------------- |
+| `bash.script`                   | Yes      | Shell command to execute (supports `{{ args.* }}`) |
+| `bash.sandbox.network`          | No       | Allow network access (default: false)              |
+| `bash.sandbox.max_time_ms`      | No       | Timeout in milliseconds (default: from config)     |
+| `bash.sandbox.max_output_bytes` | No       | Max output size (default: from config)             |
 
 **Note:** Bash uses a nested `bash` block inside `operation`.
 
 ## Sandbox
 
 Bash commands run in a sandbox by default:
+
 - **No network access** unless `network = true`
 - **Configurable timeout** via `max_time_ms`
 - **Output limits** via `max_output_bytes`

--- a/skills/getting-started-with-earl/references/bash-templates.md
+++ b/skills/getting-started-with-earl/references/bash-templates.md
@@ -1,0 +1,100 @@
+# Bash Templates
+
+Use Bash when running shell commands, CLI tools, or local scripts.
+
+## Template Skeleton
+
+```hcl
+version = 1
+provider = "tools"
+
+command "disk_usage" {
+  title       = "Disk Usage"
+  summary     = "Check disk usage for a path"
+  description = "Reports disk usage using du"
+
+  annotations {
+    mode = "read"
+  }
+
+  param "path" {
+    type        = "string"
+    required    = true
+    description = "Path to check"
+  }
+
+  operation {
+    protocol = "bash"
+
+    bash {
+      script = "du -sh {{ args.path }}"
+
+      sandbox {
+        network      = false
+        max_time_ms  = 30000
+      }
+    }
+  }
+
+  result {
+    decode = "text"
+    output = "{{ result }}"
+  }
+}
+```
+
+## Key Fields
+
+| Field | Required | Description |
+|---|---|---|
+| `bash.script` | Yes | Shell command to execute (supports `{{ args.* }}`) |
+| `bash.sandbox.network` | No | Allow network access (default: false) |
+| `bash.sandbox.max_time_ms` | No | Timeout in milliseconds (default: from config) |
+| `bash.sandbox.max_output_bytes` | No | Max output size (default: from config) |
+
+**Note:** Bash uses a nested `bash` block inside `operation`.
+
+## Sandbox
+
+Bash commands run in a sandbox by default:
+- **No network access** unless `network = true`
+- **Configurable timeout** via `max_time_ms`
+- **Output limits** via `max_output_bytes`
+
+Global sandbox defaults can be set in `~/.config/earl/config.toml`:
+
+```toml
+[sandbox]
+bash_max_time_ms = 60000
+bash_max_output_bytes = 1048576
+bash_allow_network = false
+```
+
+## Multi-line Scripts
+
+Use HCL heredoc syntax for longer scripts:
+
+```hcl
+bash {
+  script = <<-EOT
+    echo "Checking system info..."
+    uname -a
+    df -h
+    free -m 2>/dev/null || vm_stat
+  EOT
+}
+```
+
+## Auth
+
+Bash templates typically do not use auth blocks. If you need credentials in a script, reference secrets directly:
+
+```hcl
+bash {
+  script = "curl -H 'Authorization: Bearer {{ secrets.myapi_token }}' https://api.example.com/data"
+}
+```
+
+Set the secret: `earl secrets set myapi.token`
+
+Note that `secrets.*` uses underscores in template expressions (e.g., `secrets.myapi_token`), while the secret key uses dots (e.g., `myapi.token`).

--- a/skills/getting-started-with-earl/references/graphql-templates.md
+++ b/skills/getting-started-with-earl/references/graphql-templates.md
@@ -60,12 +60,12 @@ command "get_user" {
 
 ## Key Fields
 
-| Field | Required | Description |
-|---|---|---|
-| `url` | Yes | GraphQL endpoint URL |
-| `graphql.query` | Yes | The GraphQL query or mutation string |
-| `graphql.variables` | No | Variables as key-value map (supports `{{ args.* }}`) |
-| `auth` | No | Authentication block (same as HTTP) |
+| Field               | Required | Description                                          |
+| ------------------- | -------- | ---------------------------------------------------- |
+| `url`               | Yes      | GraphQL endpoint URL                                 |
+| `graphql.query`     | Yes      | The GraphQL query or mutation string                 |
+| `graphql.variables` | No       | Variables as key-value map (supports `{{ args.* }}`) |
+| `auth`              | No       | Authentication block (same as HTTP)                  |
 
 **Note:** GraphQL uses a nested `graphql` block inside `operation`, unlike HTTP which is flat.
 

--- a/skills/getting-started-with-earl/references/graphql-templates.md
+++ b/skills/getting-started-with-earl/references/graphql-templates.md
@@ -1,0 +1,117 @@
+# GraphQL Templates
+
+Use GraphQL when calling a GraphQL API endpoint.
+
+## Template Skeleton
+
+```hcl
+version = 1
+provider = "myapi_graphql"
+
+command "get_user" {
+  title       = "Get User"
+  summary     = "Fetch user profile from GraphQL API"
+  description = "Queries the authenticated user's profile"
+
+  annotations {
+    mode    = "read"
+    secrets = ["myapi.token"]
+  }
+
+  param "username" {
+    type        = "string"
+    required    = true
+    description = "Username to look up"
+  }
+
+  operation {
+    protocol = "graphql"
+    url      = "https://api.example.com/graphql"
+
+    graphql {
+      query = <<-EOT
+        query GetUser($username: String!) {
+          user(login: $username) {
+            name
+            email
+            createdAt
+          }
+        }
+      EOT
+
+      variables = {
+        username = "{{ args.username }}"
+      }
+    }
+
+    auth {
+      kind   = "bearer"
+      secret = "myapi.token"
+    }
+  }
+
+  result {
+    decode  = "json"
+    extract = { json_pointer = "/data/user" }
+    output  = "User: {{ result.name }} ({{ result.email }})"
+  }
+}
+```
+
+## Key Fields
+
+| Field | Required | Description |
+|---|---|---|
+| `url` | Yes | GraphQL endpoint URL |
+| `graphql.query` | Yes | The GraphQL query or mutation string |
+| `graphql.variables` | No | Variables as key-value map (supports `{{ args.* }}`) |
+| `auth` | No | Authentication block (same as HTTP) |
+
+**Note:** GraphQL uses a nested `graphql` block inside `operation`, unlike HTTP which is flat.
+
+## Mutations
+
+For write operations, use `annotations { mode = "write" }`:
+
+```hcl
+command "create_item" {
+  annotations {
+    mode = "write"
+  }
+
+  operation {
+    protocol = "graphql"
+    url      = "https://api.example.com/graphql"
+
+    graphql {
+      query = <<-EOT
+        mutation CreateItem($title: String!) {
+          createItem(input: { title: $title }) {
+            id
+            title
+          }
+        }
+      EOT
+
+      variables = {
+        title = "{{ args.title }}"
+      }
+    }
+  }
+}
+```
+
+## Auth
+
+GraphQL APIs typically use bearer tokens:
+
+```hcl
+auth {
+  kind   = "bearer"
+  secret = "myapi.token"
+}
+```
+
+Set the secret: `earl secrets set myapi.token`
+
+For advanced auth, see [secrets-and-auth.md](secrets-and-auth.md).

--- a/skills/getting-started-with-earl/references/grpc-templates.md
+++ b/skills/getting-started-with-earl/references/grpc-templates.md
@@ -48,14 +48,14 @@ command "health_check" {
 
 ## Key Fields
 
-| Field | Required | Description |
-|---|---|---|
-| `url` | Yes | gRPC server address (include port) |
-| `timeout_ms` | No | Request timeout in milliseconds |
-| `grpc.service` | Yes | Fully qualified service name |
-| `grpc.method` | Yes | RPC method name |
-| `grpc.body` | No | Request message as key-value map |
-| `grpc.descriptor_set_file` | No | Path to offline descriptor set (`.fds.bin`) |
+| Field                      | Required | Description                                 |
+| -------------------------- | -------- | ------------------------------------------- |
+| `url`                      | Yes      | gRPC server address (include port)          |
+| `timeout_ms`               | No       | Request timeout in milliseconds             |
+| `grpc.service`             | Yes      | Fully qualified service name                |
+| `grpc.method`              | Yes      | RPC method name                             |
+| `grpc.body`                | No       | Request message as key-value map            |
+| `grpc.descriptor_set_file` | No       | Path to offline descriptor set (`.fds.bin`) |
 
 **Note:** gRPC uses a nested `grpc` block inside `operation`.
 

--- a/skills/getting-started-with-earl/references/grpc-templates.md
+++ b/skills/getting-started-with-earl/references/grpc-templates.md
@@ -1,0 +1,90 @@
+# gRPC Templates
+
+Use gRPC when calling gRPC services (protobuf-based RPC).
+
+## Template Skeleton (with reflection)
+
+```hcl
+version = 1
+provider = "myservice"
+
+command "health_check" {
+  title       = "Health Check"
+  summary     = "Check gRPC service health"
+  description = "Calls the standard gRPC health check endpoint"
+
+  annotations {
+    mode = "read"
+  }
+
+  param "service" {
+    type        = "string"
+    required    = false
+    description = "Service name to check (empty for server health)"
+    default     = ""
+  }
+
+  operation {
+    protocol   = "grpc"
+    url        = "http://grpc.example.com:50051"
+    timeout_ms = 5000
+
+    grpc {
+      service = "grpc.health.v1.Health"
+      method  = "Check"
+
+      body = {
+        service = "{{ args.service }}"
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Status: {{ result.status }}"
+  }
+}
+```
+
+## Key Fields
+
+| Field | Required | Description |
+|---|---|---|
+| `url` | Yes | gRPC server address (include port) |
+| `timeout_ms` | No | Request timeout in milliseconds |
+| `grpc.service` | Yes | Fully qualified service name |
+| `grpc.method` | Yes | RPC method name |
+| `grpc.body` | No | Request message as key-value map |
+| `grpc.descriptor_set_file` | No | Path to offline descriptor set (`.fds.bin`) |
+
+**Note:** gRPC uses a nested `grpc` block inside `operation`.
+
+## Reflection vs Descriptor Set
+
+**Reflection (default):** Earl discovers the service schema at runtime via gRPC reflection. The server must support reflection (v1). No extra files needed.
+
+**Descriptor set:** For servers without reflection, provide a pre-compiled descriptor set:
+
+```hcl
+grpc {
+  service             = "mypackage.MyService"
+  method              = "MyMethod"
+  descriptor_set_file = "myservice.fds.bin"
+
+  body = {
+    field = "{{ args.value }}"
+  }
+}
+```
+
+Generate the descriptor set from proto files:
+
+```bash
+protoc --descriptor_set_out=myservice.fds.bin --include_imports myservice.proto
+```
+
+## Known Issues
+
+**TLS with SSRF protection:** Earl's TOCTOU protection pins the gRPC endpoint to its resolved IP address, which can break TLS certificate validation (the cert expects the hostname, not the IP). For TLS endpoints, consider using `descriptor_set_file` to avoid reflection-related issues, or use HTTP-based testing.
+
+**Reflection version:** Earl uses gRPC reflection v1. Some servers only support v1alpha. If reflection fails, try using a descriptor set instead.

--- a/skills/getting-started-with-earl/references/http-templates.md
+++ b/skills/getting-started-with-earl/references/http-templates.md
@@ -60,14 +60,14 @@ command "get_items" {
 
 ## Key Fields
 
-| Field | Required | Description |
-|---|---|---|
-| `method` | Yes | HTTP method: GET, POST, PUT, PATCH, DELETE |
-| `url` | Yes | Full URL (supports `{{ args.* }}` expressions) |
-| `query` | No | Query parameters as key-value map |
-| `headers` | No | HTTP headers as key-value map |
-| `body` | No | Request body (see body kinds below) |
-| `auth` | No | Authentication block |
+| Field     | Required | Description                                    |
+| --------- | -------- | ---------------------------------------------- |
+| `method`  | Yes      | HTTP method: GET, POST, PUT, PATCH, DELETE     |
+| `url`     | Yes      | Full URL (supports `{{ args.* }}` expressions) |
+| `query`   | No       | Query parameters as key-value map              |
+| `headers` | No       | HTTP headers as key-value map                  |
+| `body`    | No       | Request body (see body kinds below)            |
+| `auth`    | No       | Authentication block                           |
 
 **Note:** HTTP operation fields are flat (directly in the `operation` block), unlike other protocols which use nested sub-blocks.
 
@@ -129,11 +129,13 @@ For advanced auth (OAuth, profiles), see [secrets-and-auth.md](secrets-and-auth.
 ## Common Patterns
 
 **URL parameters:**
+
 ```hcl
 url = "https://api.example.com/users/{{ args.user_id }}/repos"
 ```
 
 **Result extraction with JSON pointer:**
+
 ```hcl
 result {
   decode  = "json"
@@ -143,6 +145,7 @@ result {
 ```
 
 **Write-mode command (requires user confirmation):**
+
 ```hcl
 annotations {
   mode = "write"

--- a/skills/getting-started-with-earl/references/http-templates.md
+++ b/skills/getting-started-with-earl/references/http-templates.md
@@ -1,0 +1,150 @@
+# HTTP Templates
+
+Use HTTP when calling REST APIs, webhooks, or any HTTP endpoint.
+
+## Template Skeleton
+
+```hcl
+version = 1
+provider = "myapi"
+
+command "get_items" {
+  title       = "Get Items"
+  summary     = "Fetch items from the API"
+  description = "Retrieves a list of items with optional filtering"
+
+  annotations {
+    mode = "read"
+    secrets = ["myapi.token"]
+  }
+
+  param "query" {
+    type        = "string"
+    required    = true
+    description = "Search query"
+  }
+
+  param "limit" {
+    type        = "integer"
+    required    = false
+    description = "Max results to return"
+    default     = 10
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://api.example.com/items"
+
+    query = {
+      q     = "{{ args.query }}"
+      limit = "{{ args.limit }}"
+    }
+
+    headers = {
+      Accept = "application/json"
+    }
+
+    auth {
+      kind   = "bearer"
+      secret = "myapi.token"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Found {{ result | length }} items"
+  }
+}
+```
+
+## Key Fields
+
+| Field | Required | Description |
+|---|---|---|
+| `method` | Yes | HTTP method: GET, POST, PUT, PATCH, DELETE |
+| `url` | Yes | Full URL (supports `{{ args.* }}` expressions) |
+| `query` | No | Query parameters as key-value map |
+| `headers` | No | HTTP headers as key-value map |
+| `body` | No | Request body (see body kinds below) |
+| `auth` | No | Authentication block |
+
+**Note:** HTTP operation fields are flat (directly in the `operation` block), unlike other protocols which use nested sub-blocks.
+
+## Body Kinds
+
+For POST/PUT/PATCH, add a `body` block inside `operation`:
+
+```hcl
+# JSON body
+body {
+  kind  = "json"
+  value = {
+    title = "{{ args.title }}"
+    body  = "{{ args.body }}"
+  }
+}
+
+# Form body
+body {
+  kind  = "form"
+  value = {
+    username = "{{ args.username }}"
+    password = "{{ args.password }}"
+  }
+}
+
+# Raw text body
+body {
+  kind  = "raw"
+  value = "{{ args.content }}"
+}
+```
+
+## Auth Patterns
+
+```hcl
+# Bearer token (most common for REST APIs)
+auth {
+  kind   = "bearer"
+  secret = "myapi.token"
+}
+
+# Basic auth
+auth {
+  kind   = "basic"
+  secret = "myapi.credentials"
+}
+
+# API key in header (use headers instead of auth block)
+headers = {
+  X-API-Key = "{{ secrets.myapi_key }}"
+}
+```
+
+Set the secret: `earl secrets set myapi.token`
+
+For advanced auth (OAuth, profiles), see [secrets-and-auth.md](secrets-and-auth.md).
+
+## Common Patterns
+
+**URL parameters:**
+```hcl
+url = "https://api.example.com/users/{{ args.user_id }}/repos"
+```
+
+**Result extraction with JSON pointer:**
+```hcl
+result {
+  decode  = "json"
+  extract = { json_pointer = "/items" }
+  output  = "Found {{ result | length }} items"
+}
+```
+
+**Write-mode command (requires user confirmation):**
+```hcl
+annotations {
+  mode = "write"
+}
+```

--- a/skills/getting-started-with-earl/references/mcp-integration.md
+++ b/skills/getting-started-with-earl/references/mcp-integration.md
@@ -1,0 +1,79 @@
+# MCP Integration
+
+Earl can expose your templates as MCP (Model Context Protocol) tools, making them available to Claude Desktop, Claude Code, and other MCP-compatible agents.
+
+## Quick Start
+
+Run Earl as an MCP server:
+
+```bash
+earl mcp stdio
+```
+
+This starts Earl in discovery mode (default), exposing two meta-tools:
+- `earl.tool_search` — search for templates by natural language query
+- `earl.tool_call` — execute a template by name
+
+## Two Modes
+
+**Discovery mode (default, recommended):** Two meta-tools for searching and calling templates. Best for large template catalogs.
+
+```bash
+earl mcp stdio --mode discovery
+```
+
+**Full mode:** Each template becomes a separate MCP tool. Best for small catalogs (<30 templates).
+
+```bash
+earl mcp stdio --mode full
+```
+
+## Claude Desktop Configuration
+
+Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_desktop_config.json` on macOS):
+
+```json
+{
+  "mcpServers": {
+    "earl": {
+      "command": "earl",
+      "args": ["mcp", "stdio"]
+    }
+  }
+}
+```
+
+## Claude Code Configuration
+
+Add to `.claude/settings.json` in your project:
+
+```json
+{
+  "mcpServers": {
+    "earl": {
+      "command": "earl",
+      "args": ["mcp", "stdio"]
+    }
+  }
+}
+```
+
+## HTTP Transport
+
+For remote or shared deployments, use HTTP transport:
+
+```bash
+earl mcp http --listen 127.0.0.1:3000
+```
+
+This serves MCP at `POST /mcp` with a health check at `GET /health`.
+
+## Auto-Approve Writes
+
+By default, write-mode commands require user confirmation. To auto-approve:
+
+```bash
+earl mcp stdio --yes
+```
+
+Use this only in trusted environments.

--- a/skills/getting-started-with-earl/references/mcp-integration.md
+++ b/skills/getting-started-with-earl/references/mcp-integration.md
@@ -11,6 +11,7 @@ earl mcp stdio
 ```
 
 This starts Earl in discovery mode (default), exposing two meta-tools:
+
 - `earl.tool_search` — search for templates by natural language query
 - `earl.tool_call` — execute a template by name
 

--- a/skills/getting-started-with-earl/references/secrets-and-auth.md
+++ b/skills/getting-started-with-earl/references/secrets-and-auth.md
@@ -82,16 +82,19 @@ scopes = ["read", "write"]
 Supported flows: `device_code`, `auth_code_pkce`, `client_credentials`.
 
 Log in:
+
 ```bash
 earl auth login myservice
 ```
 
 Check status:
+
 ```bash
 earl auth status myservice
 ```
 
 Then reference it in templates:
+
 ```hcl
 auth {
   kind    = "oauth2"

--- a/skills/getting-started-with-earl/references/secrets-and-auth.md
+++ b/skills/getting-started-with-earl/references/secrets-and-auth.md
@@ -1,0 +1,113 @@
+# Secrets and Authentication
+
+Earl stores secrets in the OS keychain (Apple Keychain, Windows Credential Manager, Linux Secret Service) and supports multiple authentication patterns.
+
+## Managing Secrets
+
+```bash
+# Set a secret (interactive prompt)
+earl secrets set myapi.token
+
+# Set a secret from stdin (for piping)
+echo "sk-abc123" | earl secrets set myapi.token --stdin
+
+# View a secret
+earl secrets get myapi.token
+
+# List all secrets
+earl secrets list
+
+# Delete a secret
+earl secrets delete myapi.token
+```
+
+## Auth Block Kinds
+
+Use an `auth` block inside `operation` to attach credentials to requests:
+
+```hcl
+# Bearer token
+auth {
+  kind   = "bearer"
+  secret = "myapi.token"
+}
+
+# Basic auth (username:password stored as single secret)
+auth {
+  kind   = "basic"
+  secret = "myapi.credentials"
+}
+
+# OAuth2 profile (uses config.toml profile)
+auth {
+  kind    = "oauth2"
+  profile = "myservice"
+}
+```
+
+## Referencing Secrets in Templates
+
+In `auth` blocks, use the `secret` field with the dotted key name:
+
+```hcl
+auth {
+  kind   = "bearer"
+  secret = "github.token"
+}
+```
+
+In template expressions (e.g., headers or bash scripts), use `secrets.*` with underscores:
+
+```hcl
+headers = {
+  X-API-Key = "{{ secrets.myapi_key }}"
+}
+```
+
+Note: dots in secret keys become underscores in template expressions (`myapi.key` becomes `secrets.myapi_key`).
+
+## OAuth2 Profiles
+
+For OAuth2 flows, configure a profile in `~/.config/earl/config.toml`:
+
+```toml
+[auth.profiles.myservice]
+flow = "device_code"
+client_id = "your-client-id"
+token_url = "https://auth.example.com/token"
+device_authorization_url = "https://auth.example.com/device"
+scopes = ["read", "write"]
+```
+
+Supported flows: `device_code`, `auth_code_pkce`, `client_credentials`.
+
+Log in:
+```bash
+earl auth login myservice
+```
+
+Check status:
+```bash
+earl auth status myservice
+```
+
+Then reference it in templates:
+```hcl
+auth {
+  kind    = "oauth2"
+  profile = "myservice"
+}
+```
+
+## Annotations
+
+Declare which secrets a command needs in `annotations`:
+
+```hcl
+annotations {
+  mode    = "read"
+  secrets = ["myapi.token"]
+}
+```
+
+This tells Earl (and MCP consumers) which secrets are required before the command can run.

--- a/skills/getting-started-with-earl/references/sql-templates.md
+++ b/skills/getting-started-with-earl/references/sql-templates.md
@@ -49,13 +49,13 @@ command "recent_orders" {
 
 ## Key Fields
 
-| Field | Required | Description |
-|---|---|---|
-| `sql.connection_secret` | Yes | Secret key containing the database connection URL |
-| `sql.query` | Yes | SQL query with `?` placeholders for parameters |
-| `sql.params` | No | Array of parameter values (supports `{{ args.* }}`) |
-| `sql.sandbox.read_only` | No | Force read-only mode (default: true) |
-| `sql.sandbox.max_rows` | No | Maximum rows returned |
+| Field                   | Required | Description                                         |
+| ----------------------- | -------- | --------------------------------------------------- |
+| `sql.connection_secret` | Yes      | Secret key containing the database connection URL   |
+| `sql.query`             | Yes      | SQL query with `?` placeholders for parameters      |
+| `sql.params`            | No       | Array of parameter values (supports `{{ args.* }}`) |
+| `sql.sandbox.read_only` | No       | Force read-only mode (default: true)                |
+| `sql.sandbox.max_rows`  | No       | Maximum rows returned                               |
 
 **Note:** SQL uses a nested `sql` block inside `operation`.
 
@@ -64,11 +64,13 @@ command "recent_orders" {
 HCL parsing happens BEFORE Jinja template rendering. This means all `{{ }}` expressions must be valid HCL tokens.
 
 **Correct — string-wrapped params:**
+
 ```hcl
 params = ["{{ args.limit }}"]
 ```
 
 **Wrong — bare expression (invalid HCL):**
+
 ```hcl
 params = [{{ args.limit }}]
 ```
@@ -88,6 +90,7 @@ Set it: `earl secrets set analytics.db_url --stdin` (then paste the URL)
 ## Sandbox
 
 SQL queries run with safety defaults:
+
 - **Read-only by default** (`read_only = true`) — prevents accidental writes
 - **Row limits** — cap output size with `max_rows`
 

--- a/skills/getting-started-with-earl/references/sql-templates.md
+++ b/skills/getting-started-with-earl/references/sql-templates.md
@@ -1,0 +1,116 @@
+# SQL Templates
+
+Use SQL when querying databases (PostgreSQL, MySQL, SQLite, etc.).
+
+## Template Skeleton
+
+```hcl
+version = 1
+provider = "analytics"
+
+command "recent_orders" {
+  title       = "Recent Orders"
+  summary     = "Fetch recent orders from the database"
+  description = "Queries the orders table with a configurable limit"
+
+  annotations {
+    mode    = "read"
+    secrets = ["analytics.db_url"]
+  }
+
+  param "limit" {
+    type        = "integer"
+    required    = false
+    description = "Max rows to return"
+    default     = 10
+  }
+
+  operation {
+    protocol = "sql"
+
+    sql {
+      connection_secret = "analytics.db_url"
+      query             = "SELECT id, customer, total, created_at FROM orders ORDER BY created_at DESC LIMIT ?"
+      params            = ["{{ args.limit }}"]
+
+      sandbox {
+        read_only = true
+        max_rows  = 100
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Found {{ result | length }} orders"
+  }
+}
+```
+
+## Key Fields
+
+| Field | Required | Description |
+|---|---|---|
+| `sql.connection_secret` | Yes | Secret key containing the database connection URL |
+| `sql.query` | Yes | SQL query with `?` placeholders for parameters |
+| `sql.params` | No | Array of parameter values (supports `{{ args.* }}`) |
+| `sql.sandbox.read_only` | No | Force read-only mode (default: true) |
+| `sql.sandbox.max_rows` | No | Maximum rows returned |
+
+**Note:** SQL uses a nested `sql` block inside `operation`.
+
+## Critical: HCL/Jinja Interaction
+
+HCL parsing happens BEFORE Jinja template rendering. This means all `{{ }}` expressions must be valid HCL tokens.
+
+**Correct — string-wrapped params:**
+```hcl
+params = ["{{ args.limit }}"]
+```
+
+**Wrong — bare expression (invalid HCL):**
+```hcl
+params = [{{ args.limit }}]
+```
+
+The string-wrapped version works because Earl's `render_string_value` auto-parses pure Jinja expressions as JSON, so `"{{ args.limit }}"` correctly becomes a number when `args.limit` is an integer.
+
+## Connection URL Format
+
+The connection secret should contain a standard database URL:
+
+- **PostgreSQL:** `postgres://user:pass@host:5432/dbname`
+- **MySQL:** `mysql://user:pass@host:3306/dbname`
+- **SQLite:** `sqlite:///path/to/database.db`
+
+Set it: `earl secrets set analytics.db_url --stdin` (then paste the URL)
+
+## Sandbox
+
+SQL queries run with safety defaults:
+- **Read-only by default** (`read_only = true`) — prevents accidental writes
+- **Row limits** — cap output size with `max_rows`
+
+To allow writes (INSERT, UPDATE, DELETE), set `read_only = false` and use `annotations { mode = "write" }`:
+
+```hcl
+command "insert_order" {
+  annotations {
+    mode = "write"
+  }
+
+  operation {
+    protocol = "sql"
+    sql {
+      connection_secret = "analytics.db_url"
+      query  = "INSERT INTO orders (customer, total) VALUES (?, ?)"
+      params = ["{{ args.customer }}", "{{ args.total }}"]
+      sandbox {
+        read_only = false
+      }
+    }
+  }
+}
+```
+
+For advanced auth, see [secrets-and-auth.md](secrets-and-auth.md).

--- a/skills/getting-started-with-earl/references/template-quick-ref.md
+++ b/skills/getting-started-with-earl/references/template-quick-ref.md
@@ -1,0 +1,123 @@
+# Template Quick Reference
+
+Compact reference of all Earl template shapes, field types, and options.
+
+## Operation Shapes by Protocol
+
+**HTTP** — fields are flat in operation block:
+```hcl
+operation {
+  protocol = "http"
+  method   = "GET"
+  url      = "https://..."
+  query    = { key = "value" }
+  headers  = { Accept = "application/json" }
+  auth     { kind = "bearer"; secret = "key" }
+  body     { kind = "json"; value = { ... } }
+}
+```
+
+**GraphQL** — nested `graphql` block:
+```hcl
+operation {
+  protocol = "graphql"
+  url      = "https://..."
+  graphql {
+    query     = "query { ... }"
+    variables = { key = "value" }
+  }
+  auth { kind = "bearer"; secret = "key" }
+}
+```
+
+**gRPC** — nested `grpc` block:
+```hcl
+operation {
+  protocol   = "grpc"
+  url        = "http://host:port"
+  timeout_ms = 5000
+  grpc {
+    service             = "package.Service"
+    method              = "Method"
+    descriptor_set_file = "optional.fds.bin"
+    body                = { field = "value" }
+  }
+}
+```
+
+**Bash** — nested `bash` block:
+```hcl
+operation {
+  protocol = "bash"
+  bash {
+    script = "command here"
+    sandbox {
+      network          = false
+      max_time_ms      = 30000
+      max_output_bytes = 1048576
+    }
+  }
+}
+```
+
+**SQL** — nested `sql` block:
+```hcl
+operation {
+  protocol = "sql"
+  sql {
+    connection_secret = "db.url"
+    query             = "SELECT * FROM t WHERE id = ?"
+    params            = ["{{ args.id }}"]
+    sandbox {
+      read_only = true
+      max_rows  = 100
+    }
+  }
+}
+```
+
+## Auth Block Kinds
+
+| Kind | Fields | Use case |
+|---|---|---|
+| `bearer` | `secret` | API tokens (most REST/GraphQL APIs) |
+| `basic` | `secret` | Basic HTTP auth (username:password) |
+| `oauth2` | `profile` | OAuth2 flows (configured in config.toml) |
+
+## Body Block Kinds (HTTP only)
+
+| Kind | `value` type | Use case |
+|---|---|---|
+| `json` | Object/map | JSON request body |
+| `form` | Object/map | URL-encoded form data |
+| `raw` | String | Raw text body |
+
+## Parameter Types
+
+`string`, `integer`, `number`, `boolean`, `null`, `array`, `object`
+
+## Result Decode Options
+
+`json`, `html`, `xml`, `text`, `raw`
+
+## Result Extract Options
+
+```hcl
+extract = { json_pointer = "/data/items" }
+```
+
+## Template Expression Context
+
+| Context | Available in | Example |
+|---|---|---|
+| `args.*` | Everywhere | `{{ args.query }}` |
+| `secrets.*` | Operation block only | `{{ secrets.myapi_key }}` |
+| `result` | Result block only | `{{ result.total }}` |
+
+## HCL Functions
+
+| Function | Example |
+|---|---|
+| `file("path")` | Read a file relative to template |
+| `base64encode("value")` | Base64 encode |
+| `trimspace("value")` | Trim whitespace |

--- a/skills/getting-started-with-earl/references/template-quick-ref.md
+++ b/skills/getting-started-with-earl/references/template-quick-ref.md
@@ -5,6 +5,7 @@ Compact reference of all Earl template shapes, field types, and options.
 ## Operation Shapes by Protocol
 
 **HTTP** — fields are flat in operation block:
+
 ```hcl
 operation {
   protocol = "http"
@@ -18,6 +19,7 @@ operation {
 ```
 
 **GraphQL** — nested `graphql` block:
+
 ```hcl
 operation {
   protocol = "graphql"
@@ -31,6 +33,7 @@ operation {
 ```
 
 **gRPC** — nested `grpc` block:
+
 ```hcl
 operation {
   protocol   = "grpc"
@@ -46,6 +49,7 @@ operation {
 ```
 
 **Bash** — nested `bash` block:
+
 ```hcl
 operation {
   protocol = "bash"
@@ -61,6 +65,7 @@ operation {
 ```
 
 **SQL** — nested `sql` block:
+
 ```hcl
 operation {
   protocol = "sql"
@@ -78,19 +83,19 @@ operation {
 
 ## Auth Block Kinds
 
-| Kind | Fields | Use case |
-|---|---|---|
-| `bearer` | `secret` | API tokens (most REST/GraphQL APIs) |
-| `basic` | `secret` | Basic HTTP auth (username:password) |
+| Kind     | Fields    | Use case                                 |
+| -------- | --------- | ---------------------------------------- |
+| `bearer` | `secret`  | API tokens (most REST/GraphQL APIs)      |
+| `basic`  | `secret`  | Basic HTTP auth (username:password)      |
 | `oauth2` | `profile` | OAuth2 flows (configured in config.toml) |
 
 ## Body Block Kinds (HTTP only)
 
-| Kind | `value` type | Use case |
-|---|---|---|
-| `json` | Object/map | JSON request body |
-| `form` | Object/map | URL-encoded form data |
-| `raw` | String | Raw text body |
+| Kind   | `value` type | Use case              |
+| ------ | ------------ | --------------------- |
+| `json` | Object/map   | JSON request body     |
+| `form` | Object/map   | URL-encoded form data |
+| `raw`  | String       | Raw text body         |
 
 ## Parameter Types
 
@@ -108,16 +113,16 @@ extract = { json_pointer = "/data/items" }
 
 ## Template Expression Context
 
-| Context | Available in | Example |
-|---|---|---|
-| `args.*` | Everywhere | `{{ args.query }}` |
+| Context     | Available in         | Example                   |
+| ----------- | -------------------- | ------------------------- |
+| `args.*`    | Everywhere           | `{{ args.query }}`        |
 | `secrets.*` | Operation block only | `{{ secrets.myapi_key }}` |
-| `result` | Result block only | `{{ result.total }}` |
+| `result`    | Result block only    | `{{ result.total }}`      |
 
 ## HCL Functions
 
-| Function | Example |
-|---|---|
-| `file("path")` | Read a file relative to template |
-| `base64encode("value")` | Base64 encode |
-| `trimspace("value")` | Trim whitespace |
+| Function                | Example                          |
+| ----------------------- | -------------------------------- |
+| `file("path")`          | Read a file relative to template |
+| `base64encode("value")` | Base64 encode                    |
+| `trimspace("value")`    | Trim whitespace                  |


### PR DESCRIPTION
## Summary
- Adds an agentskills.io-format skill at `skills/getting-started-with-earl/` that guides AI agents in helping developers install Earl, run a quick demo, and create their first custom template
- Uses progressive disclosure: a lean SKILL.md hub (140 lines) handles install/demo/discovery, with 8 reference files loaded on demand for each protocol, auth, MCP integration, and a schema quick reference
- Covers all 5 protocols (HTTP, GraphQL, gRPC, Bash, SQL) with complete working HCL template examples, key fields, auth patterns, and common gotchas (SSRF protection, HCL/Jinja interaction, CLI flag ordering)

## Test plan
- [ ] Verify SKILL.md frontmatter: `name` matches directory name, description under 1024 chars
- [ ] Verify all internal links resolve (8 links in SKILL.md, 3 cross-links in reference files)
- [ ] Verify SKILL.md under 500 lines, reference files 50-150 lines each
- [ ] Test with an AI agent: have it guide a new user through Earl installation and first template creation
- [ ] Validate HCL examples in reference files parse correctly with `earl templates validate`

🤖 Generated with [Claude Code](https://claude.com/claude-code)