### PR TITLE
docs: add JWT auth and policy engine to MCP docs

### DIFF
--- a/site/content/docs/mcp.mdx
+++ b/site/content/docs/mcp.mdx
@@ -7,7 +7,7 @@ icon: Bot
 Earl implements a [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server (protocol version `2024-11-05`), letting AI agents discover and invoke your API templates as native tools.
 
 ```bash
-earl mcp [stdio|http] [--mode full|discovery] [--listen ADDR] [--yes]
+earl mcp [stdio|http] [--mode full|discovery] [--listen ADDR] [--yes] [--allow-unauthenticated]
 ```
 
 ## Modes
@@ -154,7 +154,7 @@ Both formats can be mixed on the input side; earl auto-detects which format each
 For non-stdio integrations, earl can serve MCP over HTTP:
 
 ```bash
-earl mcp http --listen 127.0.0.1:8977 --mode full --yes
+earl mcp http --listen 127.0.0.1:8977 --mode full --yes --allow-unauthenticated
 ```
 
 | Endpoint  | Method | Description                             |
@@ -164,12 +164,115 @@ earl mcp http --listen 127.0.0.1:8977 --mode full --yes
 
 The `--listen` flag defaults to `127.0.0.1:8977`.
 
+The HTTP transport requires authentication by default. You must either configure JWT authentication (see [Authentication](#authentication) below) or explicitly pass `--allow-unauthenticated` to opt out. The two options are mutually exclusive — earl will refuse to start if both are set.
+
+## Authentication
+
+When using the HTTP transport, earl supports JWT-based authentication to control who can access your MCP tools.
+
+### JWT Configuration
+
+Add an `[auth.jwt]` section to your config file (`~/.config/earl/config.toml`):
+
+```toml
+[auth.jwt]
+audience = "https://api.example.com"
+issuer = "https://accounts.example.com"
+jwks_uri = "https://accounts.example.com/.well-known/jwks.json"
+```
+
+Alternatively, use OIDC discovery to auto-resolve the issuer and JWKS URI:
+
+```toml
+[auth.jwt]
+audience = "https://api.example.com"
+oidc_discovery_url = "https://accounts.example.com/.well-known/openid-configuration"
+```
+
+| Field                        | Type       | Required                           | Default    | Description                                               |
+| ---------------------------- | ---------- | ---------------------------------- | ---------- | --------------------------------------------------------- |
+| `audience`                   | `string`   | Yes                                | —          | Expected `aud` claim in the JWT                           |
+| `oidc_discovery_url`         | `string`   | If `issuer`/`jwks_uri` not set     | —          | OIDC discovery endpoint to resolve issuer and JWKS URI    |
+| `issuer`                     | `string`   | If `oidc_discovery_url` not set    | —          | Expected `iss` claim in the JWT                           |
+| `jwks_uri`                   | `string`   | If `oidc_discovery_url` not set    | —          | URL to fetch the JSON Web Key Set for token verification  |
+| `algorithms`                 | `string[]` | No                                 | `["RS256"]` | Allowed signing algorithms (RS256, RS384, RS512, ES256, ES384, PS256, PS384, PS512, EdDSA) |
+| `clock_skew_seconds`         | `integer`  | No                                 | `30`       | Maximum clock skew tolerance in seconds (capped at 300)   |
+| `jwks_cache_max_age_seconds` | `integer`  | No                                 | `900`      | How long to cache JWKS keys before refreshing             |
+
+When JWT is configured, clients must include a `Bearer` token in the `Authorization` header. The token must contain `exp`, `sub`, `iss`, and `aud` claims. The `sub` claim identifies the authenticated subject for policy evaluation.
+
+```bash
+earl mcp http --listen 127.0.0.1:8977 --mode full --yes
+```
+
+### Unauthenticated Access
+
+For development or trusted environments, you can skip authentication:
+
+```bash
+earl mcp http --listen 127.0.0.1:8977 --allow-unauthenticated
+```
+
+<Callout type="warn">
+  Using `--allow-unauthenticated` is not recommended for production. Without
+  authentication, anyone who can reach the server can call your tools.
+</Callout>
+
+## Policy Engine
+
+When JWT authentication is enabled, you can define access control policies that restrict which subjects can call which tools. Policies are defined as `[[policy]]` entries in your config file.
+
+```toml
+[[policy]]
+subjects = ["user:alice", "group:admins"]
+tools = ["github.*"]
+effect = "allow"
+
+[[policy]]
+subjects = ["*"]
+tools = ["github.delete_repo"]
+modes = ["write"]
+effect = "deny"
+```
+
+| Field      | Type       | Required | Description                                                       |
+| ---------- | ---------- | -------- | ----------------------------------------------------------------- |
+| `subjects` | `string[]` | Yes      | JWT `sub` values to match (supports `*` glob)                     |
+| `tools`    | `string[]` | Yes      | Tool name patterns to match (supports `*` glob per segment)       |
+| `modes`    | `string[]` | No       | Restrict to `read` and/or `write` tools (omit for both)           |
+| `effect`   | `string`   | Yes      | `allow` or `deny`                                                 |
+
+### Evaluation Rules
+
+Policies use a **deny-overrides** model:
+
+1. All matching policies (by subject, tool, and mode) are collected.
+2. If **any** matching policy has `effect = "deny"`, the call is denied.
+3. If **any** matching policy has `effect = "allow"` (and none deny), the call is allowed.
+4. If **no** policies match, the call is denied (default deny).
+
+### Glob Patterns
+
+The `*` wildcard matches any characters within a single segment (separated by `.`). A lone `*` matches everything.
+
+| Pattern          | Matches                       | Does Not Match           |
+| ---------------- | ----------------------------- | ------------------------ |
+| `github.*`       | `github.create_issue`         | `slack.send_message`     |
+| `*.delete_*`     | `github.delete_repo`          | `github.admin.delete`    |
+| `*`              | any tool                      | —                        |
+
+<Callout type="info">
+  Policies only apply to authenticated requests. Unauthenticated requests (when
+  using `--allow-unauthenticated`) bypass the policy engine entirely and are
+  gated only by the `--yes` flag for write-mode tools.
+</Callout>
+
 ## Write-Mode Safety
 
 Write-mode tools (templates with `annotations.mode = "write"`) are **blocked by default**. When a write-mode tool is called without opt-in, the server returns an error:
 
-- **Error code:** `-32603`
-- **Message:** `tool "<name>" is write-mode; restart the MCP server with --yes to enable write tools`
+- **Error code:** `-32001`
+- **Message:** `write-mode tools are disabled on this server instance`
 
 Pass `--yes` when starting the server to allow write-mode tool execution:
 

--- a/skills/getting-started-with-earl/references/mcp-integration.md
+++ b/skills/getting-started-with-earl/references/mcp-integration.md
@@ -10,24 +10,26 @@ Run Earl as an MCP server:
 earl mcp stdio
 ```
 
-This starts Earl in discovery mode (default), exposing two meta-tools:
-
-- `earl.tool_search` — search for templates by natural language query
-- `earl.tool_call` — execute a template by name
+This starts Earl in full mode (default), where each template becomes a separate MCP tool.
 
 ## Two Modes
 
-**Discovery mode (default, recommended):** Two meta-tools for searching and calling templates. Best for large template catalogs.
+**Full mode (default):** Each template becomes a separate MCP tool. Best for small catalogs (<30 templates).
+
+```bash
+earl mcp stdio --mode full
+```
+
+**Discovery mode (recommended for large catalogs):** Two meta-tools for searching and calling templates.
 
 ```bash
 earl mcp stdio --mode discovery
 ```
 
-**Full mode:** Each template becomes a separate MCP tool. Best for small catalogs (<30 templates).
+Discovery mode exposes two meta-tools:
 
-```bash
-earl mcp stdio --mode full
-```
+- `earl.tool_search` — search for templates by natural language query
+- `earl.tool_call` — execute a template by name
 
 ## Claude Desktop Configuration
 
@@ -64,10 +66,12 @@ Add to `.claude/settings.json` in your project:
 For remote or shared deployments, use HTTP transport:
 
 ```bash
-earl mcp http --listen 127.0.0.1:3000
+earl mcp http --listen 127.0.0.1:8977 --allow-unauthenticated
 ```
 
-This serves MCP at `POST /mcp` with a health check at `GET /health`.
+This serves MCP at `POST /mcp` with a health check at `GET /health`. The default listen address is `127.0.0.1:8977`.
+
+HTTP transport requires either JWT authentication (`[auth.jwt]` in config) or `--allow-unauthenticated`. See the full MCP docs for JWT and policy configuration.
 
 ## Auto-Approve Writes
 


### PR DESCRIPTION
## Summary
- Add documentation for JWT authentication (`[auth.jwt]` config) and the policy engine (`[[policy]]` rules) to the MCP docs page
- Fix write-mode safety error code (`-32603` → `-32001`) and message to match the implementation
- Fix default mode (was incorrectly listed as "discovery", actually "full") and default port (`3000` → `8977`) in the skills reference
- Document the `--allow-unauthenticated` flag for HTTP transport

## Test plan
- [ ] Verify all documented config fields match `JwtConfig` and `PolicyRule` structs in `src/config.rs`
- [ ] Verify error code and message match `src/mcp/mod.rs` implementation
- [ ] Confirm CLI default mode is `full` per `src/cli.rs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)