### PR TITLE
fix: resolve latest CLI release from monorepo releases

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -85,8 +85,8 @@ esac
 TARGET="${ARCH_PART}-${OS_PART}"
 
 if [[ "$VERSION" == "latest" ]]; then
-  API_URL="https://api.github.com/repos/${REPO}/releases/latest"
-  VERSION="$(downloader "$API_URL" /dev/stdout | sed -n 's/.*"tag_name"[[:space:]]*:[[:space:]]*"v\([^"]*\)".*/\1/p' | head -n1)"
+  API_URL="https://api.github.com/repos/${REPO}/releases?per_page=100"
+  VERSION="$(downloader "$API_URL" /dev/stdout | sed -n 's/.*"tag_name"[[:space:]]*:[[:space:]]*"v\([0-9][^"]*\)".*/\1/p' | head -n1)"
   if [[ -z "$VERSION" ]]; then
     echo "failed to resolve latest version from ${API_URL}" >&2
     exit 1


### PR DESCRIPTION
## Summary
- The install script's `/releases/latest` endpoint was returning the most recently published sub-crate release (`earl-protocol-sql-v0.4.0`) instead of the CLI release (`v0.4.0`)
- Switched to the `/releases?per_page=100` list endpoint so the `sed` pattern finds the first `v`-prefixed tag
- Tightened the regex to require a digit after `v` for extra safety

## Test plan
- [ ] Run `curl -fsSL https://raw.githubusercontent.com/brwse/earl/fix/install-script-latest-release/scripts/install.sh | bash` and verify it resolves the correct version

🤖 Generated with [Claude Code](https://claude.com/claude-code)