### PR TITLE
fix: remove include-component-in-tag from sub-crates

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -13,31 +13,26 @@
     "crates/earl-core": {
       "release-type": "rust",
       "package-name": "earl-core",
-      "include-component-in-tag": false,
       "include-v-in-tag": true
     },
     "crates/earl-protocol-http": {
       "release-type": "rust",
       "package-name": "earl-protocol-http",
-      "include-component-in-tag": false,
       "include-v-in-tag": true
     },
     "crates/earl-protocol-grpc": {
       "release-type": "rust",
       "package-name": "earl-protocol-grpc",
-      "include-component-in-tag": false,
       "include-v-in-tag": true
     },
     "crates/earl-protocol-bash": {
       "release-type": "rust",
       "package-name": "earl-protocol-bash",
-      "include-component-in-tag": false,
       "include-v-in-tag": true
     },
     "crates/earl-protocol-sql": {
       "release-type": "rust",
       "package-name": "earl-protocol-sql",
-      "include-component-in-tag": false,
       "include-v-in-tag": true
     }
   },


### PR DESCRIPTION
## Summary
- Removes `include-component-in-tag: false` from sub-crate packages in release-please config
- Fixes `linked-versions` plugin not bumping all crates together ([googleapis/release-please#1750](https://github.com/googleapis/release-please/issues/1750))
- Root `earl` package keeps the setting for clean `v*` tags; sub-crates now get component-prefixed tags (e.g. `earl-core-v0.4.0`) which don't trigger the release workflow

## Test plan
- [ ] Verify release-please PR bumps all 6 crates when next release is triggered
- [ ] Confirm release workflow only triggers on root `v*` tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)