### PR TITLE
fix: remove invalid matrix reference from CodeQL concurrency group

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -31,6 +31,10 @@ jobs:
         if: matrix.language == 'rust'
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Cache cargo artifacts
+        if: matrix.language == 'rust'
+        uses: Swatinem/rust-cache@v2
+
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3
         with:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,10 +8,6 @@ on:
   schedule:
     - cron: "0 6 * * 1"
 
-concurrency:
-  group: codeql-${{ github.workflow }}-${{ github.ref }}-${{ matrix.language }}
-  cancel-in-progress: true
-
 permissions:
   contents: read
   security-events: write


### PR DESCRIPTION
## Summary
- Removes the workflow-level `concurrency` block that referenced `matrix.language`
- The `matrix` context is only available inside jobs, not at the workflow level, causing a validation error

## Test plan
- [ ] Verify the CodeQL workflow no longer errors on the concurrency group expression

🤖 Generated with [Claude Code](https://claude.com/claude-code)