### PR TITLE
docs: point docs badge to GitHub Pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/brwse/earl/actions/workflows/ci.yml/badge.svg)](https://github.com/brwse/earl/actions/workflows/ci.yml)
 [![Crates.io](https://img.shields.io/crates/v/earl)](https://crates.io/crates/earl)
-[![docs.rs](https://img.shields.io/docsrs/earl)](https://docs.rs/earl)
+[![Docs](https://img.shields.io/badge/docs-brwse.github.io%2Fearl-blue)](https://brwse.github.io/earl/)
 [![License: MIT](https://img.shields.io/crates/l/earl)](LICENSE)
 
 [![HTTP](https://img.shields.io/badge/HTTP-005CDE?logo=curl&logoColor=fff)](#)

--- a/site/content/docs/index.mdx
+++ b/site/content/docs/index.mdx
@@ -14,7 +14,7 @@ icon: BookOpen
 [![gRPC](https://img.shields.io/badge/gRPC-244C5A?logo=google&logoColor=fff)](#)
 [![Bash](https://img.shields.io/badge/Bash-4EAA25?logo=gnubash&logoColor=fff)](#)
 [![SQL](https://img.shields.io/badge/SQL-%23316192.svg?logo=postgresql&logoColor=white)](#)
-
+&ensp;
 [![macOS](https://img.shields.io/badge/macOS-000000?logo=apple&logoColor=white)](https://github.com/brwse/earl/releases/latest)
 [![Linux](https://img.shields.io/badge/Linux-FCC624?logo=linux&logoColor=black)](https://github.com/brwse/earl/releases/latest)
 [![Windows](https://img.shields.io/badge/Windows-0078D4?logo=windows&logoColor=white)](https://github.com/brwse/earl/releases/latest)

--- a/site/content/docs/index.mdx
+++ b/site/content/docs/index.mdx
@@ -4,6 +4,17 @@ description: AI-safe CLI for AI agents
 icon: BookOpen
 ---
 
+[![CI](https://github.com/brwse/earl/actions/workflows/ci.yml/badge.svg)](https://github.com/brwse/earl/actions/workflows/ci.yml)
+[![Crates.io](https://img.shields.io/crates/v/earl)](https://crates.io/crates/earl)
+[![Docs](https://img.shields.io/badge/docs-brwse.github.io%2Fearl-blue)](https://brwse.github.io/earl/)
+[![License: MIT](https://img.shields.io/crates/l/earl)](https://github.com/brwse/earl/blob/main/LICENSE)
+
+[![HTTP](https://img.shields.io/badge/HTTP-005CDE?logo=curl&logoColor=fff)](#)
+[![GraphQL](https://img.shields.io/badge/GraphQL-E10098?logo=graphql&logoColor=fff)](#)
+[![gRPC](https://img.shields.io/badge/gRPC-244C5A?logo=google&logoColor=fff)](#)
+[![Bash](https://img.shields.io/badge/Bash-4EAA25?logo=gnubash&logoColor=fff)](#)
+[![SQL](https://img.shields.io/badge/SQL-%23316192.svg?logo=postgresql&logoColor=white)](#)
+
 Earl is a CLI gate between AI agents and external services. Instead of giving agents raw shell or network access with plaintext credentials, you define allowed operations as HCL templates. Agents invoke those templates by name and nothing else.
 
 ```

--- a/site/content/docs/index.mdx
+++ b/site/content/docs/index.mdx
@@ -15,6 +15,10 @@ icon: BookOpen
 [![Bash](https://img.shields.io/badge/Bash-4EAA25?logo=gnubash&logoColor=fff)](#)
 [![SQL](https://img.shields.io/badge/SQL-%23316192.svg?logo=postgresql&logoColor=white)](#)
 
+[![macOS](https://img.shields.io/badge/macOS-000000?logo=apple&logoColor=white)](https://github.com/brwse/earl/releases/latest)
+[![Linux](https://img.shields.io/badge/Linux-FCC624?logo=linux&logoColor=black)](https://github.com/brwse/earl/releases/latest)
+[![Windows](https://img.shields.io/badge/Windows-0078D4?logo=windows&logoColor=white)](https://github.com/brwse/earl/releases/latest)
+
 Earl is a CLI gate between AI agents and external services. Instead of giving agents raw shell or network access with plaintext credentials, you define allowed operations as HCL templates. Agents invoke those templates by name and nothing else.
 
 ```


### PR DESCRIPTION
## Summary
- Update the docs badge in README to link to GitHub Pages (`brwse.github.io/earl/`) instead of `docs.rs`

## Test plan
- [ ] Verify badge renders correctly in PR preview
- [ ] Confirm link navigates to GitHub Pages site

🤖 Generated with [Claude Code](https://claude.com/claude-code)