### PR TITLE
feat: add 25 pre-built company API templates

### DIFF
--- a/examples/airtable.hcl
+++ b/examples/airtable.hcl
@@ -1,0 +1,730 @@
+version = 1
+provider = "airtable"
+categories = ["databases", "productivity", "collaboration"]
+
+command "list_bases" {
+  title       = "List bases"
+  summary     = "List all accessible Airtable bases"
+  description = "Returns a list of all bases the authenticated user has access to, with pagination support."
+  categories  = ["databases"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["airtable.token"]
+  }
+
+  param "offset" {
+    type        = "string"
+    required    = false
+    description = "Pagination cursor from a previous response"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://api.airtable.com/v0/meta/bases"
+
+    auth {
+      kind   = "bearer"
+      secret = "airtable.token"
+    }
+
+    query = {
+      offset = "{{ args.offset }}"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Found {{ result.bases | length }} bases:\n{% for base in result.bases %}- {{ base.name }} ({{ base.id }}) [{{ base.permissionLevel }}]\n{% endfor %}{% if result.offset %}(more results available){% endif %}"
+  }
+}
+
+command "get_base_schema" {
+  title       = "Get base schema"
+  summary     = "Retrieve the schema of an Airtable base"
+  description = "Returns all tables, fields, and views for the specified base."
+  categories  = ["databases"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["airtable.token"]
+  }
+
+  param "base_id" {
+    type        = "string"
+    required    = true
+    description = "Base ID (e.g. appXXX)"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://api.airtable.com/v0/meta/bases/{{ args.base_id }}/tables"
+
+    auth {
+      kind   = "bearer"
+      secret = "airtable.token"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Base has {{ result.tables | length }} tables:\n{% for table in result.tables %}- {{ table.name }} ({{ table.id }}): {{ table.fields | length }} fields, {{ table.views | length }} views\n{% endfor %}"
+  }
+}
+
+command "list_records" {
+  title       = "List records"
+  summary     = "List records from an Airtable table"
+  description = "Retrieve records from a table with optional filtering, sorting, and pagination. Returns up to 100 records per page."
+  categories  = ["databases"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["airtable.token"]
+  }
+
+  param "base_id" {
+    type        = "string"
+    required    = true
+    description = "Base ID (e.g. appXXX)"
+  }
+
+  param "table_id_or_name" {
+    type        = "string"
+    required    = true
+    description = "Table ID (e.g. tblXXX) or URL-encoded table name"
+  }
+
+  param "page_size" {
+    type        = "integer"
+    required    = false
+    default     = 100
+    description = "Number of records per page (max 100)"
+  }
+
+  param "offset" {
+    type        = "string"
+    required    = false
+    description = "Pagination cursor from a previous response"
+  }
+
+  param "view" {
+    type        = "string"
+    required    = false
+    description = "View name or ID to filter records by"
+  }
+
+  param "filter_by_formula" {
+    type        = "string"
+    required    = false
+    description = "Airtable formula to filter records (e.g. {Status}='Done')"
+  }
+
+  param "max_records" {
+    type        = "integer"
+    required    = false
+    description = "Maximum total number of records to return"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://api.airtable.com/v0/{{ args.base_id }}/{{ args.table_id_or_name }}"
+
+    auth {
+      kind   = "bearer"
+      secret = "airtable.token"
+    }
+
+    query = {
+      pageSize        = "{{ args.page_size }}"
+      offset          = "{{ args.offset }}"
+      view            = "{{ args.view }}"
+      filterByFormula = "{{ args.filter_by_formula }}"
+      maxRecords      = "{{ args.max_records }}"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Found {{ result.records | length }} records:\n{% for record in result.records %}- {{ record.id }}: {{ record.fields | tojson }}\n{% endfor %}{% if result.offset %}(more results available — offset: {{ result.offset }}){% endif %}"
+  }
+}
+
+command "get_record" {
+  title       = "Get record"
+  summary     = "Retrieve a single record by ID"
+  description = "Fetch a specific record from an Airtable table by its record ID."
+  categories  = ["databases"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["airtable.token"]
+  }
+
+  param "base_id" {
+    type        = "string"
+    required    = true
+    description = "Base ID (e.g. appXXX)"
+  }
+
+  param "table_id_or_name" {
+    type        = "string"
+    required    = true
+    description = "Table ID or URL-encoded table name"
+  }
+
+  param "record_id" {
+    type        = "string"
+    required    = true
+    description = "Record ID (e.g. recXXX)"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://api.airtable.com/v0/{{ args.base_id }}/{{ args.table_id_or_name }}/{{ args.record_id }}"
+
+    auth {
+      kind   = "bearer"
+      secret = "airtable.token"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Record {{ result.id }} (created {{ result.createdTime }}):\n{% for key, value in result.fields.items() %}  {{ key }}: {{ value }}\n{% endfor %}"
+  }
+}
+
+command "create_records" {
+  title       = "Create records"
+  summary     = "Create new records in a table"
+  description = "Create up to 10 records in a single request. Each record must include a fields object with field name/value pairs."
+  categories  = ["databases"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["airtable.token"]
+  }
+
+  param "base_id" {
+    type        = "string"
+    required    = true
+    description = "Base ID (e.g. appXXX)"
+  }
+
+  param "table_id_or_name" {
+    type        = "string"
+    required    = true
+    description = "Table ID or URL-encoded table name"
+  }
+
+  param "records" {
+    type        = "array"
+    required    = true
+    description = "Array of record objects, each with a 'fields' object (e.g. [{\"fields\": {\"Name\": \"Task 1\"}}]). Max 10."
+  }
+
+  param "typecast" {
+    type        = "boolean"
+    required    = false
+    default     = false
+    description = "Auto-convert string values to correct field types"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "POST"
+    url      = "https://api.airtable.com/v0/{{ args.base_id }}/{{ args.table_id_or_name }}"
+
+    auth {
+      kind   = "bearer"
+      secret = "airtable.token"
+    }
+
+    headers = {
+      Content-Type = "application/json"
+    }
+
+    body {
+      kind = "json"
+      value = {
+        records  = "{{ args.records }}"
+        typecast = "{{ args.typecast }}"
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Created {{ result.records | length }} record(s):\n{% for record in result.records %}- {{ record.id }}: {{ record.fields | tojson }}\n{% endfor %}"
+  }
+}
+
+command "update_records" {
+  title       = "Update records"
+  summary     = "Update existing records in a table"
+  description = "Update up to 10 records using PATCH (partial update — only specified fields change). Each record must include an 'id' and 'fields' object."
+  categories  = ["databases"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["airtable.token"]
+  }
+
+  param "base_id" {
+    type        = "string"
+    required    = true
+    description = "Base ID (e.g. appXXX)"
+  }
+
+  param "table_id_or_name" {
+    type        = "string"
+    required    = true
+    description = "Table ID or URL-encoded table name"
+  }
+
+  param "records" {
+    type        = "array"
+    required    = true
+    description = "Array of record objects with 'id' and 'fields' (e.g. [{\"id\": \"recXXX\", \"fields\": {\"Status\": \"Done\"}}]). Max 10."
+  }
+
+  param "typecast" {
+    type        = "boolean"
+    required    = false
+    default     = false
+    description = "Auto-convert string values to correct field types"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "PATCH"
+    url      = "https://api.airtable.com/v0/{{ args.base_id }}/{{ args.table_id_or_name }}"
+
+    auth {
+      kind   = "bearer"
+      secret = "airtable.token"
+    }
+
+    headers = {
+      Content-Type = "application/json"
+    }
+
+    body {
+      kind = "json"
+      value = {
+        records  = "{{ args.records }}"
+        typecast = "{{ args.typecast }}"
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Updated {{ result.records | length }} record(s):\n{% for record in result.records %}- {{ record.id }}: {{ record.fields | tojson }}\n{% endfor %}"
+  }
+}
+
+command "delete_record" {
+  title       = "Delete record"
+  summary     = "Delete a record from a table"
+  description = "Permanently delete a single record from an Airtable table."
+  categories  = ["databases"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["airtable.token"]
+  }
+
+  param "base_id" {
+    type        = "string"
+    required    = true
+    description = "Base ID (e.g. appXXX)"
+  }
+
+  param "table_id_or_name" {
+    type        = "string"
+    required    = true
+    description = "Table ID or URL-encoded table name"
+  }
+
+  param "record_id" {
+    type        = "string"
+    required    = true
+    description = "Record ID to delete (e.g. recXXX)"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "DELETE"
+    url      = "https://api.airtable.com/v0/{{ args.base_id }}/{{ args.table_id_or_name }}/{{ args.record_id }}"
+
+    auth {
+      kind   = "bearer"
+      secret = "airtable.token"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Deleted record {{ result.id }}: {{ result.deleted }}"
+  }
+}
+
+command "create_table" {
+  title       = "Create table"
+  summary     = "Create a new table in a base"
+  description = "Create a new table in the specified base with a name and initial field definitions."
+  categories  = ["databases"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["airtable.token"]
+  }
+
+  param "base_id" {
+    type        = "string"
+    required    = true
+    description = "Base ID (e.g. appXXX)"
+  }
+
+  param "name" {
+    type        = "string"
+    required    = true
+    description = "Name for the new table"
+  }
+
+  param "fields" {
+    type        = "array"
+    required    = true
+    description = "Array of field definitions, each with 'name' and 'type' (e.g. [{\"name\": \"Name\", \"type\": \"singleLineText\"}])"
+  }
+
+  param "description" {
+    type        = "string"
+    required    = false
+    description = "Optional table description"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "POST"
+    url      = "https://api.airtable.com/v0/meta/bases/{{ args.base_id }}/tables"
+
+    auth {
+      kind   = "bearer"
+      secret = "airtable.token"
+    }
+
+    headers = {
+      Content-Type = "application/json"
+    }
+
+    body {
+      kind = "json"
+      value = {
+        name        = "{{ args.name }}"
+        description = "{{ args.description }}"
+        fields      = "{{ args.fields }}"
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Created table \"{{ result.name }}\" ({{ result.id }}) with {{ result.fields | length }} fields."
+  }
+}
+
+command "create_field" {
+  title       = "Create field"
+  summary     = "Add a new field to a table"
+  description = "Create a new field (column) in an existing Airtable table."
+  categories  = ["databases"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["airtable.token"]
+  }
+
+  param "base_id" {
+    type        = "string"
+    required    = true
+    description = "Base ID (e.g. appXXX)"
+  }
+
+  param "table_id" {
+    type        = "string"
+    required    = true
+    description = "Table ID (e.g. tblXXX)"
+  }
+
+  param "name" {
+    type        = "string"
+    required    = true
+    description = "Field name"
+  }
+
+  param "type" {
+    type        = "string"
+    required    = true
+    description = "Field type (e.g. singleLineText, number, singleSelect, multipleAttachments)"
+  }
+
+  param "description" {
+    type        = "string"
+    required    = false
+    description = "Optional field description"
+  }
+
+  param "options" {
+    type        = "object"
+    required    = false
+    description = "Type-specific options (e.g. select choices, number precision)"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "POST"
+    url      = "https://api.airtable.com/v0/meta/bases/{{ args.base_id }}/tables/{{ args.table_id }}/fields"
+
+    auth {
+      kind   = "bearer"
+      secret = "airtable.token"
+    }
+
+    headers = {
+      Content-Type = "application/json"
+    }
+
+    body {
+      kind = "json"
+      value = {
+        name        = "{{ args.name }}"
+        type        = "{{ args.type }}"
+        description = "{{ args.description }}"
+        options     = "{{ args.options }}"
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Created field \"{{ result.name }}\" ({{ result.id }}) of type {{ result.type }}."
+  }
+}
+
+command "list_comments" {
+  title       = "List comments"
+  summary     = "List comments on a record"
+  description = "Retrieve all comments on a specific Airtable record."
+  categories  = ["collaboration"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["airtable.token"]
+  }
+
+  param "base_id" {
+    type        = "string"
+    required    = true
+    description = "Base ID (e.g. appXXX)"
+  }
+
+  param "table_id_or_name" {
+    type        = "string"
+    required    = true
+    description = "Table ID or URL-encoded table name"
+  }
+
+  param "record_id" {
+    type        = "string"
+    required    = true
+    description = "Record ID (e.g. recXXX)"
+  }
+
+  param "offset" {
+    type        = "string"
+    required    = false
+    description = "Pagination cursor from a previous response"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://api.airtable.com/v0/{{ args.base_id }}/{{ args.table_id_or_name }}/{{ args.record_id }}/comments"
+
+    auth {
+      kind   = "bearer"
+      secret = "airtable.token"
+    }
+
+    query = {
+      offset = "{{ args.offset }}"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "{{ result.comments | length }} comment(s) on record {{ args.record_id }}:\n{% for comment in result.comments %}- {{ comment.author.name }} ({{ comment.createdTime }}): {{ comment.text }}\n{% endfor %}"
+  }
+}
+
+command "create_comment" {
+  title       = "Create comment"
+  summary     = "Add a comment to a record"
+  description = "Post a new comment on a specific Airtable record."
+  categories  = ["collaboration"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["airtable.token"]
+  }
+
+  param "base_id" {
+    type        = "string"
+    required    = true
+    description = "Base ID (e.g. appXXX)"
+  }
+
+  param "table_id_or_name" {
+    type        = "string"
+    required    = true
+    description = "Table ID or URL-encoded table name"
+  }
+
+  param "record_id" {
+    type        = "string"
+    required    = true
+    description = "Record ID (e.g. recXXX)"
+  }
+
+  param "text" {
+    type        = "string"
+    required    = true
+    description = "Comment text"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "POST"
+    url      = "https://api.airtable.com/v0/{{ args.base_id }}/{{ args.table_id_or_name }}/{{ args.record_id }}/comments"
+
+    auth {
+      kind   = "bearer"
+      secret = "airtable.token"
+    }
+
+    headers = {
+      Content-Type = "application/json"
+    }
+
+    body {
+      kind = "json"
+      value = {
+        text = "{{ args.text }}"
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Comment created by {{ result.author.name }} at {{ result.createdTime }}: {{ result.text }}"
+  }
+}
+
+command "list_webhooks" {
+  title       = "List webhooks"
+  summary     = "List all webhooks for a base"
+  description = "Retrieve all registered webhooks for the specified Airtable base."
+  categories  = ["databases"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["airtable.token"]
+  }
+
+  param "base_id" {
+    type        = "string"
+    required    = true
+    description = "Base ID (e.g. appXXX)"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://api.airtable.com/v0/bases/{{ args.base_id }}/webhooks"
+
+    auth {
+      kind   = "bearer"
+      secret = "airtable.token"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "{{ result.webhooks | length }} webhook(s):\n{% for wh in result.webhooks %}- {{ wh.id }}: {{ wh.notificationUrl }} (expires {{ wh.expirationTime }})\n{% endfor %}"
+  }
+}
+
+command "create_webhook" {
+  title       = "Create webhook"
+  summary     = "Register a new webhook for a base"
+  description = "Create a webhook to receive notifications when data changes in an Airtable base. Webhooks expire after 7 days."
+  categories  = ["databases"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["airtable.token"]
+  }
+
+  param "base_id" {
+    type        = "string"
+    required    = true
+    description = "Base ID (e.g. appXXX)"
+  }
+
+  param "notification_url" {
+    type        = "string"
+    required    = true
+    description = "URL to receive webhook payloads"
+  }
+
+  param "specification" {
+    type        = "object"
+    required    = true
+    description = "Webhook specification with options defining which changes to watch (e.g. {\"options\": {\"filters\": {\"dataTypes\": [\"tableData\"]}}})"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "POST"
+    url      = "https://api.airtable.com/v0/bases/{{ args.base_id }}/webhooks"
+
+    auth {
+      kind   = "bearer"
+      secret = "airtable.token"
+    }
+
+    headers = {
+      Content-Type = "application/json"
+    }
+
+    body {
+      kind = "json"
+      value = {
+        notificationUrl = "{{ args.notification_url }}"
+        specification   = "{{ args.specification }}"
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Webhook created: {{ result.id }}\nSecret (base64): {{ result.macSecretBase64 }}\nExpires: {{ result.expirationTime }}"
+  }
+}

--- a/examples/anthropic.hcl
+++ b/examples/anthropic.hcl
@@ -1,0 +1,591 @@
+version = 1
+provider = "anthropic"
+categories = ["ai", "llm"]
+
+command "create_message" {
+  title       = "Create message"
+  summary     = "Send a message to Claude and get a response"
+  description = "Create a message using the Anthropic Messages API. Supports system prompts, temperature control, and multiple sampling parameters."
+  categories  = ["write", "messages"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["anthropic.api_key"]
+  }
+
+  param "model" {
+    type        = "string"
+    required    = true
+    description = "Model ID (e.g. claude-sonnet-4-6, claude-haiku-4-5-20251001)"
+  }
+
+  param "max_tokens" {
+    type        = "integer"
+    required    = true
+    description = "Maximum number of output tokens"
+  }
+
+  param "messages" {
+    type        = "string"
+    required    = true
+    description = "JSON array of message objects, e.g. [{\"role\":\"user\",\"content\":\"Hello\"}]"
+  }
+
+  param "system" {
+    type        = "string"
+    required    = false
+    description = "System prompt to set context for the conversation"
+  }
+
+  param "temperature" {
+    type        = "number"
+    required    = false
+    description = "Sampling temperature between 0.0 and 1.0"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "POST"
+    url      = "https://api.anthropic.com/v1/messages"
+
+    auth {
+      kind     = "api_key"
+      location = "header"
+      name     = "x-api-key"
+      secret   = "anthropic.api_key"
+    }
+
+    headers = {
+      anthropic-version = "2023-06-01"
+    }
+
+    body {
+      kind = "json"
+      value = {
+        model      = "{{ args.model }}"
+        max_tokens = "{{ args.max_tokens }}"
+        messages   = "{{ args.messages }}"
+        system     = "{{ args.system }}"
+        temperature = "{{ args.temperature }}"
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Model: {{ result.model }}\nStop reason: {{ result.stop_reason }}\nContent: {{ result.content[0].text }}\nUsage: {{ result.usage.input_tokens }} in / {{ result.usage.output_tokens }} out"
+  }
+}
+
+command "count_tokens" {
+  title       = "Count tokens"
+  summary     = "Count the tokens in a message without sending it"
+  description = "Count the number of tokens in a Messages API request without creating a message. Useful for estimating costs and checking context limits."
+  categories  = ["read", "messages"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["anthropic.api_key"]
+  }
+
+  param "model" {
+    type        = "string"
+    required    = true
+    description = "Model ID to count tokens for"
+  }
+
+  param "messages" {
+    type        = "string"
+    required    = true
+    description = "JSON array of message objects"
+  }
+
+  param "system" {
+    type        = "string"
+    required    = false
+    description = "System prompt to include in token count"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "POST"
+    url      = "https://api.anthropic.com/v1/messages/count_tokens"
+
+    auth {
+      kind     = "api_key"
+      location = "header"
+      name     = "x-api-key"
+      secret   = "anthropic.api_key"
+    }
+
+    headers = {
+      anthropic-version = "2023-06-01"
+    }
+
+    body {
+      kind = "json"
+      value = {
+        model    = "{{ args.model }}"
+        messages = "{{ args.messages }}"
+        system   = "{{ args.system }}"
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Input tokens: {{ result.input_tokens }}"
+  }
+}
+
+command "list_models" {
+  title       = "List models"
+  summary     = "List all available Claude models"
+  description = "List available models on the Anthropic API with pagination support."
+  categories  = ["read", "models"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["anthropic.api_key"]
+  }
+
+  param "limit" {
+    type        = "integer"
+    required    = false
+    default     = 20
+    description = "Number of models to return (1-1000)"
+  }
+
+  param "after_id" {
+    type        = "string"
+    required    = false
+    description = "Cursor for forward pagination"
+  }
+
+  param "before_id" {
+    type        = "string"
+    required    = false
+    description = "Cursor for backward pagination"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://api.anthropic.com/v1/models"
+
+    auth {
+      kind     = "api_key"
+      location = "header"
+      name     = "x-api-key"
+      secret   = "anthropic.api_key"
+    }
+
+    query = {
+      limit     = "{{ args.limit }}"
+      after_id  = "{{ args.after_id }}"
+      before_id = "{{ args.before_id }}"
+    }
+
+    headers = {
+      anthropic-version = "2023-06-01"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Models ({{ result.data | length }}):\n{% for m in result.data %}  - {{ m.id }} ({{ m.display_name }}, created {{ m.created_at }})\n{% endfor %}Has more: {{ result.has_more }}"
+  }
+}
+
+command "get_model" {
+  title       = "Get model"
+  summary     = "Retrieve details about a specific model"
+  description = "Get information about a specific Claude model by its ID."
+  categories  = ["read", "models"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["anthropic.api_key"]
+  }
+
+  param "model_id" {
+    type        = "string"
+    required    = true
+    description = "Model identifier (e.g. claude-sonnet-4-6)"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://api.anthropic.com/v1/models/{{ args.model_id }}"
+
+    auth {
+      kind     = "api_key"
+      location = "header"
+      name     = "x-api-key"
+      secret   = "anthropic.api_key"
+    }
+
+    headers = {
+      anthropic-version = "2023-06-01"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Model: {{ result.id }}\nDisplay name: {{ result.display_name }}\nCreated: {{ result.created_at }}"
+  }
+}
+
+command "create_batch" {
+  title       = "Create batch"
+  summary     = "Create a batch of message requests for async processing"
+  description = "Submit a batch of Messages API requests for asynchronous processing. Each request in the batch includes a custom_id and params matching the Messages API body."
+  categories  = ["write", "batches"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["anthropic.api_key"]
+  }
+
+  param "requests" {
+    type        = "string"
+    required    = true
+    description = "JSON array of batch request objects, each with custom_id and params"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "POST"
+    url      = "https://api.anthropic.com/v1/messages/batches"
+
+    auth {
+      kind     = "api_key"
+      location = "header"
+      name     = "x-api-key"
+      secret   = "anthropic.api_key"
+    }
+
+    headers = {
+      anthropic-version = "2023-06-01"
+    }
+
+    body {
+      kind = "json"
+      value = {
+        requests = "{{ args.requests }}"
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Batch ID: {{ result.id }}\nStatus: {{ result.processing_status }}\nRequests: {{ result.request_counts.processing }} processing, {{ result.request_counts.succeeded }} succeeded, {{ result.request_counts.errored }} errored\nCreated: {{ result.created_at }}\nExpires: {{ result.expires_at }}"
+  }
+}
+
+command "list_batches" {
+  title       = "List batches"
+  summary     = "List all message batches"
+  description = "List message batches with pagination support."
+  categories  = ["read", "batches"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["anthropic.api_key"]
+  }
+
+  param "limit" {
+    type        = "integer"
+    required    = false
+    default     = 20
+    description = "Number of batches to return (1-1000)"
+  }
+
+  param "after_id" {
+    type        = "string"
+    required    = false
+    description = "Cursor for forward pagination"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://api.anthropic.com/v1/messages/batches"
+
+    auth {
+      kind     = "api_key"
+      location = "header"
+      name     = "x-api-key"
+      secret   = "anthropic.api_key"
+    }
+
+    query = {
+      limit    = "{{ args.limit }}"
+      after_id = "{{ args.after_id }}"
+    }
+
+    headers = {
+      anthropic-version = "2023-06-01"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Batches ({{ result.data | length }}):\n{% for b in result.data %}  - {{ b.id }}: {{ b.processing_status }}\n{% endfor %}Has more: {{ result.has_more }}"
+  }
+}
+
+command "get_batch" {
+  title       = "Get batch"
+  summary     = "Retrieve details about a message batch"
+  description = "Get the current status and details of a specific message batch."
+  categories  = ["read", "batches"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["anthropic.api_key"]
+  }
+
+  param "batch_id" {
+    type        = "string"
+    required    = true
+    description = "Message batch ID"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://api.anthropic.com/v1/messages/batches/{{ args.batch_id }}"
+
+    auth {
+      kind     = "api_key"
+      location = "header"
+      name     = "x-api-key"
+      secret   = "anthropic.api_key"
+    }
+
+    headers = {
+      anthropic-version = "2023-06-01"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Batch: {{ result.id }}\nStatus: {{ result.processing_status }}\nProcessing: {{ result.request_counts.processing }}\nSucceeded: {{ result.request_counts.succeeded }}\nErrored: {{ result.request_counts.errored }}\nCanceled: {{ result.request_counts.canceled }}\nCreated: {{ result.created_at }}"
+  }
+}
+
+command "cancel_batch" {
+  title       = "Cancel batch"
+  summary     = "Cancel a running message batch"
+  description = "Initiate cancellation of a message batch that is currently processing."
+  categories  = ["write", "batches"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["anthropic.api_key"]
+  }
+
+  param "batch_id" {
+    type        = "string"
+    required    = true
+    description = "Message batch ID to cancel"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "POST"
+    url      = "https://api.anthropic.com/v1/messages/batches/{{ args.batch_id }}/cancel"
+
+    auth {
+      kind     = "api_key"
+      location = "header"
+      name     = "x-api-key"
+      secret   = "anthropic.api_key"
+    }
+
+    headers = {
+      anthropic-version = "2023-06-01"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Batch {{ result.id }} cancellation initiated.\nStatus: {{ result.processing_status }}"
+  }
+}
+
+command "delete_batch" {
+  title       = "Delete batch"
+  summary     = "Delete a completed message batch"
+  description = "Delete a message batch that has reached an ended state (completed, canceled, or expired)."
+  categories  = ["write", "batches"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["anthropic.api_key"]
+  }
+
+  param "batch_id" {
+    type        = "string"
+    required    = true
+    description = "Message batch ID to delete (must be in ended state)"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "DELETE"
+    url      = "https://api.anthropic.com/v1/messages/batches/{{ args.batch_id }}"
+
+    auth {
+      kind     = "api_key"
+      location = "header"
+      name     = "x-api-key"
+      secret   = "anthropic.api_key"
+    }
+
+    headers = {
+      anthropic-version = "2023-06-01"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Deleted batch: {{ result.id }}"
+  }
+}
+
+command "get_batch_results" {
+  title       = "Get batch results"
+  summary     = "Download results from a completed batch"
+  description = "Retrieve the results of a completed message batch. Returns streamed JSONL with each line containing a custom_id and result."
+  categories  = ["read", "batches"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["anthropic.api_key"]
+  }
+
+  param "batch_id" {
+    type        = "string"
+    required    = true
+    description = "Message batch ID to get results for"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://api.anthropic.com/v1/messages/batches/{{ args.batch_id }}/results"
+
+    auth {
+      kind     = "api_key"
+      location = "header"
+      name     = "x-api-key"
+      secret   = "anthropic.api_key"
+    }
+
+    headers = {
+      anthropic-version = "2023-06-01"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Batch results for {{ args.batch_id }} (JSONL stream)"
+  }
+}
+
+command "list_files" {
+  title       = "List files"
+  summary     = "List uploaded files"
+  description = "List files uploaded to the Anthropic API (beta). Supports pagination."
+  categories  = ["read", "files"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["anthropic.api_key"]
+  }
+
+  param "limit" {
+    type        = "integer"
+    required    = false
+    default     = 20
+    description = "Number of files to return (1-1000)"
+  }
+
+  param "after_id" {
+    type        = "string"
+    required    = false
+    description = "Cursor for forward pagination"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://api.anthropic.com/v1/files"
+
+    auth {
+      kind     = "api_key"
+      location = "header"
+      name     = "x-api-key"
+      secret   = "anthropic.api_key"
+    }
+
+    query = {
+      limit    = "{{ args.limit }}"
+      after_id = "{{ args.after_id }}"
+    }
+
+    headers = {
+      anthropic-version = "2023-06-01"
+      anthropic-beta    = "files-api-2025-04-14"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Files ({{ result.data | length }}):\n{% for f in result.data %}  - {{ f.id }}: {{ f.filename }} ({{ f.mime_type }}, {{ f.size_bytes }} bytes)\n{% endfor %}Has more: {{ result.has_more }}"
+  }
+}
+
+command "delete_file" {
+  title       = "Delete file"
+  summary     = "Delete an uploaded file"
+  description = "Delete a file that was previously uploaded to the Anthropic API (beta)."
+  categories  = ["write", "files"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["anthropic.api_key"]
+  }
+
+  param "file_id" {
+    type        = "string"
+    required    = true
+    description = "File ID to delete"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "DELETE"
+    url      = "https://api.anthropic.com/v1/files/{{ args.file_id }}"
+
+    auth {
+      kind     = "api_key"
+      location = "header"
+      name     = "x-api-key"
+      secret   = "anthropic.api_key"
+    }
+
+    headers = {
+      anthropic-version = "2023-06-01"
+      anthropic-beta    = "files-api-2025-04-14"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Deleted file: {{ result.id }}"
+  }
+}

--- a/examples/auth0.hcl
+++ b/examples/auth0.hcl
@@ -1,0 +1,932 @@
+version = 1
+provider = "auth0"
+categories = ["identity", "authentication", "security"]
+
+command "list_users" {
+  title       = "List users"
+  summary     = "List or search users in your Auth0 tenant"
+  description = "Retrieve users from the Auth0 Management API with optional Lucene query filtering and pagination. Requires the AUTH0_DOMAIN environment variable to be set to your tenant domain (e.g. mytenant.us.auth0.com)."
+  categories  = ["users"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["auth0.token"]
+  }
+
+  param "q" {
+    type        = "string"
+    required    = false
+    default     = ""
+    description = "Lucene query string (e.g. 'email:\"jane@example.com\"')"
+  }
+
+  param "per_page" {
+    type        = "integer"
+    required    = false
+    default     = 50
+    description = "Results per page (max 100)"
+  }
+
+  param "page" {
+    type        = "integer"
+    required    = false
+    default     = 0
+    description = "Zero-based page number"
+  }
+
+  param "sort" {
+    type        = "string"
+    required    = false
+    default     = ""
+    description = "Sort field and direction (e.g. 'created_at:-1')"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://{{ env.AUTH0_DOMAIN }}/api/v2/users"
+
+    auth {
+      kind   = "bearer"
+      secret = "auth0.token"
+    }
+
+    query = {
+      q              = "{{ args.q }}"
+      search_engine  = "v3"
+      per_page       = "{{ args.per_page }}"
+      page           = "{{ args.page }}"
+      sort           = "{{ args.sort }}"
+      include_totals = "true"
+    }
+
+    headers = {
+      Accept = "application/json"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = <<-EOF
+    Found {{ result.total }} users (page {{ result.start }}):
+    {% for user in result.users %}
+    - {{ user.email }} ({{ user.user_id }}) — {{ user.connection }} — verified: {{ user.email_verified }} — logins: {{ user.logins_count }}
+    {% endfor %}
+    EOF
+  }
+}
+
+command "get_user" {
+  title       = "Get user"
+  summary     = "Get a user by ID"
+  description = "Retrieve detailed information about a specific Auth0 user by their user_id."
+  categories  = ["users"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["auth0.token"]
+  }
+
+  param "user_id" {
+    type        = "string"
+    required    = true
+    description = "User ID (e.g. 'auth0|507f1f77bcf86cd799439020')"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://{{ env.AUTH0_DOMAIN }}/api/v2/users/{{ args.user_id }}"
+
+    auth {
+      kind   = "bearer"
+      secret = "auth0.token"
+    }
+
+    headers = {
+      Accept = "application/json"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = <<-EOF
+    User: {{ result.name }} ({{ result.user_id }})
+    Email: {{ result.email }} (verified: {{ result.email_verified }})
+    Connection: {{ result.identities[0].connection }}
+    Created: {{ result.created_at }}
+    Last login: {{ result.last_login }}
+    Login count: {{ result.logins_count }}
+    Blocked: {{ result.blocked | default("false") }}
+    EOF
+  }
+}
+
+command "create_user" {
+  title       = "Create user"
+  summary     = "Create a new user"
+  description = "Create a new user in the specified Auth0 connection with email and password."
+  categories  = ["users"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["auth0.token"]
+  }
+
+  param "connection" {
+    type        = "string"
+    required    = true
+    description = "Connection name (e.g. 'Username-Password-Authentication')"
+  }
+
+  param "email" {
+    type        = "string"
+    required    = true
+    description = "User's email address"
+  }
+
+  param "password" {
+    type        = "string"
+    required    = true
+    description = "User's password"
+  }
+
+  param "name" {
+    type        = "string"
+    required    = false
+    default     = ""
+    description = "User's full name"
+  }
+
+  param "email_verified" {
+    type        = "boolean"
+    required    = false
+    default     = false
+    description = "Mark email as pre-verified"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "POST"
+    url      = "https://{{ env.AUTH0_DOMAIN }}/api/v2/users"
+
+    auth {
+      kind   = "bearer"
+      secret = "auth0.token"
+    }
+
+    headers = {
+      Accept = "application/json"
+    }
+
+    body {
+      kind = "json"
+      value = {
+        connection     = "{{ args.connection }}"
+        email          = "{{ args.email }}"
+        password       = "{{ args.password }}"
+        name           = "{{ args.name }}"
+        email_verified = "{{ args.email_verified }}"
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    output = <<-EOF
+    Created user: {{ result.email }} ({{ result.user_id }})
+    Connection: {{ result.identities[0].connection }}
+    Email verified: {{ result.email_verified }}
+    EOF
+  }
+}
+
+command "update_user" {
+  title       = "Update user"
+  summary     = "Update user attributes"
+  description = "Update properties of an existing Auth0 user such as name, email, blocked status, or metadata."
+  categories  = ["users"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["auth0.token"]
+  }
+
+  param "user_id" {
+    type        = "string"
+    required    = true
+    description = "The user_id to update"
+  }
+
+  param "name" {
+    type        = "string"
+    required    = false
+    description = "Updated full name"
+  }
+
+  param "email" {
+    type        = "string"
+    required    = false
+    description = "Updated email address"
+  }
+
+  param "blocked" {
+    type        = "boolean"
+    required    = false
+    description = "Block or unblock the user"
+  }
+
+  param "email_verified" {
+    type        = "boolean"
+    required    = false
+    description = "Mark email as verified or unverified"
+  }
+
+  param "connection" {
+    type        = "string"
+    required    = false
+    description = "Required when updating email or phone"
+  }
+
+  param "client_id" {
+    type        = "string"
+    required    = false
+    description = "Required when updating email or phone"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "PATCH"
+    url      = "https://{{ env.AUTH0_DOMAIN }}/api/v2/users/{{ args.user_id }}"
+
+    auth {
+      kind   = "bearer"
+      secret = "auth0.token"
+    }
+
+    headers = {
+      Accept = "application/json"
+    }
+
+    body {
+      kind = "json"
+      value = {
+        name           = "{{ args.name }}"
+        email          = "{{ args.email }}"
+        blocked        = "{{ args.blocked }}"
+        email_verified = "{{ args.email_verified }}"
+        connection     = "{{ args.connection }}"
+        client_id      = "{{ args.client_id }}"
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    output = <<-EOF
+    Updated user: {{ result.email }} ({{ result.user_id }})
+    Name: {{ result.name }}
+    Blocked: {{ result.blocked | default("false") }}
+    Updated at: {{ result.updated_at }}
+    EOF
+  }
+}
+
+command "delete_user" {
+  title       = "Delete user"
+  summary     = "Delete a user by ID"
+  description = "Permanently delete a user from Auth0. This action cannot be undone."
+  categories  = ["users"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["auth0.token"]
+  }
+
+  param "user_id" {
+    type        = "string"
+    required    = true
+    description = "The user_id to delete"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "DELETE"
+    url      = "https://{{ env.AUTH0_DOMAIN }}/api/v2/users/{{ args.user_id }}"
+
+    auth {
+      kind   = "bearer"
+      secret = "auth0.token"
+    }
+
+    headers = {
+      Accept = "application/json"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Deleted user: {{ args.user_id }}"
+  }
+}
+
+command "list_roles" {
+  title       = "List roles"
+  summary     = "List all roles defined in the tenant"
+  description = "Retrieve all roles with optional name filter and pagination."
+  categories  = ["roles"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["auth0.token"]
+  }
+
+  param "name_filter" {
+    type        = "string"
+    required    = false
+    default     = ""
+    description = "Case-insensitive filter by role name"
+  }
+
+  param "per_page" {
+    type        = "integer"
+    required    = false
+    default     = 50
+    description = "Results per page (max 100)"
+  }
+
+  param "page" {
+    type        = "integer"
+    required    = false
+    default     = 0
+    description = "Zero-based page number"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://{{ env.AUTH0_DOMAIN }}/api/v2/roles"
+
+    auth {
+      kind   = "bearer"
+      secret = "auth0.token"
+    }
+
+    query = {
+      name_filter    = "{{ args.name_filter }}"
+      per_page       = "{{ args.per_page }}"
+      page           = "{{ args.page }}"
+      include_totals = "true"
+    }
+
+    headers = {
+      Accept = "application/json"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = <<-EOF
+    Found {{ result.total }} roles:
+    {% for role in result.roles %}
+    - {{ role.name }} ({{ role.id }}): {{ role.description | default("no description") }}
+    {% endfor %}
+    EOF
+  }
+}
+
+command "assign_user_roles" {
+  title       = "Assign roles to user"
+  summary     = "Assign one or more roles to a user"
+  description = "Assign roles to a user by providing the user ID and an array of role IDs."
+  categories  = ["users", "roles"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["auth0.token"]
+  }
+
+  param "user_id" {
+    type        = "string"
+    required    = true
+    description = "The user_id to assign roles to"
+  }
+
+  param "roles" {
+    type        = "array"
+    required    = true
+    description = "Array of role IDs to assign"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "POST"
+    url      = "https://{{ env.AUTH0_DOMAIN }}/api/v2/users/{{ args.user_id }}/roles"
+
+    auth {
+      kind   = "bearer"
+      secret = "auth0.token"
+    }
+
+    headers = {
+      Accept = "application/json"
+    }
+
+    body {
+      kind = "json"
+      value = {
+        roles = "{{ args.roles }}"
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Assigned {{ args.roles | length }} role(s) to user {{ args.user_id }}."
+  }
+}
+
+command "list_clients" {
+  title       = "List applications"
+  summary     = "List all applications (clients) in the tenant"
+  description = "Retrieve all registered applications with optional type filtering and pagination."
+  categories  = ["applications"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["auth0.token"]
+  }
+
+  param "app_type" {
+    type        = "string"
+    required    = false
+    default     = ""
+    description = "Filter by type: native, spa, regular_web, or non_interactive"
+  }
+
+  param "per_page" {
+    type        = "integer"
+    required    = false
+    default     = 50
+    description = "Results per page (max 100)"
+  }
+
+  param "page" {
+    type        = "integer"
+    required    = false
+    default     = 0
+    description = "Zero-based page number"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://{{ env.AUTH0_DOMAIN }}/api/v2/clients"
+
+    auth {
+      kind   = "bearer"
+      secret = "auth0.token"
+    }
+
+    query = {
+      app_type       = "{{ args.app_type }}"
+      per_page       = "{{ args.per_page }}"
+      page           = "{{ args.page }}"
+      include_totals = "true"
+    }
+
+    headers = {
+      Accept = "application/json"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = <<-EOF
+    Found {{ result.total }} applications:
+    {% for client in result.clients %}
+    - {{ client.name }} ({{ client.client_id }}) — type: {{ client.app_type | default("unknown") }} — callbacks: {{ client.callbacks | default([]) | length }}
+    {% endfor %}
+    EOF
+  }
+}
+
+command "get_client" {
+  title       = "Get application"
+  summary     = "Get application details by client ID"
+  description = "Retrieve detailed information about a specific Auth0 application."
+  categories  = ["applications"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["auth0.token"]
+  }
+
+  param "client_id" {
+    type        = "string"
+    required    = true
+    description = "The application's client_id"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://{{ env.AUTH0_DOMAIN }}/api/v2/clients/{{ args.client_id }}"
+
+    auth {
+      kind   = "bearer"
+      secret = "auth0.token"
+    }
+
+    headers = {
+      Accept = "application/json"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = <<-EOF
+    Application: {{ result.name }} ({{ result.client_id }})
+    Type: {{ result.app_type | default("unknown") }}
+    Callbacks: {{ result.callbacks | default([]) | join(", ") }}
+    Allowed Origins: {{ result.allowed_origins | default([]) | join(", ") }}
+    Grant Types: {{ result.grant_types | default([]) | join(", ") }}
+    EOF
+  }
+}
+
+command "create_client" {
+  title       = "Create application"
+  summary     = "Register a new application"
+  description = "Create a new application (client) in Auth0 with the specified name and type."
+  categories  = ["applications"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["auth0.token"]
+  }
+
+  param "name" {
+    type        = "string"
+    required    = true
+    description = "Application name"
+  }
+
+  param "app_type" {
+    type        = "string"
+    required    = false
+    default     = "regular_web"
+    description = "Application type: native, spa, regular_web, or non_interactive"
+  }
+
+  param "description" {
+    type        = "string"
+    required    = false
+    default     = ""
+    description = "Application description"
+  }
+
+  param "callbacks" {
+    type        = "array"
+    required    = false
+    description = "Allowed callback URLs"
+  }
+
+  param "allowed_origins" {
+    type        = "array"
+    required    = false
+    description = "Allowed origins for CORS"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "POST"
+    url      = "https://{{ env.AUTH0_DOMAIN }}/api/v2/clients"
+
+    auth {
+      kind   = "bearer"
+      secret = "auth0.token"
+    }
+
+    headers = {
+      Accept = "application/json"
+    }
+
+    body {
+      kind = "json"
+      value = {
+        name            = "{{ args.name }}"
+        app_type        = "{{ args.app_type }}"
+        description     = "{{ args.description }}"
+        callbacks       = "{{ args.callbacks }}"
+        allowed_origins = "{{ args.allowed_origins }}"
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    output = <<-EOF
+    Created application: {{ result.name }} ({{ result.client_id }})
+    Type: {{ result.app_type | default("unknown") }}
+    Client Secret: {{ result.client_secret }}
+    EOF
+  }
+}
+
+command "list_connections" {
+  title       = "List connections"
+  summary     = "List identity provider connections"
+  description = "Retrieve all identity provider connections configured in the tenant, optionally filtered by strategy."
+  categories  = ["connections"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["auth0.token"]
+  }
+
+  param "strategy" {
+    type        = "string"
+    required    = false
+    default     = ""
+    description = "Filter by strategy (e.g. 'auth0', 'google-oauth2', 'samlp')"
+  }
+
+  param "per_page" {
+    type        = "integer"
+    required    = false
+    default     = 50
+    description = "Results per page (max 100)"
+  }
+
+  param "page" {
+    type        = "integer"
+    required    = false
+    default     = 0
+    description = "Zero-based page number"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://{{ env.AUTH0_DOMAIN }}/api/v2/connections"
+
+    auth {
+      kind   = "bearer"
+      secret = "auth0.token"
+    }
+
+    query = {
+      strategy       = "{{ args.strategy }}"
+      per_page       = "{{ args.per_page }}"
+      page           = "{{ args.page }}"
+      include_totals = "true"
+    }
+
+    headers = {
+      Accept = "application/json"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = <<-EOF
+    Found {{ result.total }} connections:
+    {% for conn in result.connections %}
+    - {{ conn.name }} ({{ conn.id }}) — strategy: {{ conn.strategy }} — enabled clients: {{ conn.enabled_clients | length }}
+    {% endfor %}
+    EOF
+  }
+}
+
+command "list_organizations" {
+  title       = "List organizations"
+  summary     = "List all organizations in the tenant"
+  description = "Retrieve organizations with pagination support."
+  categories  = ["organizations"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["auth0.token"]
+  }
+
+  param "per_page" {
+    type        = "integer"
+    required    = false
+    default     = 50
+    description = "Results per page (max 100)"
+  }
+
+  param "page" {
+    type        = "integer"
+    required    = false
+    default     = 0
+    description = "Zero-based page number"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://{{ env.AUTH0_DOMAIN }}/api/v2/organizations"
+
+    auth {
+      kind   = "bearer"
+      secret = "auth0.token"
+    }
+
+    query = {
+      per_page       = "{{ args.per_page }}"
+      page           = "{{ args.page }}"
+      include_totals = "true"
+    }
+
+    headers = {
+      Accept = "application/json"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = <<-EOF
+    Found {{ result.total }} organizations:
+    {% for org in result.organizations %}
+    - {{ org.display_name | default(org.name) }} ({{ org.id }}) — name: {{ org.name }}
+    {% endfor %}
+    EOF
+  }
+}
+
+command "create_organization" {
+  title       = "Create organization"
+  summary     = "Create a new organization"
+  description = "Create a new organization for multi-tenant B2B use cases."
+  categories  = ["organizations"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["auth0.token"]
+  }
+
+  param "name" {
+    type        = "string"
+    required    = true
+    description = "Organization name (lowercase, alphanumeric and hyphens only)"
+  }
+
+  param "display_name" {
+    type        = "string"
+    required    = false
+    default     = ""
+    description = "Human-readable display name"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "POST"
+    url      = "https://{{ env.AUTH0_DOMAIN }}/api/v2/organizations"
+
+    auth {
+      kind   = "bearer"
+      secret = "auth0.token"
+    }
+
+    headers = {
+      Accept = "application/json"
+    }
+
+    body {
+      kind = "json"
+      value = {
+        name         = "{{ args.name }}"
+        display_name = "{{ args.display_name }}"
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    output = <<-EOF
+    Created organization: {{ result.display_name | default(result.name) }} ({{ result.id }})
+    Name: {{ result.name }}
+    EOF
+  }
+}
+
+command "list_logs" {
+  title       = "List log events"
+  summary     = "Search tenant log events"
+  description = "Retrieve log events from the Auth0 tenant with optional Lucene query filtering. Common event types: s (success login), f (failed login), ss (signup), du (deleted user)."
+  categories  = ["logs"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["auth0.token"]
+  }
+
+  param "q" {
+    type        = "string"
+    required    = false
+    default     = ""
+    description = "Lucene query string to filter events"
+  }
+
+  param "per_page" {
+    type        = "integer"
+    required    = false
+    default     = 50
+    description = "Results per page (max 100)"
+  }
+
+  param "page" {
+    type        = "integer"
+    required    = false
+    default     = 0
+    description = "Zero-based page number"
+  }
+
+  param "sort" {
+    type        = "string"
+    required    = false
+    default     = "date:-1"
+    description = "Sort field and direction (e.g. 'date:-1' for newest first)"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://{{ env.AUTH0_DOMAIN }}/api/v2/logs"
+
+    auth {
+      kind   = "bearer"
+      secret = "auth0.token"
+    }
+
+    query = {
+      q              = "{{ args.q }}"
+      per_page       = "{{ args.per_page }}"
+      page           = "{{ args.page }}"
+      sort           = "{{ args.sort }}"
+      include_totals = "true"
+    }
+
+    headers = {
+      Accept = "application/json"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = <<-EOF
+    Found {{ result.total }} log events:
+    {% for log in result.logs %}
+    - [{{ log.date }}] {{ log.type }} — {{ log.description | default("") }} — user: {{ log.user_name | default("n/a") }} — IP: {{ log.ip | default("n/a") }}
+    {% endfor %}
+    EOF
+  }
+}
+
+command "get_log" {
+  title       = "Get log event"
+  summary     = "Get a single log event by ID"
+  description = "Retrieve detailed information about a specific log event."
+  categories  = ["logs"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["auth0.token"]
+  }
+
+  param "log_id" {
+    type        = "string"
+    required    = true
+    description = "The log event ID"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://{{ env.AUTH0_DOMAIN }}/api/v2/logs/{{ args.log_id }}"
+
+    auth {
+      kind   = "bearer"
+      secret = "auth0.token"
+    }
+
+    headers = {
+      Accept = "application/json"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = <<-EOF
+    Log Event: {{ result._id }}
+    Type: {{ result.type }} — {{ result.description | default("") }}
+    Date: {{ result.date }}
+    User: {{ result.user_name | default("n/a") }} ({{ result.user_id | default("n/a") }})
+    IP: {{ result.ip | default("n/a") }}
+    Client: {{ result.client_name | default("n/a") }} ({{ result.client_id | default("n/a") }})
+    Connection: {{ result.connection | default("n/a") }}
+    EOF
+  }
+}

--- a/examples/cloudflare.hcl
+++ b/examples/cloudflare.hcl
@@ -1,0 +1,832 @@
+version = 1
+provider = "cloudflare"
+categories = ["infrastructure", "dns", "cdn", "edge-compute"]
+
+command "verify_token" {
+  title       = "Verify API token"
+  summary     = "Check that the configured API token is valid"
+  description = "Verify the current Cloudflare API token and show its status and expiration."
+  categories  = ["auth"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["cloudflare.api_token"]
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://api.cloudflare.com/client/v4/user/tokens/verify"
+
+    auth {
+      kind   = "bearer"
+      secret = "cloudflare.api_token"
+    }
+
+    headers = {
+      Accept = "application/json"
+    }
+  }
+
+  result {
+    decode = "json"
+    extract { json_pointer = "/result" }
+    output = "Token status: {{ result.status }}\nExpires: {{ result.expires_on | default('never') }}"
+  }
+}
+
+command "list_zones" {
+  title       = "List zones"
+  summary     = "List all zones (domains) in the account"
+  description = "List zones in the Cloudflare account, optionally filtered by domain name or status."
+  categories  = ["dns"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["cloudflare.api_token"]
+  }
+
+  param "name" {
+    type        = "string"
+    required    = false
+    description = "Filter by domain name"
+  }
+
+  param "status" {
+    type        = "string"
+    required    = false
+    description = "Filter by status: initializing, pending, active, moved"
+  }
+
+  param "per_page" {
+    type        = "integer"
+    required    = false
+    default     = 20
+    description = "Results per page (5-50)"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://api.cloudflare.com/client/v4/zones"
+
+    auth {
+      kind   = "bearer"
+      secret = "cloudflare.api_token"
+    }
+
+    query = {
+      name     = "{{ args.name }}"
+      status   = "{{ args.status }}"
+      per_page = "{{ args.per_page }}"
+    }
+
+    headers = {
+      Accept = "application/json"
+    }
+  }
+
+  result {
+    decode = "json"
+    extract { json_pointer = "/result" }
+    output = "Found {{ result | length }} zones:\n{% for z in result %}\n- {{ z.name }} ({{ z.status }}) — ID: {{ z.id }}\n{% endfor %}"
+  }
+}
+
+command "get_zone" {
+  title       = "Get zone details"
+  summary     = "Get details for a specific zone by ID"
+  description = "Retrieve detailed information about a Cloudflare zone including plan, nameservers, and status."
+  categories  = ["dns"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["cloudflare.api_token"]
+  }
+
+  param "zone_id" {
+    type        = "string"
+    required    = true
+    description = "Zone identifier"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://api.cloudflare.com/client/v4/zones/{{ args.zone_id }}"
+
+    auth {
+      kind   = "bearer"
+      secret = "cloudflare.api_token"
+    }
+
+    headers = {
+      Accept = "application/json"
+    }
+  }
+
+  result {
+    decode = "json"
+    extract { json_pointer = "/result" }
+    output = "Zone: {{ result.name }}\nStatus: {{ result.status }}\nPlan: {{ result.plan.name }}\nNameservers: {{ result.name_servers | join(', ') }}\nCreated: {{ result.created_on }}"
+  }
+}
+
+command "list_dns_records" {
+  title       = "List DNS records"
+  summary     = "List DNS records for a zone"
+  description = "List all DNS records for a zone, optionally filtered by record type or name."
+  categories  = ["dns"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["cloudflare.api_token"]
+  }
+
+  param "zone_id" {
+    type        = "string"
+    required    = true
+    description = "Zone identifier"
+  }
+
+  param "type" {
+    type        = "string"
+    required    = false
+    description = "Record type filter: A, AAAA, CNAME, MX, TXT, NS, SRV"
+  }
+
+  param "name" {
+    type        = "string"
+    required    = false
+    description = "Record name filter"
+  }
+
+  param "per_page" {
+    type        = "integer"
+    required    = false
+    default     = 100
+    description = "Results per page (1-5000)"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://api.cloudflare.com/client/v4/zones/{{ args.zone_id }}/dns_records"
+
+    auth {
+      kind   = "bearer"
+      secret = "cloudflare.api_token"
+    }
+
+    query = {
+      type     = "{{ args.type }}"
+      name     = "{{ args.name }}"
+      per_page = "{{ args.per_page }}"
+    }
+
+    headers = {
+      Accept = "application/json"
+    }
+  }
+
+  result {
+    decode = "json"
+    extract { json_pointer = "/result" }
+    output = "Found {{ result | length }} DNS records:\n{% for r in result %}\n- {{ r.type }} {{ r.name }} → {{ r.content }} (TTL: {{ r.ttl }}, proxied: {{ r.proxied }})\n{% endfor %}"
+  }
+}
+
+command "create_dns_record" {
+  title       = "Create DNS record"
+  summary     = "Create a new DNS record in a zone"
+  description = "Create a DNS record (A, AAAA, CNAME, MX, TXT, etc.) in the specified zone."
+  categories  = ["dns"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["cloudflare.api_token"]
+  }
+
+  param "zone_id" {
+    type        = "string"
+    required    = true
+    description = "Zone identifier"
+  }
+
+  param "type" {
+    type        = "string"
+    required    = true
+    description = "Record type: A, AAAA, CNAME, MX, TXT, NS, SRV"
+  }
+
+  param "name" {
+    type        = "string"
+    required    = true
+    description = "Record name (e.g. sub.example.com)"
+  }
+
+  param "content" {
+    type        = "string"
+    required    = true
+    description = "Record value (e.g. IP address, target domain)"
+  }
+
+  param "ttl" {
+    type        = "integer"
+    required    = false
+    default     = 1
+    description = "TTL in seconds (60-86400, or 1 for auto)"
+  }
+
+  param "proxied" {
+    type        = "boolean"
+    required    = false
+    default     = false
+    description = "Whether to proxy through Cloudflare"
+  }
+
+  param "comment" {
+    type        = "string"
+    required    = false
+    description = "Admin comment for the record"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "POST"
+    url      = "https://api.cloudflare.com/client/v4/zones/{{ args.zone_id }}/dns_records"
+
+    auth {
+      kind   = "bearer"
+      secret = "cloudflare.api_token"
+    }
+
+    headers = {
+      Accept = "application/json"
+    }
+
+    body {
+      kind = "json"
+      value = {
+        type    = "{{ args.type }}"
+        name    = "{{ args.name }}"
+        content = "{{ args.content }}"
+        ttl     = "{{ args.ttl }}"
+        proxied = "{{ args.proxied }}"
+        comment = "{{ args.comment }}"
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    extract { json_pointer = "/result" }
+    output = "Created {{ result.type }} record: {{ result.name }} → {{ result.content }}\nID: {{ result.id }}\nProxied: {{ result.proxied }}\nTTL: {{ result.ttl }}"
+  }
+}
+
+command "update_dns_record" {
+  title       = "Update DNS record"
+  summary     = "Update an existing DNS record"
+  description = "Patch a DNS record to update its content, TTL, proxy status, or other fields."
+  categories  = ["dns"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["cloudflare.api_token"]
+  }
+
+  param "zone_id" {
+    type        = "string"
+    required    = true
+    description = "Zone identifier"
+  }
+
+  param "dns_record_id" {
+    type        = "string"
+    required    = true
+    description = "DNS record identifier"
+  }
+
+  param "content" {
+    type        = "string"
+    required    = true
+    description = "Updated record value"
+  }
+
+  param "ttl" {
+    type        = "integer"
+    required    = false
+    default     = 1
+    description = "Updated TTL in seconds (60-86400, or 1 for auto)"
+  }
+
+  param "proxied" {
+    type        = "boolean"
+    required    = false
+    default     = false
+    description = "Updated proxy status"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "PATCH"
+    url      = "https://api.cloudflare.com/client/v4/zones/{{ args.zone_id }}/dns_records/{{ args.dns_record_id }}"
+
+    auth {
+      kind   = "bearer"
+      secret = "cloudflare.api_token"
+    }
+
+    headers = {
+      Accept = "application/json"
+    }
+
+    body {
+      kind = "json"
+      value = {
+        content = "{{ args.content }}"
+        ttl     = "{{ args.ttl }}"
+        proxied = "{{ args.proxied }}"
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    extract { json_pointer = "/result" }
+    output = "Updated record {{ result.id }}:\n{{ result.type }} {{ result.name }} → {{ result.content }}\nProxied: {{ result.proxied }}, TTL: {{ result.ttl }}"
+  }
+}
+
+command "delete_dns_record" {
+  title       = "Delete DNS record"
+  summary     = "Delete a DNS record from a zone"
+  description = "Permanently delete a DNS record by its identifier."
+  categories  = ["dns"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["cloudflare.api_token"]
+  }
+
+  param "zone_id" {
+    type        = "string"
+    required    = true
+    description = "Zone identifier"
+  }
+
+  param "dns_record_id" {
+    type        = "string"
+    required    = true
+    description = "DNS record identifier"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "DELETE"
+    url      = "https://api.cloudflare.com/client/v4/zones/{{ args.zone_id }}/dns_records/{{ args.dns_record_id }}"
+
+    auth {
+      kind   = "bearer"
+      secret = "cloudflare.api_token"
+    }
+
+    headers = {
+      Accept = "application/json"
+    }
+  }
+
+  result {
+    decode = "json"
+    extract { json_pointer = "/result" }
+    output = "Deleted DNS record {{ result.id }}"
+  }
+}
+
+command "purge_cache" {
+  title       = "Purge cache"
+  summary     = "Purge all cached content for a zone"
+  description = "Purge the entire Cloudflare cache for a zone. This removes all cached resources and forces re-fetching from origin."
+  categories  = ["cdn"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["cloudflare.api_token"]
+  }
+
+  param "zone_id" {
+    type        = "string"
+    required    = true
+    description = "Zone identifier"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "POST"
+    url      = "https://api.cloudflare.com/client/v4/zones/{{ args.zone_id }}/purge_cache"
+
+    auth {
+      kind   = "bearer"
+      secret = "cloudflare.api_token"
+    }
+
+    headers = {
+      Accept = "application/json"
+    }
+
+    body {
+      kind = "json"
+      value = {
+        purge_everything = "{{ true }}"
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    extract { json_pointer = "/result" }
+    output = "Cache purge initiated. Operation ID: {{ result.id }}"
+  }
+}
+
+command "edit_zone_setting" {
+  title       = "Edit zone setting"
+  summary     = "Update a zone setting like SSL mode or security level"
+  description = "Modify a zone setting. Common settings: ssl (off/flexible/full/strict), security_level (essentially_off/low/medium/high/under_attack), always_use_https, min_tls_version, tls_1_3, browser_check."
+  categories  = ["infrastructure"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["cloudflare.api_token"]
+  }
+
+  param "zone_id" {
+    type        = "string"
+    required    = true
+    description = "Zone identifier"
+  }
+
+  param "setting_id" {
+    type        = "string"
+    required    = true
+    description = "Setting ID (e.g. ssl, security_level, always_use_https, min_tls_version)"
+  }
+
+  param "value" {
+    type        = "string"
+    required    = true
+    description = "New setting value (e.g. strict, high, on)"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "PATCH"
+    url      = "https://api.cloudflare.com/client/v4/zones/{{ args.zone_id }}/settings/{{ args.setting_id }}"
+
+    auth {
+      kind   = "bearer"
+      secret = "cloudflare.api_token"
+    }
+
+    headers = {
+      Accept = "application/json"
+    }
+
+    body {
+      kind = "json"
+      value = {
+        value = "{{ args.value }}"
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    extract { json_pointer = "/result" }
+    output = "Updated setting \"{{ result.id }}\" to \"{{ result.value }}\"\nModified: {{ result.modified_on }}"
+  }
+}
+
+command "list_workers" {
+  title       = "List Workers"
+  summary     = "List Workers scripts for an account"
+  description = "List all Cloudflare Workers scripts deployed in the specified account."
+  categories  = ["edge-compute"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["cloudflare.api_token"]
+  }
+
+  param "account_id" {
+    type        = "string"
+    required    = true
+    description = "Account identifier"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://api.cloudflare.com/client/v4/accounts/{{ args.account_id }}/workers/scripts"
+
+    auth {
+      kind   = "bearer"
+      secret = "cloudflare.api_token"
+    }
+
+    headers = {
+      Accept = "application/json"
+    }
+  }
+
+  result {
+    decode = "json"
+    extract { json_pointer = "/result" }
+    output = "Found {{ result | length }} Workers:\n{% for w in result %}\n- {{ w.id }} (modified: {{ w.modified_on }})\n{% endfor %}"
+  }
+}
+
+command "list_kv_namespaces" {
+  title       = "List KV namespaces"
+  summary     = "List Workers KV namespaces for an account"
+  description = "List all Workers KV namespaces in the specified account."
+  categories  = ["edge-compute"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["cloudflare.api_token"]
+  }
+
+  param "account_id" {
+    type        = "string"
+    required    = true
+    description = "Account identifier"
+  }
+
+  param "per_page" {
+    type        = "integer"
+    required    = false
+    default     = 20
+    description = "Results per page (1-1000)"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://api.cloudflare.com/client/v4/accounts/{{ args.account_id }}/storage/kv/namespaces"
+
+    auth {
+      kind   = "bearer"
+      secret = "cloudflare.api_token"
+    }
+
+    query = {
+      per_page = "{{ args.per_page }}"
+    }
+
+    headers = {
+      Accept = "application/json"
+    }
+  }
+
+  result {
+    decode = "json"
+    extract { json_pointer = "/result" }
+    output = "Found {{ result | length }} KV namespaces:\n{% for ns in result %}\n- {{ ns.title }} — ID: {{ ns.id }}\n{% endfor %}"
+  }
+}
+
+command "read_kv_pair" {
+  title       = "Read KV value"
+  summary     = "Read a value from a Workers KV namespace"
+  description = "Read the value of a key from a Workers KV namespace. Returns the raw stored value."
+  categories  = ["edge-compute"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["cloudflare.api_token"]
+  }
+
+  param "account_id" {
+    type        = "string"
+    required    = true
+    description = "Account identifier"
+  }
+
+  param "namespace_id" {
+    type        = "string"
+    required    = true
+    description = "KV namespace identifier"
+  }
+
+  param "key_name" {
+    type        = "string"
+    required    = true
+    description = "Key name (max 512 bytes)"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://api.cloudflare.com/client/v4/accounts/{{ args.account_id }}/storage/kv/namespaces/{{ args.namespace_id }}/values/{{ args.key_name }}"
+
+    auth {
+      kind   = "bearer"
+      secret = "cloudflare.api_token"
+    }
+
+    headers = {
+      Accept = "application/json"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Key \"{{ args.key_name }}\": {{ result }}"
+  }
+}
+
+command "write_kv_pair" {
+  title       = "Write KV value"
+  summary     = "Write a key-value pair to a Workers KV namespace"
+  description = "Store a value for a key in a Workers KV namespace. Optionally set an expiration."
+  categories  = ["edge-compute"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["cloudflare.api_token"]
+  }
+
+  param "account_id" {
+    type        = "string"
+    required    = true
+    description = "Account identifier"
+  }
+
+  param "namespace_id" {
+    type        = "string"
+    required    = true
+    description = "KV namespace identifier"
+  }
+
+  param "key_name" {
+    type        = "string"
+    required    = true
+    description = "Key name"
+  }
+
+  param "value" {
+    type        = "string"
+    required    = true
+    description = "Value to store"
+  }
+
+  param "expiration_ttl" {
+    type        = "integer"
+    required    = false
+    description = "TTL in seconds from now (minimum 60)"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "PUT"
+    url      = "https://api.cloudflare.com/client/v4/accounts/{{ args.account_id }}/storage/kv/namespaces/{{ args.namespace_id }}/values/{{ args.key_name }}"
+
+    auth {
+      kind   = "bearer"
+      secret = "cloudflare.api_token"
+    }
+
+    query = {
+      expiration_ttl = "{{ args.expiration_ttl }}"
+    }
+
+    headers = {
+      Content-Type = "text/plain"
+    }
+
+    body {
+      kind = "json"
+      value = {
+        value = "{{ args.value }}"
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Wrote key \"{{ args.key_name }}\" to namespace {{ args.namespace_id }}"
+  }
+}
+
+command "list_pages_projects" {
+  title       = "List Pages projects"
+  summary     = "List Cloudflare Pages projects for an account"
+  description = "List all Cloudflare Pages projects deployed in the specified account."
+  categories  = ["infrastructure"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["cloudflare.api_token"]
+  }
+
+  param "account_id" {
+    type        = "string"
+    required    = true
+    description = "Account identifier"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://api.cloudflare.com/client/v4/accounts/{{ args.account_id }}/pages/projects"
+
+    auth {
+      kind   = "bearer"
+      secret = "cloudflare.api_token"
+    }
+
+    headers = {
+      Accept = "application/json"
+    }
+  }
+
+  result {
+    decode = "json"
+    extract { json_pointer = "/result" }
+    output = "Found {{ result | length }} Pages projects:\n{% for p in result %}\n- {{ p.name }} — {{ p.subdomain }}\n{% endfor %}"
+  }
+}
+
+command "create_waf_rule" {
+  title       = "Create WAF rule"
+  summary     = "Create a custom WAF firewall rule"
+  description = "Create a custom Web Application Firewall rule in a zone's ruleset. Requires the ruleset ID for the http_request_firewall_custom phase."
+  categories  = ["infrastructure"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["cloudflare.api_token"]
+  }
+
+  param "zone_id" {
+    type        = "string"
+    required    = true
+    description = "Zone identifier"
+  }
+
+  param "ruleset_id" {
+    type        = "string"
+    required    = true
+    description = "Ruleset ID for the http_request_firewall_custom phase"
+  }
+
+  param "expression" {
+    type        = "string"
+    required    = true
+    description = "Rule expression (e.g. '(ip.geoip.country eq \"BR\")')"
+  }
+
+  param "action" {
+    type        = "string"
+    required    = true
+    description = "Action: block, challenge, js_challenge, managed_challenge, log, skip"
+  }
+
+  param "description" {
+    type        = "string"
+    required    = false
+    description = "Human-readable rule description"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "POST"
+    url      = "https://api.cloudflare.com/client/v4/zones/{{ args.zone_id }}/rulesets/{{ args.ruleset_id }}/rules"
+
+    auth {
+      kind   = "bearer"
+      secret = "cloudflare.api_token"
+    }
+
+    headers = {
+      Accept = "application/json"
+    }
+
+    body {
+      kind = "json"
+      value = {
+        expression  = "{{ args.expression }}"
+        action      = "{{ args.action }}"
+        description = "{{ args.description }}"
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    extract { json_pointer = "/result" }
+    output = "Created WAF rule in ruleset {{ result.id }}\nRules count: {{ result.rules | length }}"
+  }
+}

--- a/examples/datadog.hcl
+++ b/examples/datadog.hcl
@@ -1,0 +1,824 @@
+version = 1
+provider = "datadog"
+categories = ["monitoring", "observability", "infrastructure"]
+
+command "list_monitors" {
+  title       = "List monitors"
+  summary     = "List all Datadog monitors"
+  description = "Retrieve all monitors from your Datadog account, optionally filtered by tags."
+  categories  = ["monitors"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["datadog.api_key", "datadog.app_key"]
+  }
+
+  param "tags" {
+    type        = "string"
+    required    = false
+    default     = ""
+    description = "Comma-separated list of tags to filter by"
+  }
+
+  param "page_size" {
+    type        = "integer"
+    required    = false
+    default     = 100
+    description = "Number of monitors per page (max 1000)"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://api.datadoghq.com/api/v1/monitor"
+
+    auth {
+      kind     = "api_key"
+      location = "header"
+      name     = "DD-API-KEY"
+      secret   = "datadog.api_key"
+    }
+
+    query = {
+      tags      = "{{ args.tags }}"
+      page_size = "{{ args.page_size }}"
+    }
+
+    headers = {
+      "DD-APPLICATION-KEY" = "{{ secrets.datadog.app_key }}"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Found {{ result | length }} monitors."
+  }
+}
+
+command "get_monitor" {
+  title       = "Get monitor"
+  summary     = "Get a monitor by ID"
+  description = "Retrieve details for a specific Datadog monitor by its ID."
+  categories  = ["monitors"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["datadog.api_key", "datadog.app_key"]
+  }
+
+  param "monitor_id" {
+    type        = "integer"
+    required    = true
+    description = "The monitor ID"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://api.datadoghq.com/api/v1/monitor/{{ args.monitor_id }}"
+
+    auth {
+      kind     = "api_key"
+      location = "header"
+      name     = "DD-API-KEY"
+      secret   = "datadog.api_key"
+    }
+
+    headers = {
+      "DD-APPLICATION-KEY" = "{{ secrets.datadog.app_key }}"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Monitor [{{ result.id }}]: {{ result.name }}\nType: {{ result.type }}\nStatus: {{ result.overall_state }}\nQuery: {{ result.query }}"
+  }
+}
+
+command "create_monitor" {
+  title       = "Create monitor"
+  summary     = "Create a new Datadog monitor"
+  description = "Create a new monitor with the specified type, query, and notification message."
+  categories  = ["monitors"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["datadog.api_key", "datadog.app_key"]
+  }
+
+  param "name" {
+    type        = "string"
+    required    = true
+    description = "Monitor name"
+  }
+
+  param "type" {
+    type        = "string"
+    required    = true
+    description = "Monitor type (e.g. 'metric alert', 'log alert', 'query alert')"
+  }
+
+  param "query" {
+    type        = "string"
+    required    = true
+    description = "The monitor query (e.g. 'avg(last_5m):avg:system.cpu.user{*} > 90')"
+  }
+
+  param "message" {
+    type        = "string"
+    required    = true
+    description = "Notification message body, supports @-mentions and markdown"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "POST"
+    url      = "https://api.datadoghq.com/api/v1/monitor"
+
+    auth {
+      kind     = "api_key"
+      location = "header"
+      name     = "DD-API-KEY"
+      secret   = "datadog.api_key"
+    }
+
+    headers = {
+      "DD-APPLICATION-KEY" = "{{ secrets.datadog.app_key }}"
+    }
+
+    body {
+      kind = "json"
+      value = {
+        name    = "{{ args.name }}"
+        type    = "{{ args.type }}"
+        query   = "{{ args.query }}"
+        message = "{{ args.message }}"
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Created monitor [{{ result.id }}]: {{ result.name }} ({{ result.type }})"
+  }
+}
+
+command "delete_monitor" {
+  title       = "Delete monitor"
+  summary     = "Delete a monitor by ID"
+  description = "Permanently delete a Datadog monitor."
+  categories  = ["monitors"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["datadog.api_key", "datadog.app_key"]
+  }
+
+  param "monitor_id" {
+    type        = "integer"
+    required    = true
+    description = "The monitor ID to delete"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "DELETE"
+    url      = "https://api.datadoghq.com/api/v1/monitor/{{ args.monitor_id }}"
+
+    auth {
+      kind     = "api_key"
+      location = "header"
+      name     = "DD-API-KEY"
+      secret   = "datadog.api_key"
+    }
+
+    headers = {
+      "DD-APPLICATION-KEY" = "{{ secrets.datadog.app_key }}"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Deleted monitor {{ args.monitor_id }}."
+  }
+}
+
+command "search_logs" {
+  title       = "Search logs"
+  summary     = "Search log events with a query"
+  description = "Search Datadog log events using a log search query with time range filtering."
+  categories  = ["logs"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["datadog.api_key", "datadog.app_key"]
+  }
+
+  param "query" {
+    type        = "string"
+    required    = true
+    description = "Datadog log search query (e.g. 'service:frontend status:error')"
+  }
+
+  param "from" {
+    type        = "string"
+    required    = false
+    default     = "now-15m"
+    description = "Start time as ISO 8601 or relative (e.g. 'now-1h')"
+  }
+
+  param "to" {
+    type        = "string"
+    required    = false
+    default     = "now"
+    description = "End time as ISO 8601 or relative"
+  }
+
+  param "limit" {
+    type        = "integer"
+    required    = false
+    default     = 50
+    description = "Maximum number of log entries to return (max 1000)"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "POST"
+    url      = "https://api.datadoghq.com/api/v2/logs/events/search"
+
+    auth {
+      kind     = "api_key"
+      location = "header"
+      name     = "DD-API-KEY"
+      secret   = "datadog.api_key"
+    }
+
+    headers = {
+      "DD-APPLICATION-KEY" = "{{ secrets.datadog.app_key }}"
+    }
+
+    body {
+      kind = "json"
+      value = {
+        filter = {
+          query = "{{ args.query }}"
+          from  = "{{ args.from }}"
+          to    = "{{ args.to }}"
+        }
+        page = {
+          limit = "{{ args.limit }}"
+        }
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Found {{ result.data | length }} log entries."
+  }
+}
+
+command "create_event" {
+  title       = "Create event"
+  summary     = "Post an event to the Datadog event stream"
+  description = "Submit a custom event to the Datadog event stream for tracking deployments, alerts, or other notable occurrences."
+  categories  = ["events"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["datadog.api_key"]
+  }
+
+  param "title" {
+    type        = "string"
+    required    = true
+    description = "Event title"
+  }
+
+  param "text" {
+    type        = "string"
+    required    = true
+    description = "Event body text (max 4000 characters)"
+  }
+
+  param "alert_type" {
+    type        = "string"
+    required    = false
+    default     = "info"
+    description = "Alert type: error, warning, info, or success"
+  }
+
+  param "priority" {
+    type        = "string"
+    required    = false
+    default     = "normal"
+    description = "Event priority: normal or low"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "POST"
+    url      = "https://api.datadoghq.com/api/v1/events"
+
+    auth {
+      kind     = "api_key"
+      location = "header"
+      name     = "DD-API-KEY"
+      secret   = "datadog.api_key"
+    }
+
+    body {
+      kind = "json"
+      value = {
+        title      = "{{ args.title }}"
+        text       = "{{ args.text }}"
+        alert_type = "{{ args.alert_type }}"
+        priority   = "{{ args.priority }}"
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Created event: {{ result.event.title }} ({{ result.status }})"
+  }
+}
+
+command "list_events" {
+  title       = "List events"
+  summary     = "List events within a time range"
+  description = "Retrieve events from the Datadog event stream within a specified time range."
+  categories  = ["events"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["datadog.api_key", "datadog.app_key"]
+  }
+
+  param "start" {
+    type        = "integer"
+    required    = true
+    description = "POSIX timestamp for the start of the time range"
+  }
+
+  param "end" {
+    type        = "integer"
+    required    = true
+    description = "POSIX timestamp for the end of the time range"
+  }
+
+  param "priority" {
+    type        = "string"
+    required    = false
+    default     = ""
+    description = "Filter by priority: normal or low"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://api.datadoghq.com/api/v1/events"
+
+    auth {
+      kind     = "api_key"
+      location = "header"
+      name     = "DD-API-KEY"
+      secret   = "datadog.api_key"
+    }
+
+    query = {
+      start    = "{{ args.start }}"
+      end      = "{{ args.end }}"
+      priority = "{{ args.priority }}"
+    }
+
+    headers = {
+      "DD-APPLICATION-KEY" = "{{ secrets.datadog.app_key }}"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Found {{ result.events | length }} events."
+  }
+}
+
+command "query_metrics" {
+  title       = "Query metrics"
+  summary     = "Query timeseries metric data"
+  description = "Query Datadog metric timeseries data for a given time range using a metric query expression."
+  categories  = ["metrics"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["datadog.api_key", "datadog.app_key"]
+  }
+
+  param "from" {
+    type        = "integer"
+    required    = true
+    description = "POSIX timestamp for the start of the query window"
+  }
+
+  param "to" {
+    type        = "integer"
+    required    = true
+    description = "POSIX timestamp for the end of the query window"
+  }
+
+  param "query" {
+    type        = "string"
+    required    = true
+    description = "Metric query expression (e.g. 'avg:system.cpu.user{*}')"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://api.datadoghq.com/api/v1/query"
+
+    auth {
+      kind     = "api_key"
+      location = "header"
+      name     = "DD-API-KEY"
+      secret   = "datadog.api_key"
+    }
+
+    query = {
+      from  = "{{ args.from }}"
+      to    = "{{ args.to }}"
+      query = "{{ args.query }}"
+    }
+
+    headers = {
+      "DD-APPLICATION-KEY" = "{{ secrets.datadog.app_key }}"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Query status: {{ result.status }}\n{{ result.series | length }} series returned."
+  }
+}
+
+command "list_dashboards" {
+  title       = "List dashboards"
+  summary     = "List all Datadog dashboards"
+  description = "Retrieve all dashboards from your Datadog account."
+  categories  = ["dashboards"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["datadog.api_key", "datadog.app_key"]
+  }
+
+  param "count" {
+    type        = "integer"
+    required    = false
+    default     = 100
+    description = "Number of dashboards to return"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://api.datadoghq.com/api/v1/dashboard"
+
+    auth {
+      kind     = "api_key"
+      location = "header"
+      name     = "DD-API-KEY"
+      secret   = "datadog.api_key"
+    }
+
+    query = {
+      count = "{{ args.count }}"
+    }
+
+    headers = {
+      "DD-APPLICATION-KEY" = "{{ secrets.datadog.app_key }}"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Found {{ result.dashboards | length }} dashboards."
+  }
+}
+
+command "get_dashboard" {
+  title       = "Get dashboard"
+  summary     = "Get a dashboard by ID"
+  description = "Retrieve details for a specific Datadog dashboard."
+  categories  = ["dashboards"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["datadog.api_key", "datadog.app_key"]
+  }
+
+  param "dashboard_id" {
+    type        = "string"
+    required    = true
+    description = "The dashboard ID"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://api.datadoghq.com/api/v1/dashboard/{{ args.dashboard_id }}"
+
+    auth {
+      kind     = "api_key"
+      location = "header"
+      name     = "DD-API-KEY"
+      secret   = "datadog.api_key"
+    }
+
+    headers = {
+      "DD-APPLICATION-KEY" = "{{ secrets.datadog.app_key }}"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Dashboard [{{ result.id }}]: {{ result.title }}\nLayout: {{ result.layout_type }}\nWidgets: {{ result.widgets | length }}\nURL: {{ result.url }}"
+  }
+}
+
+command "list_hosts" {
+  title       = "List hosts"
+  summary     = "List infrastructure hosts"
+  description = "Retrieve a list of hosts reporting to your Datadog account, optionally filtered by name or tag."
+  categories  = ["infrastructure"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["datadog.api_key", "datadog.app_key"]
+  }
+
+  param "filter" {
+    type        = "string"
+    required    = false
+    default     = ""
+    description = "Filter hosts by name, alias, or tag"
+  }
+
+  param "count" {
+    type        = "integer"
+    required    = false
+    default     = 100
+    description = "Maximum number of hosts to return (max 1000)"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://api.datadoghq.com/api/v1/hosts"
+
+    auth {
+      kind     = "api_key"
+      location = "header"
+      name     = "DD-API-KEY"
+      secret   = "datadog.api_key"
+    }
+
+    query = {
+      filter = "{{ args.filter }}"
+      count  = "{{ args.count }}"
+    }
+
+    headers = {
+      "DD-APPLICATION-KEY" = "{{ secrets.datadog.app_key }}"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "{{ result.total_matching }} hosts found (showing {{ result.total_returned }})."
+  }
+}
+
+command "mute_host" {
+  title       = "Mute host"
+  summary     = "Mute a host to suppress alerts"
+  description = "Mute monitoring notifications for a specific host, optionally until a specified time."
+  categories  = ["infrastructure"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["datadog.api_key", "datadog.app_key"]
+  }
+
+  param "host_name" {
+    type        = "string"
+    required    = true
+    description = "The hostname to mute"
+  }
+
+  param "message" {
+    type        = "string"
+    required    = false
+    default     = ""
+    description = "Reason for muting the host"
+  }
+
+  param "end" {
+    type        = "integer"
+    required    = false
+    default     = 0
+    description = "POSIX timestamp when the mute should expire (0 for indefinite)"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "POST"
+    url      = "https://api.datadoghq.com/api/v1/host/{{ args.host_name }}/mute"
+
+    auth {
+      kind     = "api_key"
+      location = "header"
+      name     = "DD-API-KEY"
+      secret   = "datadog.api_key"
+    }
+
+    headers = {
+      "DD-APPLICATION-KEY" = "{{ secrets.datadog.app_key }}"
+    }
+
+    body {
+      kind = "json"
+      value = {
+        message  = "{{ args.message }}"
+        end      = "{{ args.end }}"
+        override = true
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Muted host {{ result.hostname }}."
+  }
+}
+
+command "list_incidents" {
+  title       = "List incidents"
+  summary     = "List Datadog incidents"
+  description = "Retrieve a paginated list of incidents from your Datadog account."
+  categories  = ["incidents"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["datadog.api_key", "datadog.app_key"]
+  }
+
+  param "page_size" {
+    type        = "integer"
+    required    = false
+    default     = 10
+    description = "Number of incidents per page"
+  }
+
+  param "page_offset" {
+    type        = "integer"
+    required    = false
+    default     = 0
+    description = "Pagination offset"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://api.datadoghq.com/api/v2/incidents"
+
+    auth {
+      kind     = "api_key"
+      location = "header"
+      name     = "DD-API-KEY"
+      secret   = "datadog.api_key"
+    }
+
+    query = {
+      "page[size]"   = "{{ args.page_size }}"
+      "page[offset]" = "{{ args.page_offset }}"
+    }
+
+    headers = {
+      "DD-APPLICATION-KEY" = "{{ secrets.datadog.app_key }}"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Found {{ result.data | length }} incidents."
+  }
+}
+
+command "create_incident" {
+  title       = "Create incident"
+  summary     = "Create a new Datadog incident"
+  description = "Declare a new incident in Datadog with a title and customer impact status."
+  categories  = ["incidents"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["datadog.api_key", "datadog.app_key"]
+  }
+
+  param "title" {
+    type        = "string"
+    required    = true
+    description = "Incident title"
+  }
+
+  param "customer_impacted" {
+    type        = "boolean"
+    required    = true
+    description = "Whether customers are impacted by this incident"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "POST"
+    url      = "https://api.datadoghq.com/api/v2/incidents"
+
+    auth {
+      kind     = "api_key"
+      location = "header"
+      name     = "DD-API-KEY"
+      secret   = "datadog.api_key"
+    }
+
+    headers = {
+      "DD-APPLICATION-KEY" = "{{ secrets.datadog.app_key }}"
+    }
+
+    body {
+      kind = "json"
+      value = {
+        data = {
+          type = "incidents"
+          attributes = {
+            title             = "{{ args.title }}"
+            customer_impacted = "{{ args.customer_impacted }}"
+          }
+        }
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Created incident [{{ result.data.id }}]: {{ result.data.attributes.title }}"
+  }
+}
+
+command "trigger_synthetics" {
+  title       = "Trigger synthetic test"
+  summary     = "Trigger a Datadog synthetic test on demand"
+  description = "Manually trigger a synthetic monitoring test by its public ID."
+  categories  = ["synthetics"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["datadog.api_key", "datadog.app_key"]
+  }
+
+  param "public_id" {
+    type        = "string"
+    required    = true
+    description = "Public ID of the synthetic test to trigger"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "POST"
+    url      = "https://api.datadoghq.com/api/v1/synthetics/tests/trigger"
+
+    auth {
+      kind     = "api_key"
+      location = "header"
+      name     = "DD-API-KEY"
+      secret   = "datadog.api_key"
+    }
+
+    headers = {
+      "DD-APPLICATION-KEY" = "{{ secrets.datadog.app_key }}"
+    }
+
+    body {
+      kind = "json"
+      value = {
+        tests = [{
+          public_id = "{{ args.public_id }}"
+        }]
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Triggered batch {{ result.batch_id }} — {{ result.results | length }} test(s) queued."
+  }
+}

--- a/examples/discord.hcl
+++ b/examples/discord.hcl
@@ -1,0 +1,537 @@
+version = 1
+provider = "discord"
+categories = ["messaging", "community"]
+
+command "send_message" {
+  title       = "Send message"
+  summary     = "Send a message to a channel"
+  description = "Send a text message to a Discord channel."
+  categories  = ["messaging"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["discord.bot_token"]
+  }
+
+  param "channel_id" {
+    type        = "string"
+    required    = true
+    description = "The channel ID to send the message to"
+  }
+
+  param "content" {
+    type        = "string"
+    required    = true
+    description = "Message text content, max 2000 characters"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "POST"
+    url      = "https://discord.com/api/v10/channels/{{ args.channel_id }}/messages"
+
+    auth {
+      kind   = "bearer"
+      secret = "discord.bot_token"
+    }
+
+    body {
+      kind = "json"
+      value = {
+        content = "{{ args.content }}"
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Sent message {{ result.id }} in channel {{ result.channel_id }} by {{ result.author.username }}"
+  }
+}
+
+command "list_messages" {
+  title       = "List messages"
+  summary     = "List recent messages in a channel"
+  description = "Retrieve recent messages from a Discord channel, ordered by most recent first."
+  categories  = ["messaging"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["discord.bot_token"]
+  }
+
+  param "channel_id" {
+    type        = "string"
+    required    = true
+    description = "The channel ID to fetch messages from"
+  }
+
+  param "limit" {
+    type        = "integer"
+    required    = false
+    default     = 50
+    description = "Number of messages to return (1-100)"
+  }
+
+  param "before" {
+    type        = "string"
+    required    = false
+    description = "Get messages before this message ID"
+  }
+
+  param "after" {
+    type        = "string"
+    required    = false
+    description = "Get messages after this message ID"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://discord.com/api/v10/channels/{{ args.channel_id }}/messages"
+
+    auth {
+      kind   = "bearer"
+      secret = "discord.bot_token"
+    }
+
+    query = {
+      limit  = "{{ args.limit }}"
+      before = "{{ args.before }}"
+      after  = "{{ args.after }}"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "{{ result | length }} messages in channel {{ args.channel_id }}"
+  }
+}
+
+command "get_message" {
+  title       = "Get message"
+  summary     = "Get a specific message by ID"
+  description = "Retrieve a single message from a Discord channel by its message ID."
+  categories  = ["messaging"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["discord.bot_token"]
+  }
+
+  param "channel_id" {
+    type        = "string"
+    required    = true
+    description = "The channel ID containing the message"
+  }
+
+  param "message_id" {
+    type        = "string"
+    required    = true
+    description = "The message ID to retrieve"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://discord.com/api/v10/channels/{{ args.channel_id }}/messages/{{ args.message_id }}"
+
+    auth {
+      kind   = "bearer"
+      secret = "discord.bot_token"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Message {{ result.id }} by {{ result.author.username }}: {{ result.content }}"
+  }
+}
+
+command "edit_message" {
+  title       = "Edit message"
+  summary     = "Edit an existing message"
+  description = "Edit a message previously sent by the bot in a Discord channel."
+  categories  = ["messaging"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["discord.bot_token"]
+  }
+
+  param "channel_id" {
+    type        = "string"
+    required    = true
+    description = "The channel ID containing the message"
+  }
+
+  param "message_id" {
+    type        = "string"
+    required    = true
+    description = "The message ID to edit"
+  }
+
+  param "content" {
+    type        = "string"
+    required    = true
+    description = "New message text content, max 2000 characters"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "PATCH"
+    url      = "https://discord.com/api/v10/channels/{{ args.channel_id }}/messages/{{ args.message_id }}"
+
+    auth {
+      kind   = "bearer"
+      secret = "discord.bot_token"
+    }
+
+    body {
+      kind = "json"
+      value = {
+        content = "{{ args.content }}"
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Updated message {{ result.id }}, edited at {{ result.edited_timestamp }}"
+  }
+}
+
+command "delete_message" {
+  title       = "Delete message"
+  summary     = "Delete a message from a channel"
+  description = "Delete a specific message from a Discord channel. Bot must have Manage Messages permission to delete others' messages."
+  categories  = ["messaging"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["discord.bot_token"]
+  }
+
+  param "channel_id" {
+    type        = "string"
+    required    = true
+    description = "The channel ID containing the message"
+  }
+
+  param "message_id" {
+    type        = "string"
+    required    = true
+    description = "The message ID to delete"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "DELETE"
+    url      = "https://discord.com/api/v10/channels/{{ args.channel_id }}/messages/{{ args.message_id }}"
+
+    auth {
+      kind   = "bearer"
+      secret = "discord.bot_token"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Deleted message {{ args.message_id }} from channel {{ args.channel_id }}"
+  }
+}
+
+command "get_channel" {
+  title       = "Get channel"
+  summary     = "Get channel details by ID"
+  description = "Retrieve details about a Discord channel including its name, type, topic, and guild."
+  categories  = ["community"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["discord.bot_token"]
+  }
+
+  param "channel_id" {
+    type        = "string"
+    required    = true
+    description = "The channel ID to look up"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://discord.com/api/v10/channels/{{ args.channel_id }}"
+
+    auth {
+      kind   = "bearer"
+      secret = "discord.bot_token"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Channel: {{ result.name }} ({{ result.id }}) type={{ result.type }} guild={{ result.guild_id }}"
+  }
+}
+
+command "list_guild_channels" {
+  title       = "List guild channels"
+  summary     = "List all channels in a guild"
+  description = "Retrieve all channels in a Discord guild/server. Includes text, voice, category, and other channel types."
+  categories  = ["community"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["discord.bot_token"]
+  }
+
+  param "guild_id" {
+    type        = "string"
+    required    = true
+    description = "The guild/server ID"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://discord.com/api/v10/guilds/{{ args.guild_id }}/channels"
+
+    auth {
+      kind   = "bearer"
+      secret = "discord.bot_token"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "{{ result | length }} channels in guild {{ args.guild_id }}"
+  }
+}
+
+command "create_channel" {
+  title       = "Create channel"
+  summary     = "Create a new channel in a guild"
+  description = "Create a new text, voice, or category channel in a Discord guild. Requires Manage Channels permission."
+  categories  = ["community"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["discord.bot_token"]
+  }
+
+  param "guild_id" {
+    type        = "string"
+    required    = true
+    description = "The guild/server ID"
+  }
+
+  param "name" {
+    type        = "string"
+    required    = true
+    description = "Channel name, 1-100 characters"
+  }
+
+  param "type" {
+    type        = "integer"
+    required    = false
+    default     = 0
+    description = "Channel type (0=text, 2=voice, 4=category, 5=announcement, 13=stage, 15=forum)"
+  }
+
+  param "topic" {
+    type        = "string"
+    required    = false
+    description = "Channel topic, 0-1024 characters"
+  }
+
+  param "parent_id" {
+    type        = "string"
+    required    = false
+    description = "Parent category ID to nest this channel under"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "POST"
+    url      = "https://discord.com/api/v10/guilds/{{ args.guild_id }}/channels"
+
+    auth {
+      kind   = "bearer"
+      secret = "discord.bot_token"
+    }
+
+    body {
+      kind = "json"
+      value = {
+        name      = "{{ args.name }}"
+        type      = "{{ args.type }}"
+        topic     = "{{ args.topic }}"
+        parent_id = "{{ args.parent_id }}"
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Created channel {{ result.name }} ({{ result.id }}) in guild {{ result.guild_id }}"
+  }
+}
+
+command "get_guild" {
+  title       = "Get guild"
+  summary     = "Get guild/server details by ID"
+  description = "Retrieve details about a Discord guild including name, owner, member count, and features."
+  categories  = ["community"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["discord.bot_token"]
+  }
+
+  param "guild_id" {
+    type        = "string"
+    required    = true
+    description = "The guild/server ID"
+  }
+
+  param "with_counts" {
+    type        = "boolean"
+    required    = false
+    default     = true
+    description = "Include approximate member and presence counts"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://discord.com/api/v10/guilds/{{ args.guild_id }}"
+
+    auth {
+      kind   = "bearer"
+      secret = "discord.bot_token"
+    }
+
+    query = {
+      with_counts = "{{ args.with_counts }}"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Guild: {{ result.name }} ({{ result.id }}) owner={{ result.owner_id }} members={{ result.approximate_member_count }}"
+  }
+}
+
+command "list_guilds" {
+  title       = "List guilds"
+  summary     = "List guilds the bot is a member of"
+  description = "Retrieve all guilds/servers the bot has joined."
+  categories  = ["community"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["discord.bot_token"]
+  }
+
+  param "limit" {
+    type        = "integer"
+    required    = false
+    default     = 200
+    description = "Max number of guilds to return (1-200)"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://discord.com/api/v10/users/@me/guilds"
+
+    auth {
+      kind   = "bearer"
+      secret = "discord.bot_token"
+    }
+
+    query = {
+      limit = "{{ args.limit }}"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Bot is in {{ result | length }} guilds"
+  }
+}
+
+command "add_reaction" {
+  title       = "Add reaction"
+  summary     = "Add a reaction emoji to a message"
+  description = "Add a reaction to a message. Use URL-encoded Unicode emoji (e.g. %F0%9F%91%8D for thumbsup) or custom emoji in name:id format."
+  categories  = ["messaging"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["discord.bot_token"]
+  }
+
+  param "channel_id" {
+    type        = "string"
+    required    = true
+    description = "The channel ID containing the message"
+  }
+
+  param "message_id" {
+    type        = "string"
+    required    = true
+    description = "The message ID to react to"
+  }
+
+  param "emoji" {
+    type        = "string"
+    required    = true
+    description = "URL-encoded emoji (e.g. %F0%9F%91%8D) or custom emoji as name:id"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "PUT"
+    url      = "https://discord.com/api/v10/channels/{{ args.channel_id }}/messages/{{ args.message_id }}/reactions/{{ args.emoji }}/@me"
+
+    auth {
+      kind   = "bearer"
+      secret = "discord.bot_token"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Added reaction {{ args.emoji }} to message {{ args.message_id }}"
+  }
+}
+
+command "get_current_user" {
+  title       = "Get current user"
+  summary     = "Get the bot's own user profile"
+  description = "Retrieve the user object for the currently authenticated bot account."
+  categories  = ["community"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["discord.bot_token"]
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://discord.com/api/v10/users/@me"
+
+    auth {
+      kind   = "bearer"
+      secret = "discord.bot_token"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Bot: {{ result.username }}#{{ result.discriminator }} ({{ result.id }}) verified={{ result.verified }}"
+  }
+}

--- a/examples/github.hcl
+++ b/examples/github.hcl
@@ -1,0 +1,1009 @@
+version = 1
+provider = "github"
+categories = ["scm", "issues", "ci-cd"]
+
+command "list_repos" {
+  title       = "List repositories"
+  summary     = "List repositories for the authenticated user"
+  description = "Fetch repositories for the authenticated user, with optional filtering by type and sorting."
+  categories  = ["repos"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["github.token"]
+  }
+
+  param "type" {
+    type        = "string"
+    required    = false
+    default     = "all"
+    description = "Filter by type: all, public, private, forks, sources, member"
+  }
+
+  param "sort" {
+    type        = "string"
+    required    = false
+    default     = "updated"
+    description = "Sort by: created, updated, pushed, full_name"
+  }
+
+  param "per_page" {
+    type        = "integer"
+    required    = false
+    default     = 30
+    description = "Number of results per page (max 100)"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://api.github.com/user/repos"
+
+    auth {
+      kind   = "bearer"
+      secret = "github.token"
+    }
+
+    query = {
+      type     = "{{ args.type }}"
+      sort     = "{{ args.sort }}"
+      per_page = "{{ args.per_page }}"
+    }
+
+    headers = {
+      Accept              = "application/vnd.github+json"
+      X-GitHub-Api-Version = "2022-11-28"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Found {{ result | length }} repositories:\n{% for repo in result %}  - {{ repo.full_name }} ({{ repo.visibility }}, stars: {{ repo.stargazers_count }}){% if repo.description %} — {{ repo.description }}{% endif %}\n{% endfor %}"
+  }
+}
+
+command "get_repo" {
+  title       = "Get repository"
+  summary     = "Get details about a specific repository"
+  description = "Fetch detailed information about a GitHub repository including stars, forks, language, and description."
+  categories  = ["repos"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["github.token"]
+  }
+
+  param "owner" {
+    type        = "string"
+    required    = true
+    description = "Repository owner (user or organization)"
+  }
+
+  param "repo" {
+    type        = "string"
+    required    = true
+    description = "Repository name"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://api.github.com/repos/{{ args.owner }}/{{ args.repo }}"
+
+    auth {
+      kind   = "bearer"
+      secret = "github.token"
+    }
+
+    headers = {
+      Accept              = "application/vnd.github+json"
+      X-GitHub-Api-Version = "2022-11-28"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "{{ result.full_name }} ({{ result.visibility }})\nStars: {{ result.stargazers_count }}  Forks: {{ result.forks_count }}  Watchers: {{ result.watchers_count }}\nLanguage: {{ result.language | default('N/A') }}\nDefault branch: {{ result.default_branch }}\nDescription: {{ result.description | default('None') }}\nURL: {{ result.html_url }}"
+  }
+}
+
+command "create_repo" {
+  title       = "Create repository"
+  summary     = "Create a new repository for the authenticated user"
+  description = "Create a new GitHub repository with optional description, visibility, and initialization settings."
+  categories  = ["repos"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["github.token"]
+  }
+
+  param "name" {
+    type        = "string"
+    required    = true
+    description = "Repository name"
+  }
+
+  param "description" {
+    type        = "string"
+    required    = false
+    default     = ""
+    description = "Repository description"
+  }
+
+  param "private" {
+    type        = "boolean"
+    required    = false
+    default     = false
+    description = "Whether the repository should be private"
+  }
+
+  param "auto_init" {
+    type        = "boolean"
+    required    = false
+    default     = false
+    description = "Initialize with a README"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "POST"
+    url      = "https://api.github.com/user/repos"
+
+    auth {
+      kind   = "bearer"
+      secret = "github.token"
+    }
+
+    headers = {
+      Accept              = "application/vnd.github+json"
+      X-GitHub-Api-Version = "2022-11-28"
+    }
+
+    body {
+      kind = "json"
+      value = {
+        name        = "{{ args.name }}"
+        description = "{{ args.description }}"
+        private     = "{{ args.private }}"
+        auto_init   = "{{ args.auto_init }}"
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Created repository: {{ result.full_name }}\nURL: {{ result.html_url }}\nVisibility: {{ result.visibility }}\nClone: {{ result.clone_url }}"
+  }
+}
+
+command "search_repos" {
+  title       = "Search repositories"
+  summary     = "Search GitHub repositories by query"
+  description = "Search repositories using GitHub's search API. Supports qualifiers like language:rust, stars:>100, topic:cli."
+  categories  = ["search", "repos"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["github.token"]
+  }
+
+  param "query" {
+    type        = "string"
+    required    = true
+    description = "Search query (e.g. 'language:rust stars:>100 topic:cli')"
+  }
+
+  param "sort" {
+    type        = "string"
+    required    = false
+    default     = "stars"
+    description = "Sort by: stars, forks, help-wanted-issues, updated"
+  }
+
+  param "per_page" {
+    type        = "integer"
+    required    = false
+    default     = 20
+    description = "Number of results per page (max 100)"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://api.github.com/search/repositories"
+
+    auth {
+      kind   = "bearer"
+      secret = "github.token"
+    }
+
+    query = {
+      q        = "{{ args.query }}"
+      sort     = "{{ args.sort }}"
+      order    = "desc"
+      per_page = "{{ args.per_page }}"
+    }
+
+    headers = {
+      Accept              = "application/vnd.github+json"
+      X-GitHub-Api-Version = "2022-11-28"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Found {{ result.total_count }} repositories:\n{% for repo in result.items[:10] %}  - {{ repo.full_name }} (stars: {{ repo.stargazers_count }}) — {{ repo.description | default('No description') | truncate(80) }}\n{% endfor %}"
+  }
+}
+
+command "list_issues" {
+  title       = "List issues"
+  summary     = "List issues in a repository"
+  description = "Fetch issues for a repository with optional filtering by state, labels, and assignee."
+  categories  = ["issues"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["github.token"]
+  }
+
+  param "owner" {
+    type        = "string"
+    required    = true
+    description = "Repository owner"
+  }
+
+  param "repo" {
+    type        = "string"
+    required    = true
+    description = "Repository name"
+  }
+
+  param "state" {
+    type        = "string"
+    required    = false
+    default     = "open"
+    description = "Filter by state: open, closed, all"
+  }
+
+  param "labels" {
+    type        = "string"
+    required    = false
+    default     = ""
+    description = "Comma-separated list of label names"
+  }
+
+  param "sort" {
+    type        = "string"
+    required    = false
+    default     = "created"
+    description = "Sort by: created, updated, comments"
+  }
+
+  param "per_page" {
+    type        = "integer"
+    required    = false
+    default     = 30
+    description = "Number of results per page (max 100)"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://api.github.com/repos/{{ args.owner }}/{{ args.repo }}/issues"
+
+    auth {
+      kind   = "bearer"
+      secret = "github.token"
+    }
+
+    query = {
+      state    = "{{ args.state }}"
+      labels   = "{{ args.labels }}"
+      sort     = "{{ args.sort }}"
+      per_page = "{{ args.per_page }}"
+    }
+
+    headers = {
+      Accept              = "application/vnd.github+json"
+      X-GitHub-Api-Version = "2022-11-28"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Found {{ result | length }} issues in {{ args.owner }}/{{ args.repo }}:\n{% for issue in result %}{% if not issue.pull_request %}  #{{ issue.number }} [{{ issue.state }}] {{ issue.title }}{% if issue.assignee %} (assigned: {{ issue.assignee.login }}){% endif %}\n{% endif %}{% endfor %}"
+  }
+}
+
+command "get_issue" {
+  title       = "Get issue"
+  summary     = "Get details about a specific issue"
+  description = "Fetch detailed information about a single issue including labels, assignees, and body."
+  categories  = ["issues"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["github.token"]
+  }
+
+  param "owner" {
+    type        = "string"
+    required    = true
+    description = "Repository owner"
+  }
+
+  param "repo" {
+    type        = "string"
+    required    = true
+    description = "Repository name"
+  }
+
+  param "issue_number" {
+    type        = "integer"
+    required    = true
+    description = "Issue number"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://api.github.com/repos/{{ args.owner }}/{{ args.repo }}/issues/{{ args.issue_number }}"
+
+    auth {
+      kind   = "bearer"
+      secret = "github.token"
+    }
+
+    headers = {
+      Accept              = "application/vnd.github+json"
+      X-GitHub-Api-Version = "2022-11-28"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "#{{ result.number }} [{{ result.state }}] {{ result.title }}\nAuthor: {{ result.user.login }}  Created: {{ result.created_at }}\nLabels: {{ result.labels | map(attribute='name') | join(', ') | default('none') }}\nAssignees: {{ result.assignees | map(attribute='login') | join(', ') | default('unassigned') }}\n\n{{ result.body | default('No description.') }}"
+  }
+}
+
+command "create_issue" {
+  title       = "Create issue"
+  summary     = "Create a new issue in a repository"
+  description = "Create a GitHub issue with a title and optional body, labels, and assignees."
+  categories  = ["issues"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["github.token"]
+  }
+
+  param "owner" {
+    type        = "string"
+    required    = true
+    description = "Repository owner"
+  }
+
+  param "repo" {
+    type        = "string"
+    required    = true
+    description = "Repository name"
+  }
+
+  param "title" {
+    type        = "string"
+    required    = true
+    description = "Issue title"
+  }
+
+  param "body" {
+    type        = "string"
+    required    = false
+    default     = ""
+    description = "Issue body (Markdown)"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "POST"
+    url      = "https://api.github.com/repos/{{ args.owner }}/{{ args.repo }}/issues"
+
+    auth {
+      kind   = "bearer"
+      secret = "github.token"
+    }
+
+    headers = {
+      Accept              = "application/vnd.github+json"
+      X-GitHub-Api-Version = "2022-11-28"
+    }
+
+    body {
+      kind = "json"
+      value = {
+        title = "{{ args.title }}"
+        body  = "{{ args.body }}"
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Created issue #{{ result.number }}: {{ result.title }}\nURL: {{ result.html_url }}"
+  }
+}
+
+command "update_issue" {
+  title       = "Update issue"
+  summary     = "Update an existing issue"
+  description = "Update the title, body, or state of an existing issue."
+  categories  = ["issues"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["github.token"]
+  }
+
+  param "owner" {
+    type        = "string"
+    required    = true
+    description = "Repository owner"
+  }
+
+  param "repo" {
+    type        = "string"
+    required    = true
+    description = "Repository name"
+  }
+
+  param "issue_number" {
+    type        = "integer"
+    required    = true
+    description = "Issue number"
+  }
+
+  param "state" {
+    type        = "string"
+    required    = false
+    default     = ""
+    description = "New state: open or closed"
+  }
+
+  param "title" {
+    type        = "string"
+    required    = false
+    default     = ""
+    description = "New title"
+  }
+
+  param "body" {
+    type        = "string"
+    required    = false
+    default     = ""
+    description = "New body (Markdown)"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "PATCH"
+    url      = "https://api.github.com/repos/{{ args.owner }}/{{ args.repo }}/issues/{{ args.issue_number }}"
+
+    auth {
+      kind   = "bearer"
+      secret = "github.token"
+    }
+
+    headers = {
+      Accept              = "application/vnd.github+json"
+      X-GitHub-Api-Version = "2022-11-28"
+    }
+
+    body {
+      kind = "json"
+      value = {
+        state = "{{ args.state }}"
+        title = "{{ args.title }}"
+        body  = "{{ args.body }}"
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Updated issue #{{ result.number }}: {{ result.title }} [{{ result.state }}]\nURL: {{ result.html_url }}"
+  }
+}
+
+command "create_comment" {
+  title       = "Create comment"
+  summary     = "Add a comment to an issue or pull request"
+  description = "Post a new comment on an issue or pull request. Pull requests are issues in GitHub's data model, so this works for both."
+  categories  = ["issues"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["github.token"]
+  }
+
+  param "owner" {
+    type        = "string"
+    required    = true
+    description = "Repository owner"
+  }
+
+  param "repo" {
+    type        = "string"
+    required    = true
+    description = "Repository name"
+  }
+
+  param "issue_number" {
+    type        = "integer"
+    required    = true
+    description = "Issue or pull request number"
+  }
+
+  param "body" {
+    type        = "string"
+    required    = true
+    description = "Comment body (Markdown)"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "POST"
+    url      = "https://api.github.com/repos/{{ args.owner }}/{{ args.repo }}/issues/{{ args.issue_number }}/comments"
+
+    auth {
+      kind   = "bearer"
+      secret = "github.token"
+    }
+
+    headers = {
+      Accept              = "application/vnd.github+json"
+      X-GitHub-Api-Version = "2022-11-28"
+    }
+
+    body {
+      kind = "json"
+      value = {
+        body = "{{ args.body }}"
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Comment added to #{{ args.issue_number }} by {{ result.user.login }}\nURL: {{ result.html_url }}"
+  }
+}
+
+command "search_issues" {
+  title       = "Search issues"
+  summary     = "Search GitHub issues and pull requests by query"
+  description = "Search issues and pull requests across repositories using GitHub's search API. Supports qualifiers like repo:owner/name, is:issue, state:open, label:bug."
+  categories  = ["search", "issues"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["github.token"]
+  }
+
+  param "query" {
+    type        = "string"
+    required    = true
+    description = "Search query (e.g. 'repo:owner/repo is:open label:bug')"
+  }
+
+  param "sort" {
+    type        = "string"
+    required    = false
+    default     = "created"
+    description = "Sort by: comments, reactions, interactions, created, updated"
+  }
+
+  param "per_page" {
+    type        = "integer"
+    required    = false
+    default     = 20
+    description = "Number of results per page (max 100)"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://api.github.com/search/issues"
+
+    auth {
+      kind   = "bearer"
+      secret = "github.token"
+    }
+
+    query = {
+      q        = "{{ args.query }}"
+      sort     = "{{ args.sort }}"
+      order    = "desc"
+      per_page = "{{ args.per_page }}"
+    }
+
+    headers = {
+      Accept              = "application/vnd.github+json"
+      X-GitHub-Api-Version = "2022-11-28"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Found {{ result.total_count }} results:\n{% for item in result.items[:10] %}  #{{ item.number }} [{{ item.state }}] {{ item.title }}\n{% endfor %}"
+  }
+}
+
+command "list_pulls" {
+  title       = "List pull requests"
+  summary     = "List pull requests in a repository"
+  description = "Fetch pull requests for a repository with optional filtering by state, head branch, and base branch."
+  categories  = ["pull-requests"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["github.token"]
+  }
+
+  param "owner" {
+    type        = "string"
+    required    = true
+    description = "Repository owner"
+  }
+
+  param "repo" {
+    type        = "string"
+    required    = true
+    description = "Repository name"
+  }
+
+  param "state" {
+    type        = "string"
+    required    = false
+    default     = "open"
+    description = "Filter by state: open, closed, all"
+  }
+
+  param "sort" {
+    type        = "string"
+    required    = false
+    default     = "created"
+    description = "Sort by: created, updated, popularity, long-running"
+  }
+
+  param "per_page" {
+    type        = "integer"
+    required    = false
+    default     = 30
+    description = "Number of results per page (max 100)"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://api.github.com/repos/{{ args.owner }}/{{ args.repo }}/pulls"
+
+    auth {
+      kind   = "bearer"
+      secret = "github.token"
+    }
+
+    query = {
+      state    = "{{ args.state }}"
+      sort     = "{{ args.sort }}"
+      per_page = "{{ args.per_page }}"
+    }
+
+    headers = {
+      Accept              = "application/vnd.github+json"
+      X-GitHub-Api-Version = "2022-11-28"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Found {{ result | length }} pull requests:\n{% for pr in result %}  #{{ pr.number }} [{{ pr.state }}{% if pr.draft %}/draft{% endif %}] {{ pr.title }} ({{ pr.head.label }} -> {{ pr.base.label }})\n{% endfor %}"
+  }
+}
+
+command "create_pull" {
+  title       = "Create pull request"
+  summary     = "Create a new pull request"
+  description = "Create a pull request to merge changes from a head branch into a base branch."
+  categories  = ["pull-requests"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["github.token"]
+  }
+
+  param "owner" {
+    type        = "string"
+    required    = true
+    description = "Repository owner"
+  }
+
+  param "repo" {
+    type        = "string"
+    required    = true
+    description = "Repository name"
+  }
+
+  param "title" {
+    type        = "string"
+    required    = true
+    description = "Pull request title"
+  }
+
+  param "head" {
+    type        = "string"
+    required    = true
+    description = "Source branch name"
+  }
+
+  param "base" {
+    type        = "string"
+    required    = true
+    description = "Target branch name"
+  }
+
+  param "body" {
+    type        = "string"
+    required    = false
+    default     = ""
+    description = "Pull request body (Markdown)"
+  }
+
+  param "draft" {
+    type        = "boolean"
+    required    = false
+    default     = false
+    description = "Create as a draft pull request"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "POST"
+    url      = "https://api.github.com/repos/{{ args.owner }}/{{ args.repo }}/pulls"
+
+    auth {
+      kind   = "bearer"
+      secret = "github.token"
+    }
+
+    headers = {
+      Accept              = "application/vnd.github+json"
+      X-GitHub-Api-Version = "2022-11-28"
+    }
+
+    body {
+      kind = "json"
+      value = {
+        title = "{{ args.title }}"
+        head  = "{{ args.head }}"
+        base  = "{{ args.base }}"
+        body  = "{{ args.body }}"
+        draft = "{{ args.draft }}"
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Created PR #{{ result.number }}: {{ result.title }}\n{{ result.head.label }} -> {{ result.base.label }}\nURL: {{ result.html_url }}"
+  }
+}
+
+command "merge_pull" {
+  title       = "Merge pull request"
+  summary     = "Merge a pull request"
+  description = "Merge a pull request using the specified merge method (merge, squash, or rebase)."
+  categories  = ["pull-requests"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["github.token"]
+  }
+
+  param "owner" {
+    type        = "string"
+    required    = true
+    description = "Repository owner"
+  }
+
+  param "repo" {
+    type        = "string"
+    required    = true
+    description = "Repository name"
+  }
+
+  param "pull_number" {
+    type        = "integer"
+    required    = true
+    description = "Pull request number"
+  }
+
+  param "merge_method" {
+    type        = "string"
+    required    = false
+    default     = "merge"
+    description = "Merge method: merge, squash, rebase"
+  }
+
+  param "commit_title" {
+    type        = "string"
+    required    = false
+    default     = ""
+    description = "Custom commit title for squash or merge commits"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "PUT"
+    url      = "https://api.github.com/repos/{{ args.owner }}/{{ args.repo }}/pulls/{{ args.pull_number }}/merge"
+
+    auth {
+      kind   = "bearer"
+      secret = "github.token"
+    }
+
+    headers = {
+      Accept              = "application/vnd.github+json"
+      X-GitHub-Api-Version = "2022-11-28"
+    }
+
+    body {
+      kind = "json"
+      value = {
+        merge_method = "{{ args.merge_method }}"
+        commit_title = "{{ args.commit_title }}"
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Merged PR #{{ args.pull_number }}: {{ result.message }}\nSHA: {{ result.sha }}"
+  }
+}
+
+command "list_workflow_runs" {
+  title       = "List workflow runs"
+  summary     = "List GitHub Actions workflow runs for a repository"
+  description = "Fetch recent workflow runs with optional filtering by branch, event type, and status."
+  categories  = ["ci-cd"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["github.token"]
+  }
+
+  param "owner" {
+    type        = "string"
+    required    = true
+    description = "Repository owner"
+  }
+
+  param "repo" {
+    type        = "string"
+    required    = true
+    description = "Repository name"
+  }
+
+  param "branch" {
+    type        = "string"
+    required    = false
+    default     = ""
+    description = "Filter by branch name"
+  }
+
+  param "status" {
+    type        = "string"
+    required    = false
+    default     = ""
+    description = "Filter by status: completed, success, failure, cancelled, in_progress, queued"
+  }
+
+  param "per_page" {
+    type        = "integer"
+    required    = false
+    default     = 20
+    description = "Number of results per page (max 100)"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://api.github.com/repos/{{ args.owner }}/{{ args.repo }}/actions/runs"
+
+    auth {
+      kind   = "bearer"
+      secret = "github.token"
+    }
+
+    query = {
+      branch   = "{{ args.branch }}"
+      status   = "{{ args.status }}"
+      per_page = "{{ args.per_page }}"
+    }
+
+    headers = {
+      Accept              = "application/vnd.github+json"
+      X-GitHub-Api-Version = "2022-11-28"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Workflow runs for {{ args.owner }}/{{ args.repo }}:\n{% for run in result.workflow_runs[:10] %}  #{{ run.id }} {{ run.name }} [{{ run.conclusion | default(run.status) }}] on {{ run.head_branch }} ({{ run.created_at }})\n{% endfor %}"
+  }
+}
+
+command "trigger_workflow" {
+  title       = "Trigger workflow"
+  summary     = "Manually trigger a GitHub Actions workflow"
+  description = "Dispatch a workflow_dispatch event to trigger a GitHub Actions workflow on the specified branch or tag."
+  categories  = ["ci-cd"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["github.token"]
+  }
+
+  param "owner" {
+    type        = "string"
+    required    = true
+    description = "Repository owner"
+  }
+
+  param "repo" {
+    type        = "string"
+    required    = true
+    description = "Repository name"
+  }
+
+  param "workflow_id" {
+    type        = "string"
+    required    = true
+    description = "Workflow filename (e.g. 'ci.yml') or numeric ID"
+  }
+
+  param "ref" {
+    type        = "string"
+    required    = true
+    description = "Branch or tag to run the workflow on"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "POST"
+    url      = "https://api.github.com/repos/{{ args.owner }}/{{ args.repo }}/actions/workflows/{{ args.workflow_id }}/dispatches"
+
+    auth {
+      kind   = "bearer"
+      secret = "github.token"
+    }
+
+    headers = {
+      Accept              = "application/vnd.github+json"
+      X-GitHub-Api-Version = "2022-11-28"
+    }
+
+    body {
+      kind = "json"
+      value = {
+        ref = "{{ args.ref }}"
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Triggered workflow {{ args.workflow_id }} on {{ args.ref }} for {{ args.owner }}/{{ args.repo }}.\nNote: GitHub returns 204 No Content on success. Check workflow runs to monitor status."
+  }
+}

--- a/examples/gitlab.hcl
+++ b/examples/gitlab.hcl
@@ -1,0 +1,927 @@
+version = 1
+provider = "gitlab"
+categories = ["devops", "version-control", "ci-cd"]
+
+command "get_current_user" {
+  title       = "Get current user"
+  summary     = "Get the currently authenticated GitLab user"
+  description = "Retrieve profile information for the user associated with the provided token."
+  categories  = ["users"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["gitlab.token"]
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://gitlab.com/api/v4/user"
+
+    auth {
+      kind     = "api_key"
+      location = "header"
+      name     = "PRIVATE-TOKEN"
+      secret   = "gitlab.token"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "{{ result.username }} ({{ result.name }}) — ID: {{ result.id }}, email: {{ result.email }}, state: {{ result.state }}"
+  }
+}
+
+command "list_projects" {
+  title       = "List projects"
+  summary     = "List GitLab projects visible to the authenticated user"
+  description = "Search and list projects. Filter by ownership, visibility, or search term."
+  categories  = ["projects"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["gitlab.token"]
+  }
+
+  param "search" {
+    type        = "string"
+    required    = false
+    description = "Search by name, path, or description"
+  }
+
+  param "owned" {
+    type        = "boolean"
+    required    = false
+    default     = false
+    description = "Only return projects owned by the current user"
+  }
+
+  param "visibility" {
+    type        = "string"
+    required    = false
+    description = "Filter by visibility: public, internal, or private"
+  }
+
+  param "per_page" {
+    type        = "integer"
+    required    = false
+    default     = 20
+    description = "Number of results per page (max 100)"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://gitlab.com/api/v4/projects"
+
+    auth {
+      kind     = "api_key"
+      location = "header"
+      name     = "PRIVATE-TOKEN"
+      secret   = "gitlab.token"
+    }
+
+    query = {
+      search     = "{{ args.search }}"
+      owned      = "{{ args.owned }}"
+      visibility = "{{ args.visibility }}"
+      per_page   = "{{ args.per_page }}"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Found {{ result | length }} projects."
+  }
+}
+
+command "get_project" {
+  title       = "Get project"
+  summary     = "Get details of a specific GitLab project"
+  description = "Retrieve detailed information about a project by its numeric ID or URL-encoded path (e.g. my-group%2Fmy-project)."
+  categories  = ["projects"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["gitlab.token"]
+  }
+
+  param "project_id" {
+    type        = "string"
+    required    = true
+    description = "Project ID (integer) or URL-encoded namespace/path"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://gitlab.com/api/v4/projects/{{ args.project_id }}"
+
+    auth {
+      kind     = "api_key"
+      location = "header"
+      name     = "PRIVATE-TOKEN"
+      secret   = "gitlab.token"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "{{ result.path_with_namespace }} (ID: {{ result.id }}) [{{ result.visibility }}] — default branch: {{ result.default_branch }}, stars: {{ result.star_count }}, forks: {{ result.forks_count }} — {{ result.web_url }}"
+  }
+}
+
+command "create_project" {
+  title       = "Create project"
+  summary     = "Create a new GitLab project"
+  description = "Create a new project. Optionally specify visibility, namespace, and whether to initialize with a README."
+  categories  = ["projects"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["gitlab.token"]
+  }
+
+  param "name" {
+    type        = "string"
+    required    = true
+    description = "Project name"
+  }
+
+  param "description" {
+    type        = "string"
+    required    = false
+    description = "Project description"
+  }
+
+  param "visibility" {
+    type        = "string"
+    required    = false
+    default     = "private"
+    description = "Visibility level: private, internal, or public"
+  }
+
+  param "namespace_id" {
+    type        = "integer"
+    required    = false
+    description = "Group or namespace ID to create the project in"
+  }
+
+  param "initialize_with_readme" {
+    type        = "boolean"
+    required    = false
+    default     = false
+    description = "Initialize the repository with a README"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "POST"
+    url      = "https://gitlab.com/api/v4/projects"
+
+    auth {
+      kind     = "api_key"
+      location = "header"
+      name     = "PRIVATE-TOKEN"
+      secret   = "gitlab.token"
+    }
+
+    body {
+      kind = "json"
+      value = {
+        name                     = "{{ args.name }}"
+        description              = "{{ args.description }}"
+        visibility               = "{{ args.visibility }}"
+        namespace_id             = "{{ args.namespace_id }}"
+        initialize_with_readme   = "{{ args.initialize_with_readme }}"
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Created project {{ result.path_with_namespace }} (ID: {{ result.id }}) [{{ result.visibility }}] — {{ result.web_url }}"
+  }
+}
+
+command "list_issues" {
+  title       = "List issues"
+  summary     = "List issues for a GitLab project"
+  description = "List issues in a project with optional filters for state, labels, assignee, and milestone."
+  categories  = ["issues"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["gitlab.token"]
+  }
+
+  param "project_id" {
+    type        = "string"
+    required    = true
+    description = "Project ID or URL-encoded path"
+  }
+
+  param "state" {
+    type        = "string"
+    required    = false
+    default     = "opened"
+    description = "Filter by state: opened, closed, or all"
+  }
+
+  param "labels" {
+    type        = "string"
+    required    = false
+    description = "Comma-separated label names to filter by"
+  }
+
+  param "search" {
+    type        = "string"
+    required    = false
+    description = "Search in title and description"
+  }
+
+  param "per_page" {
+    type        = "integer"
+    required    = false
+    default     = 20
+    description = "Number of results per page (max 100)"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://gitlab.com/api/v4/projects/{{ args.project_id }}/issues"
+
+    auth {
+      kind     = "api_key"
+      location = "header"
+      name     = "PRIVATE-TOKEN"
+      secret   = "gitlab.token"
+    }
+
+    query = {
+      state    = "{{ args.state }}"
+      labels   = "{{ args.labels }}"
+      search   = "{{ args.search }}"
+      per_page = "{{ args.per_page }}"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Found {{ result | length }} issues."
+  }
+}
+
+command "get_issue" {
+  title       = "Get issue"
+  summary     = "Get details of a specific issue"
+  description = "Retrieve detailed information about a single issue by its project-scoped IID."
+  categories  = ["issues"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["gitlab.token"]
+  }
+
+  param "project_id" {
+    type        = "string"
+    required    = true
+    description = "Project ID or URL-encoded path"
+  }
+
+  param "issue_iid" {
+    type        = "integer"
+    required    = true
+    description = "Project-scoped issue IID"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://gitlab.com/api/v4/projects/{{ args.project_id }}/issues/{{ args.issue_iid }}"
+
+    auth {
+      kind     = "api_key"
+      location = "header"
+      name     = "PRIVATE-TOKEN"
+      secret   = "gitlab.token"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Issue #{{ result.iid }}: {{ result.title }} [{{ result.state }}] — author: {{ result.author.username }}, labels: {{ result.labels | join(\", \") }}, {{ result.web_url }}"
+  }
+}
+
+command "create_issue" {
+  title       = "Create issue"
+  summary     = "Create a new issue in a GitLab project"
+  description = "Create a new issue with a title and optional description, labels, and assignees."
+  categories  = ["issues"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["gitlab.token"]
+  }
+
+  param "project_id" {
+    type        = "string"
+    required    = true
+    description = "Project ID or URL-encoded path"
+  }
+
+  param "title" {
+    type        = "string"
+    required    = true
+    description = "Issue title"
+  }
+
+  param "description" {
+    type        = "string"
+    required    = false
+    description = "Issue description (supports Markdown)"
+  }
+
+  param "labels" {
+    type        = "string"
+    required    = false
+    description = "Comma-separated label names"
+  }
+
+  param "assignee_ids" {
+    type        = "string"
+    required    = false
+    description = "Comma-separated user IDs to assign"
+  }
+
+  param "confidential" {
+    type        = "boolean"
+    required    = false
+    default     = false
+    description = "Mark as confidential"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "POST"
+    url      = "https://gitlab.com/api/v4/projects/{{ args.project_id }}/issues"
+
+    auth {
+      kind     = "api_key"
+      location = "header"
+      name     = "PRIVATE-TOKEN"
+      secret   = "gitlab.token"
+    }
+
+    body {
+      kind = "json"
+      value = {
+        title         = "{{ args.title }}"
+        description   = "{{ args.description }}"
+        labels        = "{{ args.labels }}"
+        assignee_ids  = "{{ args.assignee_ids }}"
+        confidential  = "{{ args.confidential }}"
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Created issue #{{ result.iid }}: {{ result.title }} — {{ result.web_url }}"
+  }
+}
+
+command "update_issue" {
+  title       = "Update issue"
+  summary     = "Update an existing issue"
+  description = "Update an issue's title, description, state, labels, or assignees."
+  categories  = ["issues"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["gitlab.token"]
+  }
+
+  param "project_id" {
+    type        = "string"
+    required    = true
+    description = "Project ID or URL-encoded path"
+  }
+
+  param "issue_iid" {
+    type        = "integer"
+    required    = true
+    description = "Project-scoped issue IID"
+  }
+
+  param "title" {
+    type        = "string"
+    required    = false
+    description = "New issue title"
+  }
+
+  param "description" {
+    type        = "string"
+    required    = false
+    description = "New issue description"
+  }
+
+  param "state_event" {
+    type        = "string"
+    required    = false
+    description = "Change state: close or reopen"
+  }
+
+  param "labels" {
+    type        = "string"
+    required    = false
+    description = "Replace all labels (comma-separated names)"
+  }
+
+  param "add_labels" {
+    type        = "string"
+    required    = false
+    description = "Labels to add (comma-separated)"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "PUT"
+    url      = "https://gitlab.com/api/v4/projects/{{ args.project_id }}/issues/{{ args.issue_iid }}"
+
+    auth {
+      kind     = "api_key"
+      location = "header"
+      name     = "PRIVATE-TOKEN"
+      secret   = "gitlab.token"
+    }
+
+    body {
+      kind = "json"
+      value = {
+        title       = "{{ args.title }}"
+        description = "{{ args.description }}"
+        state_event = "{{ args.state_event }}"
+        labels      = "{{ args.labels }}"
+        add_labels  = "{{ args.add_labels }}"
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Updated issue #{{ result.iid }}: {{ result.title }} [{{ result.state }}] — {{ result.web_url }}"
+  }
+}
+
+command "list_merge_requests" {
+  title       = "List merge requests"
+  summary     = "List merge requests for a GitLab project"
+  description = "List merge requests with optional filters for state, scope, labels, and search."
+  categories  = ["merge-requests"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["gitlab.token"]
+  }
+
+  param "project_id" {
+    type        = "string"
+    required    = true
+    description = "Project ID or URL-encoded path"
+  }
+
+  param "state" {
+    type        = "string"
+    required    = false
+    default     = "opened"
+    description = "Filter by state: opened, closed, merged, locked, or all"
+  }
+
+  param "scope" {
+    type        = "string"
+    required    = false
+    description = "Filter by scope: created_by_me, assigned_to_me, or all"
+  }
+
+  param "labels" {
+    type        = "string"
+    required    = false
+    description = "Comma-separated label names to filter by"
+  }
+
+  param "per_page" {
+    type        = "integer"
+    required    = false
+    default     = 20
+    description = "Number of results per page (max 100)"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://gitlab.com/api/v4/projects/{{ args.project_id }}/merge_requests"
+
+    auth {
+      kind     = "api_key"
+      location = "header"
+      name     = "PRIVATE-TOKEN"
+      secret   = "gitlab.token"
+    }
+
+    query = {
+      state    = "{{ args.state }}"
+      scope    = "{{ args.scope }}"
+      labels   = "{{ args.labels }}"
+      per_page = "{{ args.per_page }}"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Found {{ result | length }} merge requests."
+  }
+}
+
+command "get_merge_request" {
+  title       = "Get merge request"
+  summary     = "Get details of a specific merge request"
+  description = "Retrieve detailed information about a merge request including its status, branches, and pipeline state."
+  categories  = ["merge-requests"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["gitlab.token"]
+  }
+
+  param "project_id" {
+    type        = "string"
+    required    = true
+    description = "Project ID or URL-encoded path"
+  }
+
+  param "merge_request_iid" {
+    type        = "integer"
+    required    = true
+    description = "Project-scoped merge request IID"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://gitlab.com/api/v4/projects/{{ args.project_id }}/merge_requests/{{ args.merge_request_iid }}"
+
+    auth {
+      kind     = "api_key"
+      location = "header"
+      name     = "PRIVATE-TOKEN"
+      secret   = "gitlab.token"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "MR !{{ result.iid }}: {{ result.title }} [{{ result.state }}] — {{ result.source_branch }} -> {{ result.target_branch }}, author: {{ result.author.username }}, conflicts: {{ result.has_conflicts }}, {{ result.web_url }}"
+  }
+}
+
+command "create_merge_request" {
+  title       = "Create merge request"
+  summary     = "Create a new merge request"
+  description = "Create a merge request from a source branch to a target branch with optional reviewers and labels."
+  categories  = ["merge-requests"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["gitlab.token"]
+  }
+
+  param "project_id" {
+    type        = "string"
+    required    = true
+    description = "Project ID or URL-encoded path"
+  }
+
+  param "source_branch" {
+    type        = "string"
+    required    = true
+    description = "Source branch name"
+  }
+
+  param "target_branch" {
+    type        = "string"
+    required    = true
+    description = "Target branch name"
+  }
+
+  param "title" {
+    type        = "string"
+    required    = true
+    description = "Merge request title"
+  }
+
+  param "description" {
+    type        = "string"
+    required    = false
+    description = "Merge request description (supports Markdown)"
+  }
+
+  param "draft" {
+    type        = "boolean"
+    required    = false
+    default     = false
+    description = "Mark as draft"
+  }
+
+  param "squash" {
+    type        = "boolean"
+    required    = false
+    default     = false
+    description = "Squash commits when merging"
+  }
+
+  param "remove_source_branch" {
+    type        = "boolean"
+    required    = false
+    default     = false
+    description = "Delete source branch after merge"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "POST"
+    url      = "https://gitlab.com/api/v4/projects/{{ args.project_id }}/merge_requests"
+
+    auth {
+      kind     = "api_key"
+      location = "header"
+      name     = "PRIVATE-TOKEN"
+      secret   = "gitlab.token"
+    }
+
+    body {
+      kind = "json"
+      value = {
+        source_branch        = "{{ args.source_branch }}"
+        target_branch        = "{{ args.target_branch }}"
+        title                = "{{ args.title }}"
+        description          = "{{ args.description }}"
+        draft                = "{{ args.draft }}"
+        squash               = "{{ args.squash }}"
+        remove_source_branch = "{{ args.remove_source_branch }}"
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Created MR !{{ result.iid }}: {{ result.title }} ({{ result.source_branch }} -> {{ result.target_branch }}) — {{ result.web_url }}"
+  }
+}
+
+command "merge_merge_request" {
+  title       = "Merge a merge request"
+  summary     = "Merge an open merge request"
+  description = "Accept and merge a merge request. Optionally squash commits, delete the source branch, or set auto-merge when the pipeline succeeds."
+  categories  = ["merge-requests"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["gitlab.token"]
+  }
+
+  param "project_id" {
+    type        = "string"
+    required    = true
+    description = "Project ID or URL-encoded path"
+  }
+
+  param "merge_request_iid" {
+    type        = "integer"
+    required    = true
+    description = "Project-scoped merge request IID"
+  }
+
+  param "squash" {
+    type        = "boolean"
+    required    = false
+    default     = false
+    description = "Squash commits on merge"
+  }
+
+  param "should_remove_source_branch" {
+    type        = "boolean"
+    required    = false
+    default     = false
+    description = "Delete source branch after merge"
+  }
+
+  param "merge_when_pipeline_succeeds" {
+    type        = "boolean"
+    required    = false
+    default     = false
+    description = "Auto-merge when the pipeline passes"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "PUT"
+    url      = "https://gitlab.com/api/v4/projects/{{ args.project_id }}/merge_requests/{{ args.merge_request_iid }}/merge"
+
+    auth {
+      kind     = "api_key"
+      location = "header"
+      name     = "PRIVATE-TOKEN"
+      secret   = "gitlab.token"
+    }
+
+    body {
+      kind = "json"
+      value = {
+        squash                       = "{{ args.squash }}"
+        should_remove_source_branch  = "{{ args.should_remove_source_branch }}"
+        merge_when_pipeline_succeeds = "{{ args.merge_when_pipeline_succeeds }}"
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Merged !{{ result.iid }}: {{ result.title }} ({{ result.source_branch }} -> {{ result.target_branch }}) — merge commit: {{ result.merge_commit_sha }}"
+  }
+}
+
+command "list_pipelines" {
+  title       = "List pipelines"
+  summary     = "List CI/CD pipelines for a project"
+  description = "List pipelines with optional filters for status, ref, and scope."
+  categories  = ["ci-cd"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["gitlab.token"]
+  }
+
+  param "project_id" {
+    type        = "string"
+    required    = true
+    description = "Project ID or URL-encoded path"
+  }
+
+  param "status" {
+    type        = "string"
+    required    = false
+    description = "Filter by status: running, pending, success, failed, canceled, skipped, or manual"
+  }
+
+  param "ref" {
+    type        = "string"
+    required    = false
+    description = "Filter by branch or tag name"
+  }
+
+  param "per_page" {
+    type        = "integer"
+    required    = false
+    default     = 20
+    description = "Number of results per page (max 100)"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://gitlab.com/api/v4/projects/{{ args.project_id }}/pipelines"
+
+    auth {
+      kind     = "api_key"
+      location = "header"
+      name     = "PRIVATE-TOKEN"
+      secret   = "gitlab.token"
+    }
+
+    query = {
+      status   = "{{ args.status }}"
+      ref      = "{{ args.ref }}"
+      per_page = "{{ args.per_page }}"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Found {{ result | length }} pipelines."
+  }
+}
+
+command "create_pipeline" {
+  title       = "Create pipeline"
+  summary     = "Trigger a new CI/CD pipeline"
+  description = "Create and trigger a new pipeline on a given branch or tag."
+  categories  = ["ci-cd"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["gitlab.token"]
+  }
+
+  param "project_id" {
+    type        = "string"
+    required    = true
+    description = "Project ID or URL-encoded path"
+  }
+
+  param "ref" {
+    type        = "string"
+    required    = true
+    description = "Branch or tag to run the pipeline on"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "POST"
+    url      = "https://gitlab.com/api/v4/projects/{{ args.project_id }}/pipeline"
+
+    auth {
+      kind     = "api_key"
+      location = "header"
+      name     = "PRIVATE-TOKEN"
+      secret   = "gitlab.token"
+    }
+
+    body {
+      kind = "json"
+      value = {
+        ref = "{{ args.ref }}"
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Created pipeline #{{ result.id }} [{{ result.status }}] on ref {{ result.ref }} — {{ result.web_url }}"
+  }
+}
+
+command "list_groups" {
+  title       = "List groups"
+  summary     = "List GitLab groups visible to the authenticated user"
+  description = "List groups with optional filters for search, ownership, and visibility."
+  categories  = ["groups"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["gitlab.token"]
+  }
+
+  param "search" {
+    type        = "string"
+    required    = false
+    description = "Filter by group name or path"
+  }
+
+  param "owned" {
+    type        = "boolean"
+    required    = false
+    default     = false
+    description = "Only return groups owned by the current user"
+  }
+
+  param "visibility" {
+    type        = "string"
+    required    = false
+    description = "Filter by visibility: public, internal, or private"
+  }
+
+  param "per_page" {
+    type        = "integer"
+    required    = false
+    default     = 20
+    description = "Number of results per page (max 100)"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://gitlab.com/api/v4/groups"
+
+    auth {
+      kind     = "api_key"
+      location = "header"
+      name     = "PRIVATE-TOKEN"
+      secret   = "gitlab.token"
+    }
+
+    query = {
+      search     = "{{ args.search }}"
+      owned      = "{{ args.owned }}"
+      visibility = "{{ args.visibility }}"
+      per_page   = "{{ args.per_page }}"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Found {{ result | length }} groups."
+  }
+}

--- a/examples/hubspot.hcl
+++ b/examples/hubspot.hcl
@@ -1,0 +1,843 @@
+version = 1
+provider = "hubspot"
+categories = ["crm", "sales", "marketing"]
+
+command "list_contacts" {
+  title       = "List contacts"
+  summary     = "List CRM contacts with optional property selection"
+  description = "Retrieve a paginated list of contacts from HubSpot CRM. Use the properties parameter to specify which contact fields to return."
+  categories  = ["crm"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["hubspot.token"]
+  }
+
+  param "limit" {
+    type        = "integer"
+    required    = false
+    default     = 10
+    description = "Records per page (max 100)"
+  }
+
+  param "after" {
+    type        = "string"
+    required    = false
+    default     = ""
+    description = "Pagination cursor from a previous response"
+  }
+
+  param "properties" {
+    type        = "string"
+    required    = false
+    default     = "firstname,lastname,email"
+    description = "Comma-separated property names to return"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://api.hubapi.com/crm/v3/objects/contacts"
+
+    auth {
+      kind   = "bearer"
+      secret = "hubspot.token"
+    }
+
+    query = {
+      limit      = "{{ args.limit }}"
+      after      = "{{ args.after }}"
+      properties = "{{ args.properties }}"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Found {{ result.results | length }} contacts.{% for c in result.results %}\n- [{{ c.id }}] {{ c.properties.firstname }} {{ c.properties.lastname }} <{{ c.properties.email }}>{% endfor %}"
+  }
+}
+
+command "get_contact" {
+  title       = "Get contact"
+  summary     = "Retrieve a single contact by ID"
+  description = "Fetch a HubSpot contact by its ID or by a custom identity property such as email."
+  categories  = ["crm"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["hubspot.token"]
+  }
+
+  param "contact_id" {
+    type        = "string"
+    required    = true
+    description = "HubSpot contact ID or value of id_property"
+  }
+
+  param "id_property" {
+    type        = "string"
+    required    = false
+    default     = ""
+    description = "Custom property to use as lookup key (e.g. email)"
+  }
+
+  param "properties" {
+    type        = "string"
+    required    = false
+    default     = "firstname,lastname,email,phone,company,lifecyclestage"
+    description = "Comma-separated property names to return"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://api.hubapi.com/crm/v3/objects/contacts/{{ args.contact_id }}"
+
+    auth {
+      kind   = "bearer"
+      secret = "hubspot.token"
+    }
+
+    query = {
+      idProperty = "{{ args.id_property }}"
+      properties = "{{ args.properties }}"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Contact {{ result.id }}:\n  Name: {{ result.properties.firstname }} {{ result.properties.lastname }}\n  Email: {{ result.properties.email }}\n  Phone: {{ result.properties.phone }}\n  Company: {{ result.properties.company }}\n  Lifecycle: {{ result.properties.lifecyclestage }}\n  Created: {{ result.createdAt }}"
+  }
+}
+
+command "create_contact" {
+  title       = "Create contact"
+  summary     = "Create a new CRM contact"
+  description = "Create a new contact in HubSpot CRM with the specified properties."
+  categories  = ["crm"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["hubspot.token"]
+  }
+
+  param "email" {
+    type        = "string"
+    required    = true
+    description = "Contact email address"
+  }
+
+  param "firstname" {
+    type        = "string"
+    required    = false
+    default     = ""
+    description = "First name"
+  }
+
+  param "lastname" {
+    type        = "string"
+    required    = false
+    default     = ""
+    description = "Last name"
+  }
+
+  param "phone" {
+    type        = "string"
+    required    = false
+    default     = ""
+    description = "Phone number"
+  }
+
+  param "company" {
+    type        = "string"
+    required    = false
+    default     = ""
+    description = "Company name"
+  }
+
+  param "jobtitle" {
+    type        = "string"
+    required    = false
+    default     = ""
+    description = "Job title"
+  }
+
+  param "lifecyclestage" {
+    type        = "string"
+    required    = false
+    default     = ""
+    description = "Lifecycle stage (e.g. lead, customer, subscriber)"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "POST"
+    url      = "https://api.hubapi.com/crm/v3/objects/contacts"
+
+    auth {
+      kind   = "bearer"
+      secret = "hubspot.token"
+    }
+
+    body {
+      kind = "json"
+      value = {
+        properties = {
+          email          = "{{ args.email }}"
+          firstname      = "{{ args.firstname }}"
+          lastname       = "{{ args.lastname }}"
+          phone          = "{{ args.phone }}"
+          company        = "{{ args.company }}"
+          jobtitle       = "{{ args.jobtitle }}"
+          lifecyclestage = "{{ args.lifecyclestage }}"
+        }
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Created contact {{ result.id }}: {{ result.properties.firstname }} {{ result.properties.lastname }} <{{ result.properties.email }}>"
+  }
+}
+
+command "update_contact" {
+  title       = "Update contact"
+  summary     = "Update properties on an existing contact"
+  description = "Update one or more properties on a HubSpot contact. Pass a JSON object of property names to values."
+  categories  = ["crm"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["hubspot.token"]
+  }
+
+  param "contact_id" {
+    type        = "string"
+    required    = true
+    description = "HubSpot contact ID"
+  }
+
+  param "properties" {
+    type        = "object"
+    required    = true
+    description = "JSON object of property names to values (e.g. {\"email\": \"new@example.com\"})"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "PATCH"
+    url      = "https://api.hubapi.com/crm/v3/objects/contacts/{{ args.contact_id }}"
+
+    auth {
+      kind   = "bearer"
+      secret = "hubspot.token"
+    }
+
+    body {
+      kind = "json"
+      value = {
+        properties = "{{ args.properties | tojson }}"
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Updated contact {{ result.id }}: {{ result.properties.firstname }} {{ result.properties.lastname }}"
+  }
+}
+
+command "delete_contact" {
+  title       = "Delete contact"
+  summary     = "Archive a contact by ID"
+  description = "Archive (soft-delete) a contact in HubSpot CRM. The contact can be restored from the recycling bin."
+  categories  = ["crm"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["hubspot.token"]
+  }
+
+  param "contact_id" {
+    type        = "string"
+    required    = true
+    description = "HubSpot contact ID to archive"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "DELETE"
+    url      = "https://api.hubapi.com/crm/v3/objects/contacts/{{ args.contact_id }}"
+
+    auth {
+      kind   = "bearer"
+      secret = "hubspot.token"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Archived contact {{ args.contact_id }}."
+  }
+}
+
+command "search_contacts" {
+  title       = "Search contacts"
+  summary     = "Search contacts by query string"
+  description = "Search HubSpot contacts using a full-text query. Returns matching contacts with key properties."
+  categories  = ["crm", "search"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["hubspot.token"]
+  }
+
+  param "query" {
+    type        = "string"
+    required    = true
+    description = "Full-text search query"
+  }
+
+  param "limit" {
+    type        = "integer"
+    required    = false
+    default     = 10
+    description = "Results per page (max 200)"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "POST"
+    url      = "https://api.hubapi.com/crm/v3/objects/contacts/search"
+
+    auth {
+      kind   = "bearer"
+      secret = "hubspot.token"
+    }
+
+    body {
+      kind = "json"
+      value = {
+        query      = "{{ args.query }}"
+        limit      = "{{ args.limit }}"
+        properties = ["firstname", "lastname", "email", "company", "lifecyclestage"]
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Found {{ result.total }} contacts.{% for c in result.results %}\n- [{{ c.id }}] {{ c.properties.firstname }} {{ c.properties.lastname }} <{{ c.properties.email }}> ({{ c.properties.lifecyclestage }}){% endfor %}"
+  }
+}
+
+command "list_companies" {
+  title       = "List companies"
+  summary     = "List CRM companies"
+  description = "Retrieve a paginated list of companies from HubSpot CRM."
+  categories  = ["crm"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["hubspot.token"]
+  }
+
+  param "limit" {
+    type        = "integer"
+    required    = false
+    default     = 10
+    description = "Records per page (max 100)"
+  }
+
+  param "after" {
+    type        = "string"
+    required    = false
+    default     = ""
+    description = "Pagination cursor from a previous response"
+  }
+
+  param "properties" {
+    type        = "string"
+    required    = false
+    default     = "name,domain,industry"
+    description = "Comma-separated property names to return"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://api.hubapi.com/crm/v3/objects/companies"
+
+    auth {
+      kind   = "bearer"
+      secret = "hubspot.token"
+    }
+
+    query = {
+      limit      = "{{ args.limit }}"
+      after      = "{{ args.after }}"
+      properties = "{{ args.properties }}"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Found {{ result.results | length }} companies.{% for c in result.results %}\n- [{{ c.id }}] {{ c.properties.name }} ({{ c.properties.domain }}) — {{ c.properties.industry }}{% endfor %}"
+  }
+}
+
+command "create_company" {
+  title       = "Create company"
+  summary     = "Create a new CRM company"
+  description = "Create a new company record in HubSpot CRM."
+  categories  = ["crm"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["hubspot.token"]
+  }
+
+  param "name" {
+    type        = "string"
+    required    = true
+    description = "Company name"
+  }
+
+  param "domain" {
+    type        = "string"
+    required    = false
+    default     = ""
+    description = "Primary website domain"
+  }
+
+  param "industry" {
+    type        = "string"
+    required    = false
+    default     = ""
+    description = "Industry (e.g. COMPUTER_SOFTWARE)"
+  }
+
+  param "phone" {
+    type        = "string"
+    required    = false
+    default     = ""
+    description = "Company phone number"
+  }
+
+  param "city" {
+    type        = "string"
+    required    = false
+    default     = ""
+    description = "City"
+  }
+
+  param "state" {
+    type        = "string"
+    required    = false
+    default     = ""
+    description = "State or region"
+  }
+
+  param "country" {
+    type        = "string"
+    required    = false
+    default     = ""
+    description = "Country"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "POST"
+    url      = "https://api.hubapi.com/crm/v3/objects/companies"
+
+    auth {
+      kind   = "bearer"
+      secret = "hubspot.token"
+    }
+
+    body {
+      kind = "json"
+      value = {
+        properties = {
+          name     = "{{ args.name }}"
+          domain   = "{{ args.domain }}"
+          industry = "{{ args.industry }}"
+          phone    = "{{ args.phone }}"
+          city     = "{{ args.city }}"
+          state    = "{{ args.state }}"
+          country  = "{{ args.country }}"
+        }
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Created company {{ result.id }}: {{ result.properties.name }} ({{ result.properties.domain }})"
+  }
+}
+
+command "list_deals" {
+  title       = "List deals"
+  summary     = "List CRM deals"
+  description = "Retrieve a paginated list of deals from HubSpot CRM."
+  categories  = ["sales"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["hubspot.token"]
+  }
+
+  param "limit" {
+    type        = "integer"
+    required    = false
+    default     = 10
+    description = "Records per page (max 100)"
+  }
+
+  param "after" {
+    type        = "string"
+    required    = false
+    default     = ""
+    description = "Pagination cursor from a previous response"
+  }
+
+  param "properties" {
+    type        = "string"
+    required    = false
+    default     = "dealname,amount,dealstage"
+    description = "Comma-separated property names to return"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://api.hubapi.com/crm/v3/objects/deals"
+
+    auth {
+      kind   = "bearer"
+      secret = "hubspot.token"
+    }
+
+    query = {
+      limit      = "{{ args.limit }}"
+      after      = "{{ args.after }}"
+      properties = "{{ args.properties }}"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Found {{ result.results | length }} deals.{% for d in result.results %}\n- [{{ d.id }}] {{ d.properties.dealname }} — {{ d.properties.amount }} (stage: {{ d.properties.dealstage }}){% endfor %}"
+  }
+}
+
+command "create_deal" {
+  title       = "Create deal"
+  summary     = "Create a new sales deal"
+  description = "Create a new deal in HubSpot CRM with the specified properties."
+  categories  = ["sales"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["hubspot.token"]
+  }
+
+  param "dealname" {
+    type        = "string"
+    required    = true
+    description = "Deal title"
+  }
+
+  param "dealstage" {
+    type        = "string"
+    required    = true
+    description = "Pipeline stage internal ID"
+  }
+
+  param "pipeline" {
+    type        = "string"
+    required    = false
+    default     = "default"
+    description = "Pipeline ID"
+  }
+
+  param "amount" {
+    type        = "string"
+    required    = false
+    default     = ""
+    description = "Deal value"
+  }
+
+  param "closedate" {
+    type        = "string"
+    required    = false
+    default     = ""
+    description = "Expected close date (ISO 8601)"
+  }
+
+  param "hubspot_owner_id" {
+    type        = "string"
+    required    = false
+    default     = ""
+    description = "Assigned owner ID"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "POST"
+    url      = "https://api.hubapi.com/crm/v3/objects/deals"
+
+    auth {
+      kind   = "bearer"
+      secret = "hubspot.token"
+    }
+
+    body {
+      kind = "json"
+      value = {
+        properties = {
+          dealname         = "{{ args.dealname }}"
+          dealstage        = "{{ args.dealstage }}"
+          pipeline         = "{{ args.pipeline }}"
+          amount           = "{{ args.amount }}"
+          closedate        = "{{ args.closedate }}"
+          hubspot_owner_id = "{{ args.hubspot_owner_id }}"
+        }
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Created deal {{ result.id }}: {{ result.properties.dealname }} — {{ result.properties.amount }}"
+  }
+}
+
+command "create_ticket" {
+  title       = "Create ticket"
+  summary     = "Create a support ticket"
+  description = "Create a new support ticket in HubSpot CRM."
+  categories  = ["crm"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["hubspot.token"]
+  }
+
+  param "subject" {
+    type        = "string"
+    required    = true
+    description = "Ticket title"
+  }
+
+  param "content" {
+    type        = "string"
+    required    = false
+    default     = ""
+    description = "Ticket description body"
+  }
+
+  param "hs_pipeline" {
+    type        = "string"
+    required    = false
+    default     = "0"
+    description = "Pipeline ID"
+  }
+
+  param "hs_pipeline_stage" {
+    type        = "string"
+    required    = false
+    default     = "1"
+    description = "Stage ID"
+  }
+
+  param "hs_ticket_priority" {
+    type        = "string"
+    required    = false
+    default     = ""
+    description = "Priority: LOW, MEDIUM, or HIGH"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "POST"
+    url      = "https://api.hubapi.com/crm/v3/objects/tickets"
+
+    auth {
+      kind   = "bearer"
+      secret = "hubspot.token"
+    }
+
+    body {
+      kind = "json"
+      value = {
+        properties = {
+          subject            = "{{ args.subject }}"
+          content            = "{{ args.content }}"
+          hs_pipeline        = "{{ args.hs_pipeline }}"
+          hs_pipeline_stage  = "{{ args.hs_pipeline_stage }}"
+          hs_ticket_priority = "{{ args.hs_ticket_priority }}"
+        }
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Created ticket {{ result.id }}: {{ result.properties.subject }} (priority: {{ result.properties.hs_ticket_priority }})"
+  }
+}
+
+command "create_note" {
+  title       = "Create note"
+  summary     = "Create a note and associate it with a CRM record"
+  description = "Create an engagement note in HubSpot and associate it with a contact, deal, company, or ticket. Use association_type_id: 202=contact, 214=deal, 190=company, 220=ticket."
+  categories  = ["crm"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["hubspot.token"]
+  }
+
+  param "note_body" {
+    type        = "string"
+    required    = true
+    description = "Note text content"
+  }
+
+  param "timestamp" {
+    type        = "string"
+    required    = true
+    description = "Note timestamp in ISO 8601 format (e.g. 2024-01-15T10:30:00Z)"
+  }
+
+  param "associated_object_id" {
+    type        = "string"
+    required    = true
+    description = "ID of the record to attach the note to"
+  }
+
+  param "association_type_id" {
+    type        = "integer"
+    required    = true
+    description = "Association type ID (202=contact, 214=deal, 190=company, 220=ticket)"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "POST"
+    url      = "https://api.hubapi.com/crm/v3/objects/notes"
+
+    auth {
+      kind   = "bearer"
+      secret = "hubspot.token"
+    }
+
+    body {
+      kind = "json"
+      value = {
+        properties = {
+          hs_note_body = "{{ args.note_body }}"
+          hs_timestamp = "{{ args.timestamp }}"
+        }
+        associations = [{
+          to = {
+            id = "{{ args.associated_object_id }}"
+          }
+          types = [{
+            associationCategory = "HUBSPOT_DEFINED"
+            associationTypeId   = "{{ args.association_type_id }}"
+          }]
+        }]
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Created note {{ result.id }} associated with record {{ args.associated_object_id }}."
+  }
+}
+
+command "list_owners" {
+  title       = "List owners"
+  summary     = "List HubSpot users who can be assigned as owners"
+  description = "Retrieve a list of HubSpot owners (users) who can be assigned to contacts, deals, and other CRM records."
+  categories  = ["crm"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["hubspot.token"]
+  }
+
+  param "limit" {
+    type        = "integer"
+    required    = false
+    default     = 100
+    description = "Records per page"
+  }
+
+  param "after" {
+    type        = "string"
+    required    = false
+    default     = ""
+    description = "Pagination cursor from a previous response"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://api.hubapi.com/crm/v3/owners"
+
+    auth {
+      kind   = "bearer"
+      secret = "hubspot.token"
+    }
+
+    query = {
+      limit = "{{ args.limit }}"
+      after = "{{ args.after }}"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Found {{ result.results | length }} owners.{% for o in result.results %}\n- [{{ o.id }}] {{ o.firstName }} {{ o.lastName }} <{{ o.email }}>{% endfor %}"
+  }
+}
+
+command "list_pipelines" {
+  title       = "List pipelines"
+  summary     = "List pipelines and stages for deals or tickets"
+  description = "Retrieve all pipelines and their stages for a given object type. Use object_type 'deals' for sales pipelines or 'tickets' for support pipelines."
+  categories  = ["sales", "crm"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["hubspot.token"]
+  }
+
+  param "object_type" {
+    type        = "string"
+    required    = true
+    description = "Object type: deals or tickets"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://api.hubapi.com/crm/v3/pipelines/{{ args.object_type }}"
+
+    auth {
+      kind   = "bearer"
+      secret = "hubspot.token"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Found {{ result.results | length }} pipelines.{% for p in result.results %}\n{{ p.label }} [{{ p.id }}]{% for s in p.stages %}\n  - {{ s.label }} ({{ s.id }}){% endfor %}{% endfor %}"
+  }
+}

--- a/examples/jira.hcl
+++ b/examples/jira.hcl
@@ -1,0 +1,863 @@
+version = 1
+provider = "jira"
+categories = ["project-management", "issue-tracking", "agile"]
+
+command "search_issues" {
+  title       = "Search issues"
+  summary     = "Search Jira issues using JQL"
+  description = "Search for issues across projects using Jira Query Language (JQL)."
+  categories  = ["search", "issues"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["jira.email", "jira.api_token"]
+  }
+
+  param "domain" {
+    type        = "string"
+    required    = true
+    description = "Atlassian subdomain (e.g. 'mycompany' for mycompany.atlassian.net)"
+  }
+
+  param "jql" {
+    type        = "string"
+    required    = true
+    description = "JQL query (e.g. 'project = PROJ AND status = \"In Progress\"')"
+  }
+
+  param "max_results" {
+    type        = "integer"
+    required    = false
+    default     = 50
+    description = "Maximum number of results to return"
+  }
+
+  param "fields" {
+    type        = "string"
+    required    = false
+    default     = "key,summary,status,assignee,priority,issuetype"
+    description = "Comma-separated list of fields to return"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://{{ args.domain }}.atlassian.net/rest/api/2/search"
+
+    auth {
+      kind            = "basic"
+      username        = "{{ secrets.jira_email }}"
+      password_secret = "jira.api_token"
+    }
+
+    query = {
+      jql        = "{{ args.jql }}"
+      maxResults = "{{ args.max_results }}"
+      fields     = "{{ args.fields }}"
+    }
+
+    headers = {
+      Accept = "application/json"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Found {{ result.total }} issues matching the query."
+  }
+}
+
+command "get_issue" {
+  title       = "Get issue"
+  summary     = "Get details of a Jira issue"
+  description = "Retrieve full details of a Jira issue by its key."
+  categories  = ["issues"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["jira.email", "jira.api_token"]
+  }
+
+  param "domain" {
+    type        = "string"
+    required    = true
+    description = "Atlassian subdomain"
+  }
+
+  param "issue_key" {
+    type        = "string"
+    required    = true
+    description = "Issue key (e.g. 'PROJ-123')"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://{{ args.domain }}.atlassian.net/rest/api/2/issue/{{ args.issue_key }}"
+
+    auth {
+      kind            = "basic"
+      username        = "{{ secrets.jira_email }}"
+      password_secret = "jira.api_token"
+    }
+
+    headers = {
+      Accept = "application/json"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "{{ result.key }}: {{ result.fields.summary }}\nType: {{ result.fields.issuetype.name }}  Status: {{ result.fields.status.name }}  Priority: {{ result.fields.priority.name }}\nAssignee: {{ result.fields.assignee.displayName | default('Unassigned') }}\nReporter: {{ result.fields.reporter.displayName }}"
+  }
+}
+
+command "create_issue" {
+  title       = "Create issue"
+  summary     = "Create a new Jira issue"
+  description = "Create a new issue in a Jira project."
+  categories  = ["write", "issues"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["jira.email", "jira.api_token"]
+  }
+
+  param "domain" {
+    type        = "string"
+    required    = true
+    description = "Atlassian subdomain"
+  }
+
+  param "project_key" {
+    type        = "string"
+    required    = true
+    description = "Project key (e.g. 'PROJ')"
+  }
+
+  param "summary" {
+    type        = "string"
+    required    = true
+    description = "Issue title/summary"
+  }
+
+  param "issue_type" {
+    type        = "string"
+    required    = true
+    description = "Issue type (e.g. 'Bug', 'Story', 'Task')"
+  }
+
+  param "description" {
+    type        = "string"
+    required    = false
+    default     = ""
+    description = "Issue description (plain text)"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "POST"
+    url      = "https://{{ args.domain }}.atlassian.net/rest/api/2/issue"
+
+    auth {
+      kind            = "basic"
+      username        = "{{ secrets.jira_email }}"
+      password_secret = "jira.api_token"
+    }
+
+    headers = {
+      Accept = "application/json"
+    }
+
+    body {
+      kind = "json"
+      value = {
+        fields = {
+          project = {
+            key = "{{ args.project_key }}"
+          }
+          summary = "{{ args.summary }}"
+          issuetype = {
+            name = "{{ args.issue_type }}"
+          }
+          description = "{{ args.description }}"
+        }
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Created issue {{ result.key }}\nURL: https://{{ args.domain }}.atlassian.net/browse/{{ result.key }}"
+  }
+}
+
+command "update_issue" {
+  title       = "Update issue"
+  summary     = "Update the summary of a Jira issue"
+  description = "Update the summary (title) of an existing Jira issue."
+  categories  = ["write", "issues"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["jira.email", "jira.api_token"]
+  }
+
+  param "domain" {
+    type        = "string"
+    required    = true
+    description = "Atlassian subdomain"
+  }
+
+  param "issue_key" {
+    type        = "string"
+    required    = true
+    description = "Issue key to update"
+  }
+
+  param "summary" {
+    type        = "string"
+    required    = true
+    description = "New issue summary"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "PUT"
+    url      = "https://{{ args.domain }}.atlassian.net/rest/api/2/issue/{{ args.issue_key }}"
+
+    auth {
+      kind            = "basic"
+      username        = "{{ secrets.jira_email }}"
+      password_secret = "jira.api_token"
+    }
+
+    headers = {
+      Accept = "application/json"
+    }
+
+    body {
+      kind = "json"
+      value = {
+        fields = {
+          summary = "{{ args.summary }}"
+        }
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Updated issue {{ args.issue_key }} successfully."
+  }
+}
+
+command "delete_issue" {
+  title       = "Delete issue"
+  summary     = "Delete a Jira issue"
+  description = "Permanently delete a Jira issue. Use with caution."
+  categories  = ["write", "issues"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["jira.email", "jira.api_token"]
+  }
+
+  param "domain" {
+    type        = "string"
+    required    = true
+    description = "Atlassian subdomain"
+  }
+
+  param "issue_key" {
+    type        = "string"
+    required    = true
+    description = "Issue key to delete"
+  }
+
+  param "delete_subtasks" {
+    type        = "boolean"
+    required    = false
+    default     = false
+    description = "Also delete subtasks"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "DELETE"
+    url      = "https://{{ args.domain }}.atlassian.net/rest/api/2/issue/{{ args.issue_key }}"
+
+    auth {
+      kind            = "basic"
+      username        = "{{ secrets.jira_email }}"
+      password_secret = "jira.api_token"
+    }
+
+    query = {
+      deleteSubtasks = "{{ args.delete_subtasks }}"
+    }
+
+    headers = {
+      Accept = "application/json"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Deleted issue {{ args.issue_key }}."
+  }
+}
+
+command "add_comment" {
+  title       = "Add comment"
+  summary     = "Add a comment to a Jira issue"
+  description = "Post a new comment on a Jira issue."
+  categories  = ["write", "issues"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["jira.email", "jira.api_token"]
+  }
+
+  param "domain" {
+    type        = "string"
+    required    = true
+    description = "Atlassian subdomain"
+  }
+
+  param "issue_key" {
+    type        = "string"
+    required    = true
+    description = "Issue key to comment on"
+  }
+
+  param "body" {
+    type        = "string"
+    required    = true
+    description = "Comment text (plain text)"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "POST"
+    url      = "https://{{ args.domain }}.atlassian.net/rest/api/2/issue/{{ args.issue_key }}/comment"
+
+    auth {
+      kind            = "basic"
+      username        = "{{ secrets.jira_email }}"
+      password_secret = "jira.api_token"
+    }
+
+    headers = {
+      Accept = "application/json"
+    }
+
+    body {
+      kind = "json"
+      value = {
+        body = "{{ args.body }}"
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Added comment to {{ args.issue_key }} (comment id: {{ result.id }})"
+  }
+}
+
+command "list_comments" {
+  title       = "List comments"
+  summary     = "List comments on a Jira issue"
+  description = "Retrieve all comments on a Jira issue."
+  categories  = ["issues"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["jira.email", "jira.api_token"]
+  }
+
+  param "domain" {
+    type        = "string"
+    required    = true
+    description = "Atlassian subdomain"
+  }
+
+  param "issue_key" {
+    type        = "string"
+    required    = true
+    description = "Issue key"
+  }
+
+  param "max_results" {
+    type        = "integer"
+    required    = false
+    default     = 50
+    description = "Maximum number of comments to return"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://{{ args.domain }}.atlassian.net/rest/api/2/issue/{{ args.issue_key }}/comment"
+
+    auth {
+      kind            = "basic"
+      username        = "{{ secrets.jira_email }}"
+      password_secret = "jira.api_token"
+    }
+
+    query = {
+      maxResults = "{{ args.max_results }}"
+      orderBy    = "created"
+    }
+
+    headers = {
+      Accept = "application/json"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "{{ result.total }} comments on {{ args.issue_key }}."
+  }
+}
+
+command "transition_issue" {
+  title       = "Transition issue"
+  summary     = "Change the status of a Jira issue"
+  description = "Transition a Jira issue to a new status. Use get_transitions to find available transition IDs."
+  categories  = ["write", "issues"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["jira.email", "jira.api_token"]
+  }
+
+  param "domain" {
+    type        = "string"
+    required    = true
+    description = "Atlassian subdomain"
+  }
+
+  param "issue_key" {
+    type        = "string"
+    required    = true
+    description = "Issue key to transition"
+  }
+
+  param "transition_id" {
+    type        = "string"
+    required    = true
+    description = "Transition ID (use get_transitions to find available IDs)"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "POST"
+    url      = "https://{{ args.domain }}.atlassian.net/rest/api/2/issue/{{ args.issue_key }}/transitions"
+
+    auth {
+      kind            = "basic"
+      username        = "{{ secrets.jira_email }}"
+      password_secret = "jira.api_token"
+    }
+
+    headers = {
+      Accept = "application/json"
+    }
+
+    body {
+      kind = "json"
+      value = {
+        transition = {
+          id = "{{ args.transition_id }}"
+        }
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Transitioned {{ args.issue_key }} successfully."
+  }
+}
+
+command "get_transitions" {
+  title       = "Get transitions"
+  summary     = "Get available status transitions for an issue"
+  description = "List the available status transitions for a Jira issue."
+  categories  = ["issues"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["jira.email", "jira.api_token"]
+  }
+
+  param "domain" {
+    type        = "string"
+    required    = true
+    description = "Atlassian subdomain"
+  }
+
+  param "issue_key" {
+    type        = "string"
+    required    = true
+    description = "Issue key"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://{{ args.domain }}.atlassian.net/rest/api/2/issue/{{ args.issue_key }}/transitions"
+
+    auth {
+      kind            = "basic"
+      username        = "{{ secrets.jira_email }}"
+      password_secret = "jira.api_token"
+    }
+
+    headers = {
+      Accept = "application/json"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Available transitions for {{ args.issue_key }}:\n{% for t in result.transitions %}ID: {{ t.id }} -> {{ t.name }} ({{ t.to.name }})\n{% endfor %}"
+  }
+}
+
+command "assign_issue" {
+  title       = "Assign issue"
+  summary     = "Assign a Jira issue to a user"
+  description = "Set the assignee of a Jira issue. Use search_users to find account IDs."
+  categories  = ["write", "issues"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["jira.email", "jira.api_token"]
+  }
+
+  param "domain" {
+    type        = "string"
+    required    = true
+    description = "Atlassian subdomain"
+  }
+
+  param "issue_key" {
+    type        = "string"
+    required    = true
+    description = "Issue key"
+  }
+
+  param "account_id" {
+    type        = "string"
+    required    = true
+    description = "Account ID of the assignee (use search_users to find IDs)"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "PUT"
+    url      = "https://{{ args.domain }}.atlassian.net/rest/api/2/issue/{{ args.issue_key }}/assignee"
+
+    auth {
+      kind            = "basic"
+      username        = "{{ secrets.jira_email }}"
+      password_secret = "jira.api_token"
+    }
+
+    headers = {
+      Accept = "application/json"
+    }
+
+    body {
+      kind = "json"
+      value = {
+        accountId = "{{ args.account_id }}"
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Assigned {{ args.issue_key }} to account {{ args.account_id }}."
+  }
+}
+
+command "list_projects" {
+  title       = "List projects"
+  summary     = "List Jira projects"
+  description = "List all accessible Jira projects in the instance."
+  categories  = ["projects"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["jira.email", "jira.api_token"]
+  }
+
+  param "domain" {
+    type        = "string"
+    required    = true
+    description = "Atlassian subdomain"
+  }
+
+  param "max_results" {
+    type        = "integer"
+    required    = false
+    default     = 50
+    description = "Maximum number of projects to return"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://{{ args.domain }}.atlassian.net/rest/api/2/project/search"
+
+    auth {
+      kind            = "basic"
+      username        = "{{ secrets.jira_email }}"
+      password_secret = "jira.api_token"
+    }
+
+    query = {
+      maxResults = "{{ args.max_results }}"
+    }
+
+    headers = {
+      Accept = "application/json"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "{{ result.total }} projects found."
+  }
+}
+
+command "get_myself" {
+  title       = "Get current user"
+  summary     = "Get details of the authenticated user"
+  description = "Retrieve information about the currently authenticated Jira user."
+  categories  = ["users"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["jira.email", "jira.api_token"]
+  }
+
+  param "domain" {
+    type        = "string"
+    required    = true
+    description = "Atlassian subdomain"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://{{ args.domain }}.atlassian.net/rest/api/2/myself"
+
+    auth {
+      kind            = "basic"
+      username        = "{{ secrets.jira_email }}"
+      password_secret = "jira.api_token"
+    }
+
+    headers = {
+      Accept = "application/json"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "{{ result.displayName }} ({{ result.emailAddress }})\nAccount ID: {{ result.accountId }}\nTimezone: {{ result.timeZone }}"
+  }
+}
+
+command "search_users" {
+  title       = "Search users"
+  summary     = "Search for Jira users"
+  description = "Search for Jira users by display name or email address."
+  categories  = ["users"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["jira.email", "jira.api_token"]
+  }
+
+  param "domain" {
+    type        = "string"
+    required    = true
+    description = "Atlassian subdomain"
+  }
+
+  param "query" {
+    type        = "string"
+    required    = true
+    description = "Search string (matches display name and email)"
+  }
+
+  param "max_results" {
+    type        = "integer"
+    required    = false
+    default     = 50
+    description = "Maximum number of results"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://{{ args.domain }}.atlassian.net/rest/api/2/user/search"
+
+    auth {
+      kind            = "basic"
+      username        = "{{ secrets.jira_email }}"
+      password_secret = "jira.api_token"
+    }
+
+    query = {
+      query      = "{{ args.query }}"
+      maxResults = "{{ args.max_results }}"
+    }
+
+    headers = {
+      Accept = "application/json"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "{{ result | length }} users found."
+  }
+}
+
+command "list_sprints" {
+  title       = "List sprints"
+  summary     = "List sprints for a Jira board"
+  description = "List sprints associated with an agile board. Use list_boards to find board IDs."
+  categories  = ["agile"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["jira.email", "jira.api_token"]
+  }
+
+  param "domain" {
+    type        = "string"
+    required    = true
+    description = "Atlassian subdomain"
+  }
+
+  param "board_id" {
+    type        = "integer"
+    required    = true
+    description = "Board ID (use list_boards to find IDs)"
+  }
+
+  param "state" {
+    type        = "string"
+    required    = false
+    default     = ""
+    description = "Filter by state: 'future', 'active', 'closed' (comma-separated)"
+  }
+
+  param "max_results" {
+    type        = "integer"
+    required    = false
+    default     = 50
+    description = "Maximum number of sprints to return"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://{{ args.domain }}.atlassian.net/rest/agile/1.0/board/{{ args.board_id }}/sprint"
+
+    auth {
+      kind            = "basic"
+      username        = "{{ secrets.jira_email }}"
+      password_secret = "jira.api_token"
+    }
+
+    query = {
+      state      = "{{ args.state }}"
+      maxResults = "{{ args.max_results }}"
+    }
+
+    headers = {
+      Accept = "application/json"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Sprints for board {{ args.board_id }}:\n{% for s in result.values %}[{{ s.state }}] {{ s.name }} (id: {{ s.id }})\n{% endfor %}"
+  }
+}
+
+command "list_boards" {
+  title       = "List boards"
+  summary     = "List Jira agile boards"
+  description = "List agile boards accessible to the current user."
+  categories  = ["agile"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["jira.email", "jira.api_token"]
+  }
+
+  param "domain" {
+    type        = "string"
+    required    = true
+    description = "Atlassian subdomain"
+  }
+
+  param "type" {
+    type        = "string"
+    required    = false
+    default     = ""
+    description = "Board type: 'scrum' or 'kanban'"
+  }
+
+  param "project_key" {
+    type        = "string"
+    required    = false
+    default     = ""
+    description = "Filter by project key"
+  }
+
+  param "max_results" {
+    type        = "integer"
+    required    = false
+    default     = 50
+    description = "Maximum number of boards to return"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://{{ args.domain }}.atlassian.net/rest/agile/1.0/board"
+
+    auth {
+      kind            = "basic"
+      username        = "{{ secrets.jira_email }}"
+      password_secret = "jira.api_token"
+    }
+
+    query = {
+      type           = "{{ args.type }}"
+      projectKeyOrId = "{{ args.project_key }}"
+      maxResults     = "{{ args.max_results }}"
+    }
+
+    headers = {
+      Accept = "application/json"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "{{ result.total }} boards found."
+  }
+}

--- a/examples/linear.hcl
+++ b/examples/linear.hcl
@@ -1,0 +1,872 @@
+version = 1
+provider = "linear"
+categories = ["project-management", "issue-tracking"]
+
+command "viewer" {
+  title       = "Current user"
+  summary     = "Get the authenticated user's profile"
+  description = "Fetch the display name, email, and active status of the currently authenticated Linear user."
+  categories  = ["profile"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["linear.api_key"]
+  }
+
+  operation {
+    protocol = "graphql"
+    url      = "https://api.linear.app/graphql"
+
+    auth {
+      kind   = "bearer"
+      secret = "linear.api_key"
+    }
+
+    graphql {
+      query = <<-EOT
+        {
+          viewer {
+            id
+            name
+            email
+            active
+            admin
+            displayName
+            createdAt
+          }
+        }
+      EOT
+    }
+  }
+
+  result {
+    decode = "json"
+    extract {
+      json_pointer = "/data/viewer"
+    }
+    output = "{{ result.displayName }} ({{ result.email }}) — active: {{ result.active }}"
+  }
+}
+
+command "list_issues" {
+  title       = "List issues"
+  summary     = "List recent issues with optional filtering"
+  description = "Fetch recent issues from Linear, ordered by last updated. Optionally filter by team."
+  categories  = ["issues"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["linear.api_key"]
+  }
+
+  param "count" {
+    type        = "integer"
+    required    = false
+    default     = 20
+    description = "Number of issues to fetch"
+  }
+
+  param "team_key" {
+    type        = "string"
+    required    = false
+    default     = ""
+    description = "Team key to filter by (e.g. 'ENG'). Leave empty for all teams."
+  }
+
+  operation {
+    protocol = "graphql"
+    url      = "https://api.linear.app/graphql"
+
+    auth {
+      kind   = "bearer"
+      secret = "linear.api_key"
+    }
+
+    graphql {
+      query = <<-EOT
+        query ListIssues($count: Int!, $teamKey: String) {
+          issues(
+            first: $count
+            orderBy: updatedAt
+            filter: { team: { key: { eq: $teamKey } } }
+          ) {
+            nodes {
+              identifier
+              title
+              priority
+              state { name }
+              assignee { displayName }
+              updatedAt
+            }
+          }
+        }
+      EOT
+      variables = {
+        count   = "{{ args.count }}"
+        teamKey = "{{ args.team_key if args.team_key else None }}"
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    extract {
+      json_pointer = "/data/issues"
+    }
+    output = "{{ result.nodes | length }} issues returned"
+  }
+}
+
+command "get_issue" {
+  title       = "Get issue"
+  summary     = "Get a single issue by its identifier"
+  description = "Fetch full details of a Linear issue by its identifier (e.g. 'ENG-123')."
+  categories  = ["issues"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["linear.api_key"]
+  }
+
+  param "issue_id" {
+    type        = "string"
+    required    = true
+    description = "Issue identifier (e.g. 'ENG-123')"
+  }
+
+  operation {
+    protocol = "graphql"
+    url      = "https://api.linear.app/graphql"
+
+    auth {
+      kind   = "bearer"
+      secret = "linear.api_key"
+    }
+
+    graphql {
+      query = <<-EOT
+        query GetIssue($id: String!) {
+          issueSearch(query: $id, first: 1) {
+            nodes {
+              identifier
+              title
+              description
+              priority
+              estimate
+              state { name }
+              assignee { displayName }
+              team { name key }
+              project { name }
+              labels { nodes { name } }
+              createdAt
+              updatedAt
+            }
+          }
+        }
+      EOT
+      variables = {
+        id = "{{ args.issue_id }}"
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    extract {
+      json_pointer = "/data/issueSearch/nodes/0"
+    }
+    output = "{{ result.identifier }}: {{ result.title }} [{{ result.state.name }}] — assigned to {{ result.assignee.displayName if result.assignee else 'unassigned' }}"
+  }
+}
+
+command "create_issue" {
+  title       = "Create issue"
+  summary     = "Create a new issue in a team"
+  description = "Create a new Linear issue in the specified team with a title and optional description."
+  categories  = ["issues"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["linear.api_key"]
+  }
+
+  param "team_id" {
+    type        = "string"
+    required    = true
+    description = "Team ID to create the issue in"
+  }
+
+  param "title" {
+    type        = "string"
+    required    = true
+    description = "Issue title"
+  }
+
+  param "description" {
+    type        = "string"
+    required    = false
+    default     = ""
+    description = "Issue description (Markdown)"
+  }
+
+  param "priority" {
+    type        = "integer"
+    required    = false
+    default     = 0
+    description = "Priority: 0=none, 1=urgent, 2=high, 3=medium, 4=low"
+  }
+
+  param "assignee_id" {
+    type        = "string"
+    required    = false
+    default     = ""
+    description = "User ID to assign the issue to"
+  }
+
+  operation {
+    protocol = "graphql"
+    url      = "https://api.linear.app/graphql"
+
+    auth {
+      kind   = "bearer"
+      secret = "linear.api_key"
+    }
+
+    graphql {
+      query = <<-EOT
+        mutation CreateIssue($input: IssueCreateInput!) {
+          issueCreate(input: $input) {
+            success
+            issue {
+              identifier
+              title
+              url
+            }
+          }
+        }
+      EOT
+      variables = {
+        input = {
+          teamId      = "{{ args.team_id }}"
+          title       = "{{ args.title }}"
+          description = "{{ args.description if args.description else None }}"
+          priority    = "{{ args.priority }}"
+          assigneeId  = "{{ args.assignee_id if args.assignee_id else None }}"
+        }
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    extract {
+      json_pointer = "/data/issueCreate"
+    }
+    output = "{{ 'Created ' ~ result.issue.identifier ~ ': ' ~ result.issue.title ~ ' — ' ~ result.issue.url if result.success else 'Failed to create issue' }}"
+  }
+}
+
+command "update_issue" {
+  title       = "Update issue"
+  summary     = "Update an existing issue"
+  description = "Update fields on an existing Linear issue such as title, state, priority, or assignee."
+  categories  = ["issues"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["linear.api_key"]
+  }
+
+  param "issue_id" {
+    type        = "string"
+    required    = true
+    description = "Issue UUID to update"
+  }
+
+  param "title" {
+    type        = "string"
+    required    = false
+    default     = ""
+    description = "New issue title"
+  }
+
+  param "state_id" {
+    type        = "string"
+    required    = false
+    default     = ""
+    description = "Workflow state ID to transition to"
+  }
+
+  param "priority" {
+    type        = "integer"
+    required    = false
+    default     = 0
+    description = "Priority: 0=none, 1=urgent, 2=high, 3=medium, 4=low"
+  }
+
+  param "assignee_id" {
+    type        = "string"
+    required    = false
+    default     = ""
+    description = "User ID to assign the issue to"
+  }
+
+  operation {
+    protocol = "graphql"
+    url      = "https://api.linear.app/graphql"
+
+    auth {
+      kind   = "bearer"
+      secret = "linear.api_key"
+    }
+
+    graphql {
+      query = <<-EOT
+        mutation UpdateIssue($id: String!, $input: IssueUpdateInput!) {
+          issueUpdate(id: $id, input: $input) {
+            success
+            issue {
+              identifier
+              title
+              state { name }
+              url
+            }
+          }
+        }
+      EOT
+      variables = {
+        id = "{{ args.issue_id }}"
+        input = {
+          title      = "{{ args.title if args.title else None }}"
+          stateId    = "{{ args.state_id if args.state_id else None }}"
+          priority   = "{{ args.priority if args.priority else None }}"
+          assigneeId = "{{ args.assignee_id if args.assignee_id else None }}"
+        }
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    extract {
+      json_pointer = "/data/issueUpdate"
+    }
+    output = "{{ 'Updated ' ~ result.issue.identifier ~ ': ' ~ result.issue.title ~ ' [' ~ result.issue.state.name ~ ']' if result.success else 'Failed to update issue' }}"
+  }
+}
+
+command "delete_issue" {
+  title       = "Delete issue"
+  summary     = "Archive/delete an issue"
+  description = "Permanently delete a Linear issue. This action cannot be undone."
+  categories  = ["issues"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["linear.api_key"]
+  }
+
+  param "issue_id" {
+    type        = "string"
+    required    = true
+    description = "Issue UUID to delete"
+  }
+
+  operation {
+    protocol = "graphql"
+    url      = "https://api.linear.app/graphql"
+
+    auth {
+      kind   = "bearer"
+      secret = "linear.api_key"
+    }
+
+    graphql {
+      query = <<-EOT
+        mutation DeleteIssue($id: String!) {
+          issueDelete(id: $id) {
+            success
+          }
+        }
+      EOT
+      variables = {
+        id = "{{ args.issue_id }}"
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    extract {
+      json_pointer = "/data/issueDelete"
+    }
+    output = "{{ 'Issue deleted successfully' if result.success else 'Failed to delete issue' }}"
+  }
+}
+
+command "search_issues" {
+  title       = "Search issues"
+  summary     = "Search issues by text query"
+  description = "Search Linear issues by a free-text query string across titles and descriptions."
+  categories  = ["search", "issues"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["linear.api_key"]
+  }
+
+  param "query" {
+    type        = "string"
+    required    = true
+    description = "Search query text"
+  }
+
+  param "count" {
+    type        = "integer"
+    required    = false
+    default     = 10
+    description = "Number of results to return"
+  }
+
+  operation {
+    protocol = "graphql"
+    url      = "https://api.linear.app/graphql"
+
+    auth {
+      kind   = "bearer"
+      secret = "linear.api_key"
+    }
+
+    graphql {
+      query = <<-EOT
+        query SearchIssues($query: String!, $count: Int!) {
+          issueSearch(query: $query, first: $count) {
+            nodes {
+              identifier
+              title
+              priority
+              state { name }
+              assignee { displayName }
+              team { key }
+              updatedAt
+            }
+          }
+        }
+      EOT
+      variables = {
+        query = "{{ args.query }}"
+        count = "{{ args.count }}"
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    extract {
+      json_pointer = "/data/issueSearch"
+    }
+    output = "{{ result.nodes | length }} issues found"
+  }
+}
+
+command "list_teams" {
+  title       = "List teams"
+  summary     = "List all teams in the workspace"
+  description = "Fetch all teams in the Linear workspace with their keys, names, and member counts."
+  categories  = ["teams"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["linear.api_key"]
+  }
+
+  operation {
+    protocol = "graphql"
+    url      = "https://api.linear.app/graphql"
+
+    auth {
+      kind   = "bearer"
+      secret = "linear.api_key"
+    }
+
+    graphql {
+      query = <<-EOT
+        {
+          teams {
+            nodes {
+              id
+              name
+              key
+              description
+              members {
+                nodes { displayName }
+              }
+            }
+          }
+        }
+      EOT
+    }
+  }
+
+  result {
+    decode = "json"
+    extract {
+      json_pointer = "/data/teams"
+    }
+    output = "{{ result.nodes | length }} teams found"
+  }
+}
+
+command "list_projects" {
+  title       = "List projects"
+  summary     = "List projects in the workspace"
+  description = "Fetch projects from the Linear workspace with their status and progress."
+  categories  = ["projects"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["linear.api_key"]
+  }
+
+  param "count" {
+    type        = "integer"
+    required    = false
+    default     = 20
+    description = "Number of projects to fetch"
+  }
+
+  operation {
+    protocol = "graphql"
+    url      = "https://api.linear.app/graphql"
+
+    auth {
+      kind   = "bearer"
+      secret = "linear.api_key"
+    }
+
+    graphql {
+      query = <<-EOT
+        query ListProjects($count: Int!) {
+          projects(first: $count, orderBy: updatedAt) {
+            nodes {
+              id
+              name
+              description
+              state
+              progress
+              targetDate
+              lead { displayName }
+              teams { nodes { key } }
+            }
+          }
+        }
+      EOT
+      variables = {
+        count = "{{ args.count }}"
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    extract {
+      json_pointer = "/data/projects"
+    }
+    output = "{{ result.nodes | length }} projects returned"
+  }
+}
+
+command "create_comment" {
+  title       = "Create comment"
+  summary     = "Add a comment to an issue"
+  description = "Create a new comment on a Linear issue."
+  categories  = ["issues", "comments"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["linear.api_key"]
+  }
+
+  param "issue_id" {
+    type        = "string"
+    required    = true
+    description = "Issue UUID to comment on"
+  }
+
+  param "body" {
+    type        = "string"
+    required    = true
+    description = "Comment body (Markdown)"
+  }
+
+  operation {
+    protocol = "graphql"
+    url      = "https://api.linear.app/graphql"
+
+    auth {
+      kind   = "bearer"
+      secret = "linear.api_key"
+    }
+
+    graphql {
+      query = <<-EOT
+        mutation CreateComment($input: CommentCreateInput!) {
+          commentCreate(input: $input) {
+            success
+            comment {
+              id
+              body
+              createdAt
+              user { displayName }
+            }
+          }
+        }
+      EOT
+      variables = {
+        input = {
+          issueId = "{{ args.issue_id }}"
+          body    = "{{ args.body }}"
+        }
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    extract {
+      json_pointer = "/data/commentCreate"
+    }
+    output = "{{ 'Comment added by ' ~ result.comment.user.displayName if result.success else 'Failed to create comment' }}"
+  }
+}
+
+command "list_cycles" {
+  title       = "List cycles"
+  summary     = "List cycles for a team"
+  description = "Fetch cycles (sprints) for a given team, including their progress and dates."
+  categories  = ["cycles"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["linear.api_key"]
+  }
+
+  param "team_id" {
+    type        = "string"
+    required    = true
+    description = "Team UUID to list cycles for"
+  }
+
+  param "count" {
+    type        = "integer"
+    required    = false
+    default     = 10
+    description = "Number of cycles to fetch"
+  }
+
+  operation {
+    protocol = "graphql"
+    url      = "https://api.linear.app/graphql"
+
+    auth {
+      kind   = "bearer"
+      secret = "linear.api_key"
+    }
+
+    graphql {
+      query = <<-EOT
+        query ListCycles($teamId: String!, $count: Int!) {
+          team(id: $teamId) {
+            cycles(first: $count, orderBy: createdAt) {
+              nodes {
+                id
+                number
+                name
+                startsAt
+                endsAt
+                progress
+                completedScopeHistory
+                issueCountHistory
+              }
+            }
+          }
+        }
+      EOT
+      variables = {
+        teamId = "{{ args.team_id }}"
+        count  = "{{ args.count }}"
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    extract {
+      json_pointer = "/data/team/cycles"
+    }
+    output = "{{ result.nodes | length }} cycles returned"
+  }
+}
+
+command "list_labels" {
+  title       = "List labels"
+  summary     = "List all issue labels"
+  description = "Fetch all issue labels available in the Linear workspace."
+  categories  = ["labels"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["linear.api_key"]
+  }
+
+  operation {
+    protocol = "graphql"
+    url      = "https://api.linear.app/graphql"
+
+    auth {
+      kind   = "bearer"
+      secret = "linear.api_key"
+    }
+
+    graphql {
+      query = <<-EOT
+        {
+          issueLabels(first: 100) {
+            nodes {
+              id
+              name
+              color
+              parent { name }
+            }
+          }
+        }
+      EOT
+    }
+  }
+
+  result {
+    decode = "json"
+    extract {
+      json_pointer = "/data/issueLabels"
+    }
+    output = "{{ result.nodes | length }} labels found"
+  }
+}
+
+command "list_workflow_states" {
+  title       = "List workflow states"
+  summary     = "List workflow states for a team"
+  description = "Fetch all workflow states (e.g. Backlog, Todo, In Progress, Done) for a given team."
+  categories  = ["teams", "workflow"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["linear.api_key"]
+  }
+
+  param "team_id" {
+    type        = "string"
+    required    = true
+    description = "Team UUID to list workflow states for"
+  }
+
+  operation {
+    protocol = "graphql"
+    url      = "https://api.linear.app/graphql"
+
+    auth {
+      kind   = "bearer"
+      secret = "linear.api_key"
+    }
+
+    graphql {
+      query = <<-EOT
+        query ListWorkflowStates($teamId: String!) {
+          team(id: $teamId) {
+            states {
+              nodes {
+                id
+                name
+                type
+                color
+                position
+              }
+            }
+          }
+        }
+      EOT
+      variables = {
+        teamId = "{{ args.team_id }}"
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    extract {
+      json_pointer = "/data/team/states"
+    }
+    output = "{{ result.nodes | length }} workflow states"
+  }
+}
+
+command "add_label" {
+  title       = "Add label to issue"
+  summary     = "Add a label to an existing issue"
+  description = "Attach an existing label to a Linear issue by adding it to the issue's label set."
+  categories  = ["issues", "labels"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["linear.api_key"]
+  }
+
+  param "issue_id" {
+    type        = "string"
+    required    = true
+    description = "Issue UUID to label"
+  }
+
+  param "label_id" {
+    type        = "string"
+    required    = true
+    description = "Label UUID to add"
+  }
+
+  operation {
+    protocol = "graphql"
+    url      = "https://api.linear.app/graphql"
+
+    auth {
+      kind   = "bearer"
+      secret = "linear.api_key"
+    }
+
+    graphql {
+      query = <<-EOT
+        mutation AddLabel($issueId: String!, $labelId: String!) {
+          issueAddLabel(id: $issueId, labelId: $labelId) {
+            success
+            issue {
+              identifier
+              title
+              labels { nodes { name } }
+            }
+          }
+        }
+      EOT
+      variables = {
+        issueId = "{{ args.issue_id }}"
+        labelId = "{{ args.label_id }}"
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    extract {
+      json_pointer = "/data/issueAddLabel"
+    }
+    output = "{{ 'Label added to ' ~ result.issue.identifier if result.success else 'Failed to add label' }}"
+  }
+}

--- a/examples/mailchimp.hcl
+++ b/examples/mailchimp.hcl
@@ -1,0 +1,848 @@
+version = 1
+provider = "mailchimp"
+categories = ["email", "marketing"]
+
+command "ping" {
+  title       = "Ping"
+  summary     = "Check Mailchimp API connectivity"
+  description = "Verify that your API key is valid and the Mailchimp API is reachable."
+  categories  = ["utility"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["mailchimp.api_key"]
+  }
+
+  param "dc" {
+    type        = "string"
+    required    = true
+    description = "Datacenter slug from your API key (e.g. 'us6')"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://{{ args.dc }}.api.mailchimp.com/3.0/ping"
+
+    auth {
+      kind            = "basic"
+      username        = "anystring"
+      password_secret = "mailchimp.api_key"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Status: {{ result.health_status }}"
+  }
+}
+
+command "list_audiences" {
+  title       = "List audiences"
+  summary     = "List all audiences (lists) in your account"
+  description = "Retrieve audiences with member counts and stats. Supports pagination."
+  categories  = ["audiences"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["mailchimp.api_key"]
+  }
+
+  param "dc" {
+    type        = "string"
+    required    = true
+    description = "Datacenter slug from your API key (e.g. 'us6')"
+  }
+
+  param "count" {
+    type        = "integer"
+    required    = false
+    default     = 10
+    description = "Number of results to return"
+  }
+
+  param "offset" {
+    type        = "integer"
+    required    = false
+    default     = 0
+    description = "Pagination offset"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://{{ args.dc }}.api.mailchimp.com/3.0/lists"
+
+    auth {
+      kind            = "basic"
+      username        = "anystring"
+      password_secret = "mailchimp.api_key"
+    }
+
+    query = {
+      count  = "{{ args.count }}"
+      offset = "{{ args.offset }}"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Found {{ result.total_items }} audiences:\n{% for list in result.lists %}  - {{ list.name }} ({{ list.id }}) — {{ list.stats.member_count }} members\n{% endfor %}"
+  }
+}
+
+command "get_audience" {
+  title       = "Get audience"
+  summary     = "Get details for a specific audience"
+  description = "Retrieve detailed information about an audience including stats and settings."
+  categories  = ["audiences"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["mailchimp.api_key"]
+  }
+
+  param "dc" {
+    type        = "string"
+    required    = true
+    description = "Datacenter slug from your API key (e.g. 'us6')"
+  }
+
+  param "list_id" {
+    type        = "string"
+    required    = true
+    description = "Audience/list ID"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://{{ args.dc }}.api.mailchimp.com/3.0/lists/{{ args.list_id }}"
+
+    auth {
+      kind            = "basic"
+      username        = "anystring"
+      password_secret = "mailchimp.api_key"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Audience: {{ result.name }} ({{ result.id }})\nMembers: {{ result.stats.member_count }}\nOpen rate: {{ result.stats.open_rate }}\nClick rate: {{ result.stats.click_rate }}\nCreated: {{ result.date_created }}"
+  }
+}
+
+command "list_members" {
+  title       = "List members"
+  summary     = "List members of an audience"
+  description = "Retrieve subscribers for a specific audience. Supports filtering by status and pagination."
+  categories  = ["members"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["mailchimp.api_key"]
+  }
+
+  param "dc" {
+    type        = "string"
+    required    = true
+    description = "Datacenter slug from your API key (e.g. 'us6')"
+  }
+
+  param "list_id" {
+    type        = "string"
+    required    = true
+    description = "Audience/list ID"
+  }
+
+  param "count" {
+    type        = "integer"
+    required    = false
+    default     = 10
+    description = "Number of results to return (max 50)"
+  }
+
+  param "offset" {
+    type        = "integer"
+    required    = false
+    default     = 0
+    description = "Pagination offset"
+  }
+
+  param "status" {
+    type        = "string"
+    required    = false
+    description = "Filter by status: subscribed, unsubscribed, cleaned, pending, transactional, archived"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://{{ args.dc }}.api.mailchimp.com/3.0/lists/{{ args.list_id }}/members"
+
+    auth {
+      kind            = "basic"
+      username        = "anystring"
+      password_secret = "mailchimp.api_key"
+    }
+
+    query = {
+      count  = "{{ args.count }}"
+      offset = "{{ args.offset }}"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Found {{ result.total_items }} members:\n{% for m in result.members %}  - {{ m.email_address }} ({{ m.status }}) — {{ m.merge_fields.FNAME }} {{ m.merge_fields.LNAME }}\n{% endfor %}"
+  }
+}
+
+command "search_members" {
+  title       = "Search members"
+  summary     = "Search for members by email or name"
+  description = "Search across all audiences for members matching a query string."
+  categories  = ["members"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["mailchimp.api_key"]
+  }
+
+  param "dc" {
+    type        = "string"
+    required    = true
+    description = "Datacenter slug from your API key (e.g. 'us6')"
+  }
+
+  param "query" {
+    type        = "string"
+    required    = true
+    description = "Email address or name to search for"
+  }
+
+  param "list_id" {
+    type        = "string"
+    required    = false
+    description = "Restrict search to a specific audience"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://{{ args.dc }}.api.mailchimp.com/3.0/search-members"
+
+    auth {
+      kind            = "basic"
+      username        = "anystring"
+      password_secret = "mailchimp.api_key"
+    }
+
+    query = {
+      query = "{{ args.query }}"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Exact matches: {{ result.exact_matches.total_items }}\n{% for m in result.exact_matches.members %}  - {{ m.email_address }} ({{ m.list_id }})\n{% endfor %}Full search: {{ result.full_search.total_items }} results"
+  }
+}
+
+command "add_member" {
+  title       = "Add member"
+  summary     = "Add a subscriber to an audience"
+  description = "Add a new member to a Mailchimp audience with the specified subscription status."
+  categories  = ["members"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["mailchimp.api_key"]
+  }
+
+  param "dc" {
+    type        = "string"
+    required    = true
+    description = "Datacenter slug from your API key (e.g. 'us6')"
+  }
+
+  param "list_id" {
+    type        = "string"
+    required    = true
+    description = "Audience/list ID"
+  }
+
+  param "email_address" {
+    type        = "string"
+    required    = true
+    description = "Subscriber email address"
+  }
+
+  param "status" {
+    type        = "string"
+    required    = true
+    description = "Subscription status: subscribed, pending, unsubscribed, or transactional"
+  }
+
+  param "first_name" {
+    type        = "string"
+    required    = false
+    default     = ""
+    description = "Subscriber first name"
+  }
+
+  param "last_name" {
+    type        = "string"
+    required    = false
+    default     = ""
+    description = "Subscriber last name"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "POST"
+    url      = "https://{{ args.dc }}.api.mailchimp.com/3.0/lists/{{ args.list_id }}/members"
+
+    auth {
+      kind            = "basic"
+      username        = "anystring"
+      password_secret = "mailchimp.api_key"
+    }
+
+    body {
+      kind = "json"
+      value = {
+        email_address = "{{ args.email_address }}"
+        status        = "{{ args.status }}"
+        merge_fields = {
+          FNAME = "{{ args.first_name }}"
+          LNAME = "{{ args.last_name }}"
+        }
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Added {{ result.email_address }} to list {{ result.list_id }}\nStatus: {{ result.status }}\nID: {{ result.id }}"
+  }
+}
+
+command "update_member" {
+  title       = "Update member"
+  summary     = "Update a subscriber in an audience"
+  description = "Update an existing member's information. The subscriber_hash is the MD5 hash of the lowercased email address."
+  categories  = ["members"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["mailchimp.api_key"]
+  }
+
+  param "dc" {
+    type        = "string"
+    required    = true
+    description = "Datacenter slug from your API key (e.g. 'us6')"
+  }
+
+  param "list_id" {
+    type        = "string"
+    required    = true
+    description = "Audience/list ID"
+  }
+
+  param "subscriber_hash" {
+    type        = "string"
+    required    = true
+    description = "MD5 hash of the lowercased subscriber email address"
+  }
+
+  param "status" {
+    type        = "string"
+    required    = false
+    description = "New subscription status: subscribed, unsubscribed, cleaned, pending"
+  }
+
+  param "first_name" {
+    type        = "string"
+    required    = false
+    default     = ""
+    description = "Updated first name"
+  }
+
+  param "last_name" {
+    type        = "string"
+    required    = false
+    default     = ""
+    description = "Updated last name"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "PATCH"
+    url      = "https://{{ args.dc }}.api.mailchimp.com/3.0/lists/{{ args.list_id }}/members/{{ args.subscriber_hash }}"
+
+    auth {
+      kind            = "basic"
+      username        = "anystring"
+      password_secret = "mailchimp.api_key"
+    }
+
+    body {
+      kind = "json"
+      value = {
+        merge_fields = {
+          FNAME = "{{ args.first_name }}"
+          LNAME = "{{ args.last_name }}"
+        }
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Updated {{ result.email_address }}\nStatus: {{ result.status }}"
+  }
+}
+
+command "archive_member" {
+  title       = "Archive member"
+  summary     = "Archive a subscriber from an audience"
+  description = "Archive (soft-delete) a member from an audience. The subscriber_hash is the MD5 hash of the lowercased email address."
+  categories  = ["members"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["mailchimp.api_key"]
+  }
+
+  param "dc" {
+    type        = "string"
+    required    = true
+    description = "Datacenter slug from your API key (e.g. 'us6')"
+  }
+
+  param "list_id" {
+    type        = "string"
+    required    = true
+    description = "Audience/list ID"
+  }
+
+  param "subscriber_hash" {
+    type        = "string"
+    required    = true
+    description = "MD5 hash of the lowercased subscriber email address"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "DELETE"
+    url      = "https://{{ args.dc }}.api.mailchimp.com/3.0/lists/{{ args.list_id }}/members/{{ args.subscriber_hash }}"
+
+    auth {
+      kind            = "basic"
+      username        = "anystring"
+      password_secret = "mailchimp.api_key"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Member archived from list {{ args.list_id }}"
+  }
+}
+
+command "list_campaigns" {
+  title       = "List campaigns"
+  summary     = "List email campaigns"
+  description = "Retrieve campaigns with optional filtering by status and type. Supports pagination."
+  categories  = ["campaigns"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["mailchimp.api_key"]
+  }
+
+  param "dc" {
+    type        = "string"
+    required    = true
+    description = "Datacenter slug from your API key (e.g. 'us6')"
+  }
+
+  param "count" {
+    type        = "integer"
+    required    = false
+    default     = 10
+    description = "Number of results to return"
+  }
+
+  param "offset" {
+    type        = "integer"
+    required    = false
+    default     = 0
+    description = "Pagination offset"
+  }
+
+  param "status" {
+    type        = "string"
+    required    = false
+    description = "Filter by status: save, sent, sending, schedule, paused"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://{{ args.dc }}.api.mailchimp.com/3.0/campaigns"
+
+    auth {
+      kind            = "basic"
+      username        = "anystring"
+      password_secret = "mailchimp.api_key"
+    }
+
+    query = {
+      count  = "{{ args.count }}"
+      offset = "{{ args.offset }}"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Found {{ result.total_items }} campaigns:\n{% for c in result.campaigns %}  - {{ c.settings.title }} [{{ c.status }}] ({{ c.id }}) — {{ c.emails_sent }} sent\n{% endfor %}"
+  }
+}
+
+command "get_campaign" {
+  title       = "Get campaign"
+  summary     = "Get details for a specific campaign"
+  description = "Retrieve detailed information about a campaign including settings, recipients, and send stats."
+  categories  = ["campaigns"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["mailchimp.api_key"]
+  }
+
+  param "dc" {
+    type        = "string"
+    required    = true
+    description = "Datacenter slug from your API key (e.g. 'us6')"
+  }
+
+  param "campaign_id" {
+    type        = "string"
+    required    = true
+    description = "Campaign ID"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://{{ args.dc }}.api.mailchimp.com/3.0/campaigns/{{ args.campaign_id }}"
+
+    auth {
+      kind            = "basic"
+      username        = "anystring"
+      password_secret = "mailchimp.api_key"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Campaign: {{ result.settings.title }}\nSubject: {{ result.settings.subject_line }}\nStatus: {{ result.status }}\nType: {{ result.type }}\nList: {{ result.recipients.list_name }} ({{ result.recipients.list_id }})\nEmails sent: {{ result.emails_sent }}\nSend time: {{ result.send_time }}"
+  }
+}
+
+command "create_campaign" {
+  title       = "Create campaign"
+  summary     = "Create a new email campaign"
+  description = "Create a new campaign targeting a specific audience. After creating, set content and then send."
+  categories  = ["campaigns"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["mailchimp.api_key"]
+  }
+
+  param "dc" {
+    type        = "string"
+    required    = true
+    description = "Datacenter slug from your API key (e.g. 'us6')"
+  }
+
+  param "type" {
+    type        = "string"
+    required    = true
+    description = "Campaign type: regular, plaintext, rss, variate, or absplit"
+  }
+
+  param "list_id" {
+    type        = "string"
+    required    = true
+    description = "Audience/list ID to send to"
+  }
+
+  param "subject_line" {
+    type        = "string"
+    required    = false
+    default     = ""
+    description = "Email subject line"
+  }
+
+  param "title" {
+    type        = "string"
+    required    = false
+    default     = ""
+    description = "Internal campaign title"
+  }
+
+  param "from_name" {
+    type        = "string"
+    required    = false
+    default     = ""
+    description = "From name for the campaign"
+  }
+
+  param "reply_to" {
+    type        = "string"
+    required    = false
+    default     = ""
+    description = "Reply-to email address"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "POST"
+    url      = "https://{{ args.dc }}.api.mailchimp.com/3.0/campaigns"
+
+    auth {
+      kind            = "basic"
+      username        = "anystring"
+      password_secret = "mailchimp.api_key"
+    }
+
+    body {
+      kind = "json"
+      value = {
+        type = "{{ args.type }}"
+        recipients = {
+          list_id = "{{ args.list_id }}"
+        }
+        settings = {
+          subject_line = "{{ args.subject_line }}"
+          title        = "{{ args.title }}"
+          from_name    = "{{ args.from_name }}"
+          reply_to     = "{{ args.reply_to }}"
+        }
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Created campaign {{ result.id }}\nTitle: {{ result.settings.title }}\nStatus: {{ result.status }}"
+  }
+}
+
+command "send_campaign" {
+  title       = "Send campaign"
+  summary     = "Send an email campaign"
+  description = "Send a campaign immediately. The campaign must have content set before sending."
+  categories  = ["campaigns"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["mailchimp.api_key"]
+  }
+
+  param "dc" {
+    type        = "string"
+    required    = true
+    description = "Datacenter slug from your API key (e.g. 'us6')"
+  }
+
+  param "campaign_id" {
+    type        = "string"
+    required    = true
+    description = "Campaign ID to send"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "POST"
+    url      = "https://{{ args.dc }}.api.mailchimp.com/3.0/campaigns/{{ args.campaign_id }}/actions/send"
+
+    auth {
+      kind            = "basic"
+      username        = "anystring"
+      password_secret = "mailchimp.api_key"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Campaign {{ args.campaign_id }} has been sent."
+  }
+}
+
+command "send_test_email" {
+  title       = "Send test email"
+  summary     = "Send a test email for a campaign"
+  description = "Send a test version of a campaign to specified email addresses before sending to the full audience."
+  categories  = ["campaigns"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["mailchimp.api_key"]
+  }
+
+  param "dc" {
+    type        = "string"
+    required    = true
+    description = "Datacenter slug from your API key (e.g. 'us6')"
+  }
+
+  param "campaign_id" {
+    type        = "string"
+    required    = true
+    description = "Campaign ID to test"
+  }
+
+  param "test_emails" {
+    type        = "array"
+    required    = true
+    description = "List of email addresses to send the test to"
+  }
+
+  param "send_type" {
+    type        = "string"
+    required    = true
+    description = "Type of test email to send: html or plaintext"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "POST"
+    url      = "https://{{ args.dc }}.api.mailchimp.com/3.0/campaigns/{{ args.campaign_id }}/actions/test"
+
+    auth {
+      kind            = "basic"
+      username        = "anystring"
+      password_secret = "mailchimp.api_key"
+    }
+
+    body {
+      kind = "json"
+      value = {
+        test_emails = "{{ args.test_emails }}"
+        send_type   = "{{ args.send_type }}"
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Test email sent for campaign {{ args.campaign_id }}"
+  }
+}
+
+command "list_templates" {
+  title       = "List templates"
+  summary     = "List email templates"
+  description = "Retrieve email templates in your account. Supports filtering by type and pagination."
+  categories  = ["templates"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["mailchimp.api_key"]
+  }
+
+  param "dc" {
+    type        = "string"
+    required    = true
+    description = "Datacenter slug from your API key (e.g. 'us6')"
+  }
+
+  param "count" {
+    type        = "integer"
+    required    = false
+    default     = 10
+    description = "Number of results to return"
+  }
+
+  param "offset" {
+    type        = "integer"
+    required    = false
+    default     = 0
+    description = "Pagination offset"
+  }
+
+  param "type" {
+    type        = "string"
+    required    = false
+    description = "Filter by type: user, base, or gallery"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://{{ args.dc }}.api.mailchimp.com/3.0/templates"
+
+    auth {
+      kind            = "basic"
+      username        = "anystring"
+      password_secret = "mailchimp.api_key"
+    }
+
+    query = {
+      count  = "{{ args.count }}"
+      offset = "{{ args.offset }}"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Found {{ result.total_items }} templates:\n{% for t in result.templates %}  - {{ t.name }} ({{ t.id }}) [{{ t.type }}] — edited {{ t.date_edited }}\n{% endfor %}"
+  }
+}
+
+command "delete_campaign" {
+  title       = "Delete campaign"
+  summary     = "Delete a campaign"
+  description = "Permanently delete a campaign. This cannot be undone."
+  categories  = ["campaigns"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["mailchimp.api_key"]
+  }
+
+  param "dc" {
+    type        = "string"
+    required    = true
+    description = "Datacenter slug from your API key (e.g. 'us6')"
+  }
+
+  param "campaign_id" {
+    type        = "string"
+    required    = true
+    description = "Campaign ID to delete"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "DELETE"
+    url      = "https://{{ args.dc }}.api.mailchimp.com/3.0/campaigns/{{ args.campaign_id }}"
+
+    auth {
+      kind            = "basic"
+      username        = "anystring"
+      password_secret = "mailchimp.api_key"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Campaign {{ args.campaign_id }} deleted."
+  }
+}

--- a/examples/notion.hcl
+++ b/examples/notion.hcl
@@ -1,0 +1,592 @@
+version = 1
+provider = "notion"
+categories = ["productivity", "knowledge-management"]
+
+command "search" {
+  title       = "Search"
+  summary     = "Search pages and databases by title"
+  description = "Search across all pages and databases accessible to the integration. Matches against titles only, not page content."
+  categories  = ["search"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["notion.token"]
+  }
+
+  param "query" {
+    type        = "string"
+    required    = false
+    default     = ""
+    description = "Text to match against page and database titles"
+  }
+
+  param "page_size" {
+    type        = "integer"
+    required    = false
+    default     = 10
+    description = "Number of results per page (max 100)"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "POST"
+    url      = "https://api.notion.com/v1/search"
+
+    auth {
+      kind   = "bearer"
+      secret = "notion.token"
+    }
+
+    headers = {
+      Notion-Version = "2022-06-28"
+    }
+
+    body {
+      kind = "json"
+      value = {
+        query     = "{{ args.query }}"
+        page_size = "{{ args.page_size }}"
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Found {{ result.results | length }} results."
+  }
+}
+
+command "query_database" {
+  title       = "Query database"
+  summary     = "Query a database with optional filters and sorts"
+  description = "Retrieve pages from a Notion database, optionally filtered and sorted."
+  categories  = ["databases"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["notion.token"]
+  }
+
+  param "database_id" {
+    type        = "string"
+    required    = true
+    description = "UUID of the database to query"
+  }
+
+  param "page_size" {
+    type        = "integer"
+    required    = false
+    default     = 10
+    description = "Number of results per page (max 100)"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "POST"
+    url      = "https://api.notion.com/v1/databases/{{ args.database_id }}/query"
+
+    auth {
+      kind   = "bearer"
+      secret = "notion.token"
+    }
+
+    headers = {
+      Notion-Version = "2022-06-28"
+    }
+
+    body {
+      kind = "json"
+      value = {
+        page_size = "{{ args.page_size }}"
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Database query returned {{ result.results | length }} pages."
+  }
+}
+
+command "get_database" {
+  title       = "Get database"
+  summary     = "Retrieve a database by ID"
+  description = "Fetch metadata and schema for a Notion database including its properties."
+  categories  = ["databases"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["notion.token"]
+  }
+
+  param "database_id" {
+    type        = "string"
+    required    = true
+    description = "UUID of the database"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://api.notion.com/v1/databases/{{ args.database_id }}"
+
+    auth {
+      kind   = "bearer"
+      secret = "notion.token"
+    }
+
+    headers = {
+      Notion-Version = "2022-06-28"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Database: {{ result.id }} — Created: {{ result.created_time }}, Last edited: {{ result.last_edited_time }}"
+  }
+}
+
+command "create_page" {
+  title       = "Create page"
+  summary     = "Create a new page in a database or as a child of another page"
+  description = "Create a Notion page. Specify a parent database or page, properties, and optional content blocks."
+  categories  = ["pages"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["notion.token"]
+  }
+
+  param "parent" {
+    type        = "object"
+    required    = true
+    description = "Parent object, e.g. {\"database_id\": \"...\"} or {\"page_id\": \"...\"}"
+  }
+
+  param "properties" {
+    type        = "object"
+    required    = true
+    description = "Page properties matching the parent database schema or a title property"
+  }
+
+  param "children" {
+    type        = "array"
+    required    = false
+    description = "Array of block objects for page content (max 100)"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "POST"
+    url      = "https://api.notion.com/v1/pages"
+
+    auth {
+      kind   = "bearer"
+      secret = "notion.token"
+    }
+
+    headers = {
+      Notion-Version = "2022-06-28"
+    }
+
+    body {
+      kind = "json"
+      value = {
+        parent     = "{{ args.parent }}"
+        properties = "{{ args.properties }}"
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Created page: {{ result.id }} — {{ result.url }}"
+  }
+}
+
+command "get_page" {
+  title       = "Get page"
+  summary     = "Retrieve a page by ID"
+  description = "Fetch metadata and properties for a Notion page."
+  categories  = ["pages"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["notion.token"]
+  }
+
+  param "page_id" {
+    type        = "string"
+    required    = true
+    description = "UUID of the page"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://api.notion.com/v1/pages/{{ args.page_id }}"
+
+    auth {
+      kind   = "bearer"
+      secret = "notion.token"
+    }
+
+    headers = {
+      Notion-Version = "2022-06-28"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Page: {{ result.id }} — Created: {{ result.created_time }}, Last edited: {{ result.last_edited_time }}, Archived: {{ result.archived }}, URL: {{ result.url }}"
+  }
+}
+
+command "update_page" {
+  title       = "Update page"
+  summary     = "Update properties or archive a page"
+  description = "Update a Notion page's properties, icon, cover, or archive status."
+  categories  = ["pages"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["notion.token"]
+  }
+
+  param "page_id" {
+    type        = "string"
+    required    = true
+    description = "UUID of the page to update"
+  }
+
+  param "properties" {
+    type        = "object"
+    required    = false
+    description = "Property values to update"
+  }
+
+  param "archived" {
+    type        = "boolean"
+    required    = false
+    description = "Set to true to archive the page, false to unarchive"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "PATCH"
+    url      = "https://api.notion.com/v1/pages/{{ args.page_id }}"
+
+    auth {
+      kind   = "bearer"
+      secret = "notion.token"
+    }
+
+    headers = {
+      Notion-Version = "2022-06-28"
+    }
+
+    body {
+      kind = "json"
+      value = {
+        properties = "{{ args.properties }}"
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Updated page: {{ result.id }} — Last edited: {{ result.last_edited_time }}, URL: {{ result.url }}"
+  }
+}
+
+command "get_block_children" {
+  title       = "Get block children"
+  summary     = "Retrieve child blocks of a block or page"
+  description = "List the child blocks of a given block or page. Use this to read page content."
+  categories  = ["blocks"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["notion.token"]
+  }
+
+  param "block_id" {
+    type        = "string"
+    required    = true
+    description = "UUID of the block or page"
+  }
+
+  param "page_size" {
+    type        = "integer"
+    required    = false
+    default     = 100
+    description = "Number of blocks to return (max 100)"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://api.notion.com/v1/blocks/{{ args.block_id }}/children"
+
+    auth {
+      kind   = "bearer"
+      secret = "notion.token"
+    }
+
+    query = {
+      page_size = "{{ args.page_size }}"
+    }
+
+    headers = {
+      Notion-Version = "2022-06-28"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "{{ result.results | length }} child blocks returned."
+  }
+}
+
+command "append_blocks" {
+  title       = "Append blocks"
+  summary     = "Append content blocks to a page or block"
+  description = "Append child blocks to a parent block or page. Use this to add content to a page."
+  categories  = ["blocks"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["notion.token"]
+  }
+
+  param "block_id" {
+    type        = "string"
+    required    = true
+    description = "UUID of the parent block or page"
+  }
+
+  param "children" {
+    type        = "array"
+    required    = true
+    description = "Array of block objects to append (max 100)"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "PATCH"
+    url      = "https://api.notion.com/v1/blocks/{{ args.block_id }}/children"
+
+    auth {
+      kind   = "bearer"
+      secret = "notion.token"
+    }
+
+    headers = {
+      Notion-Version = "2022-06-28"
+    }
+
+    body {
+      kind = "json"
+      value = {
+        children = "{{ args.children }}"
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Appended {{ result.results | length }} blocks."
+  }
+}
+
+command "delete_block" {
+  title       = "Delete block"
+  summary     = "Delete a block by ID"
+  description = "Delete (archive) a block. This also deletes all child blocks."
+  categories  = ["blocks"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["notion.token"]
+  }
+
+  param "block_id" {
+    type        = "string"
+    required    = true
+    description = "UUID of the block to delete"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "DELETE"
+    url      = "https://api.notion.com/v1/blocks/{{ args.block_id }}"
+
+    auth {
+      kind   = "bearer"
+      secret = "notion.token"
+    }
+
+    headers = {
+      Notion-Version = "2022-06-28"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Deleted block: {{ result.id }} (type: {{ result.type }})"
+  }
+}
+
+command "list_users" {
+  title       = "List users"
+  summary     = "List all users in the workspace"
+  description = "Retrieve all users (people and bots) in the Notion workspace."
+  categories  = ["users"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["notion.token"]
+  }
+
+  param "page_size" {
+    type        = "integer"
+    required    = false
+    default     = 100
+    description = "Number of users to return (max 100)"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://api.notion.com/v1/users"
+
+    auth {
+      kind   = "bearer"
+      secret = "notion.token"
+    }
+
+    query = {
+      page_size = "{{ args.page_size }}"
+    }
+
+    headers = {
+      Notion-Version = "2022-06-28"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "{{ result.results | length }} users returned."
+  }
+}
+
+command "create_comment" {
+  title       = "Create comment"
+  summary     = "Add a comment to a page"
+  description = "Create a new comment on a Notion page."
+  categories  = ["comments"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["notion.token"]
+  }
+
+  param "page_id" {
+    type        = "string"
+    required    = true
+    description = "UUID of the page to comment on"
+  }
+
+  param "text" {
+    type        = "string"
+    required    = true
+    description = "Plain text content of the comment"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "POST"
+    url      = "https://api.notion.com/v1/comments"
+
+    auth {
+      kind   = "bearer"
+      secret = "notion.token"
+    }
+
+    headers = {
+      Notion-Version = "2022-06-28"
+    }
+
+    body {
+      kind = "json"
+      value = {
+        parent = {
+          page_id = "{{ args.page_id }}"
+        }
+        rich_text = [
+          {
+            type = "text"
+            text = {
+              content = "{{ args.text }}"
+            }
+          }
+        ]
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Created comment: {{ result.id }} in discussion {{ result.discussion_id }}"
+  }
+}
+
+command "list_comments" {
+  title       = "List comments"
+  summary     = "List comments on a page or block"
+  description = "Retrieve all comments on a Notion page or block."
+  categories  = ["comments"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["notion.token"]
+  }
+
+  param "block_id" {
+    type        = "string"
+    required    = true
+    description = "UUID of the page or block to list comments for"
+  }
+
+  param "page_size" {
+    type        = "integer"
+    required    = false
+    default     = 100
+    description = "Number of comments to return (max 100)"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://api.notion.com/v1/comments"
+
+    auth {
+      kind   = "bearer"
+      secret = "notion.token"
+    }
+
+    query = {
+      block_id  = "{{ args.block_id }}"
+      page_size = "{{ args.page_size }}"
+    }
+
+    headers = {
+      Notion-Version = "2022-06-28"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "{{ result.results | length }} comments returned."
+  }
+}

--- a/examples/openai.hcl
+++ b/examples/openai.hcl
@@ -1,0 +1,523 @@
+version = 1
+provider = "openai"
+categories = ["ai", "llm", "machine-learning"]
+
+command "create_chat_completion" {
+  title       = "Create chat completion"
+  summary     = "Generate a chat completion using an OpenAI model"
+  description = "Send a conversation to an OpenAI model and receive a generated response. Supports GPT-4o, GPT-4.1, o3, o4-mini, and other chat models."
+  categories  = ["chat", "completions"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["openai.api_key"]
+  }
+
+  param "model" {
+    type        = "string"
+    required    = true
+    description = "Model ID (e.g. gpt-4o, gpt-4o-mini, gpt-4.1, o3, o4-mini)"
+  }
+
+  param "system_prompt" {
+    type        = "string"
+    required    = false
+    default     = ""
+    description = "System message to set the assistant's behavior"
+  }
+
+  param "message" {
+    type        = "string"
+    required    = true
+    description = "User message content"
+  }
+
+  param "temperature" {
+    type        = "number"
+    required    = false
+    default     = 1
+    description = "Sampling temperature (0-2)"
+  }
+
+  param "max_completion_tokens" {
+    type        = "integer"
+    required    = false
+    description = "Maximum number of tokens to generate"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "POST"
+    url      = "https://api.openai.com/v1/chat/completions"
+
+    auth {
+      kind   = "bearer"
+      secret = "openai.api_key"
+    }
+
+    headers = {
+      Content-Type = "application/json"
+    }
+
+    body {
+      kind = "json"
+      value = {
+        model    = "{{ args.model }}"
+        messages = [
+          {
+            role    = "system"
+            content = "{{ args.system_prompt }}"
+          },
+          {
+            role    = "user"
+            content = "{{ args.message }}"
+          }
+        ]
+        temperature          = "{{ args.temperature }}"
+        max_completion_tokens = "{{ args.max_completion_tokens }}"
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Model: {{ result.model }}\nResponse: {{ result.choices[0].message.content }}\nFinish reason: {{ result.choices[0].finish_reason }}\nTokens: {{ result.usage.prompt_tokens }} prompt + {{ result.usage.completion_tokens }} completion = {{ result.usage.total_tokens }} total"
+  }
+}
+
+command "list_models" {
+  title       = "List models"
+  summary     = "List all available OpenAI models"
+  description = "Retrieve a list of all models currently available through the OpenAI API."
+  categories  = ["models"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["openai.api_key"]
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://api.openai.com/v1/models"
+
+    auth {
+      kind   = "bearer"
+      secret = "openai.api_key"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "{% for model in result.data %}- {{ model.id }} (owned by {{ model.owned_by }})\n{% endfor %}"
+  }
+}
+
+command "get_model" {
+  title       = "Get model"
+  summary     = "Retrieve details about a specific model"
+  description = "Fetch metadata for a specific OpenAI model by its ID."
+  categories  = ["models"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["openai.api_key"]
+  }
+
+  param "model" {
+    type        = "string"
+    required    = true
+    description = "Model ID (e.g. gpt-4o, gpt-4.1)"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://api.openai.com/v1/models/{{ args.model }}"
+
+    auth {
+      kind   = "bearer"
+      secret = "openai.api_key"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Model: {{ result.id }}\nOwner: {{ result.owned_by }}\nCreated: {{ result.created }}"
+  }
+}
+
+command "create_embedding" {
+  title       = "Create embedding"
+  summary     = "Generate vector embeddings for text input"
+  description = "Create vector embeddings for the given text input using an OpenAI embedding model."
+  categories  = ["embeddings"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["openai.api_key"]
+  }
+
+  param "model" {
+    type        = "string"
+    required    = false
+    default     = "text-embedding-3-small"
+    description = "Embedding model (text-embedding-3-small, text-embedding-3-large, text-embedding-ada-002)"
+  }
+
+  param "input" {
+    type        = "string"
+    required    = true
+    description = "Text to embed"
+  }
+
+  param "dimensions" {
+    type        = "integer"
+    required    = false
+    description = "Output vector dimensions (embedding-3 models only)"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "POST"
+    url      = "https://api.openai.com/v1/embeddings"
+
+    auth {
+      kind   = "bearer"
+      secret = "openai.api_key"
+    }
+
+    headers = {
+      Content-Type = "application/json"
+    }
+
+    body {
+      kind = "json"
+      value = {
+        model      = "{{ args.model }}"
+        input      = "{{ args.input }}"
+        dimensions = "{{ args.dimensions }}"
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Model: {{ result.model }}\nEmbeddings: {{ result.data | length }} vector(s)\nDimensions: {{ result.data[0].embedding | length }}\nTokens used: {{ result.usage.total_tokens }}"
+  }
+}
+
+command "create_image" {
+  title       = "Create image"
+  summary     = "Generate an image from a text prompt"
+  description = "Generate one or more images from a text description using DALL-E or GPT Image models."
+  categories  = ["images"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["openai.api_key"]
+  }
+
+  param "prompt" {
+    type        = "string"
+    required    = true
+    description = "Text description of the desired image"
+  }
+
+  param "model" {
+    type        = "string"
+    required    = false
+    default     = "gpt-image-1"
+    description = "Image model (gpt-image-1, dall-e-3, dall-e-2)"
+  }
+
+  param "size" {
+    type        = "string"
+    required    = false
+    default     = "1024x1024"
+    description = "Image dimensions (e.g. 1024x1024, 1792x1024, 1024x1792)"
+  }
+
+  param "quality" {
+    type        = "string"
+    required    = false
+    default     = "auto"
+    description = "Image quality (auto, low, medium, high for gpt-image; standard, hd for dall-e-3)"
+  }
+
+  param "n" {
+    type        = "integer"
+    required    = false
+    default     = 1
+    description = "Number of images to generate"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "POST"
+    url      = "https://api.openai.com/v1/images/generations"
+
+    auth {
+      kind   = "bearer"
+      secret = "openai.api_key"
+    }
+
+    headers = {
+      Content-Type = "application/json"
+    }
+
+    body {
+      kind = "json"
+      value = {
+        prompt  = "{{ args.prompt }}"
+        model   = "{{ args.model }}"
+        size    = "{{ args.size }}"
+        quality = "{{ args.quality }}"
+        n       = "{{ args.n }}"
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Generated {{ result.data | length }} image(s)\n{% for img in result.data %}{{ img.url }}\n{% endfor %}"
+  }
+}
+
+command "create_moderation" {
+  title       = "Create moderation"
+  summary     = "Check text for policy violations"
+  description = "Classify text content for potential policy violations using OpenAI's moderation endpoint. This endpoint is free to use."
+  categories  = ["moderation"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["openai.api_key"]
+  }
+
+  param "input" {
+    type        = "string"
+    required    = true
+    description = "Text content to classify"
+  }
+
+  param "model" {
+    type        = "string"
+    required    = false
+    default     = "omni-moderation-latest"
+    description = "Moderation model (omni-moderation-latest, text-moderation-latest)"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "POST"
+    url      = "https://api.openai.com/v1/moderations"
+
+    auth {
+      kind   = "bearer"
+      secret = "openai.api_key"
+    }
+
+    headers = {
+      Content-Type = "application/json"
+    }
+
+    body {
+      kind = "json"
+      value = {
+        input = "{{ args.input }}"
+        model = "{{ args.model }}"
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Flagged: {{ result.results[0].flagged }}\nModel: {{ result.model }}"
+  }
+}
+
+command "list_files" {
+  title       = "List files"
+  summary     = "List files uploaded to OpenAI"
+  description = "Retrieve a list of files that have been uploaded to the OpenAI API, optionally filtered by purpose."
+  categories  = ["files"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["openai.api_key"]
+  }
+
+  param "purpose" {
+    type        = "string"
+    required    = false
+    description = "Filter by purpose (assistants, batch, fine-tune, vision, user_data)"
+  }
+
+  param "limit" {
+    type        = "integer"
+    required    = false
+    default     = 20
+    description = "Maximum number of files to return"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://api.openai.com/v1/files"
+
+    auth {
+      kind   = "bearer"
+      secret = "openai.api_key"
+    }
+
+    query = {
+      purpose = "{{ args.purpose }}"
+      limit   = "{{ args.limit }}"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "{% for file in result.data %}- {{ file.id }}: {{ file.filename }} ({{ file.bytes }} bytes, purpose: {{ file.purpose }})\n{% endfor %}Total: {{ result.data | length }} file(s)"
+  }
+}
+
+command "delete_file" {
+  title       = "Delete file"
+  summary     = "Delete an uploaded file"
+  description = "Delete a file that was previously uploaded to the OpenAI API."
+  categories  = ["files"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["openai.api_key"]
+  }
+
+  param "file_id" {
+    type        = "string"
+    required    = true
+    description = "File ID to delete"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "DELETE"
+    url      = "https://api.openai.com/v1/files/{{ args.file_id }}"
+
+    auth {
+      kind   = "bearer"
+      secret = "openai.api_key"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Deleted: {{ result.id }} (success: {{ result.deleted }})"
+  }
+}
+
+command "create_fine_tuning_job" {
+  title       = "Create fine-tuning job"
+  summary     = "Start a model fine-tuning job"
+  description = "Create a fine-tuning job to customize a model with your training data."
+  categories  = ["fine-tuning"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["openai.api_key"]
+  }
+
+  param "model" {
+    type        = "string"
+    required    = true
+    description = "Base model to fine-tune (e.g. gpt-4o-mini-2024-07-18, gpt-4.1-2025-04-14)"
+  }
+
+  param "training_file" {
+    type        = "string"
+    required    = true
+    description = "File ID of the uploaded JSONL training data"
+  }
+
+  param "validation_file" {
+    type        = "string"
+    required    = false
+    description = "File ID for validation data"
+  }
+
+  param "suffix" {
+    type        = "string"
+    required    = false
+    description = "Custom suffix for the fine-tuned model name (max 64 chars)"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "POST"
+    url      = "https://api.openai.com/v1/fine_tuning/jobs"
+
+    auth {
+      kind   = "bearer"
+      secret = "openai.api_key"
+    }
+
+    headers = {
+      Content-Type = "application/json"
+    }
+
+    body {
+      kind = "json"
+      value = {
+        model           = "{{ args.model }}"
+        training_file   = "{{ args.training_file }}"
+        validation_file = "{{ args.validation_file }}"
+        suffix          = "{{ args.suffix }}"
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Job: {{ result.id }}\nStatus: {{ result.status }}\nModel: {{ result.model }}\nTraining file: {{ result.training_file }}"
+  }
+}
+
+command "list_fine_tuning_jobs" {
+  title       = "List fine-tuning jobs"
+  summary     = "List all fine-tuning jobs"
+  description = "Retrieve a list of fine-tuning jobs for your organization."
+  categories  = ["fine-tuning"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["openai.api_key"]
+  }
+
+  param "limit" {
+    type        = "integer"
+    required    = false
+    default     = 20
+    description = "Maximum number of jobs to return (1-100)"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://api.openai.com/v1/fine_tuning/jobs"
+
+    auth {
+      kind   = "bearer"
+      secret = "openai.api_key"
+    }
+
+    query = {
+      limit = "{{ args.limit }}"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "{% for job in result.data %}- {{ job.id }}: {{ job.model }} ({{ job.status }})\n{% endfor %}"
+  }
+}

--- a/examples/pagerduty.hcl
+++ b/examples/pagerduty.hcl
@@ -1,0 +1,865 @@
+version = 1
+provider = "pagerduty"
+categories = ["incident-management", "on-call", "monitoring"]
+
+command "list_incidents" {
+  title       = "List Incidents"
+  summary     = "List and filter PagerDuty incidents"
+  description = "Retrieve incidents sorted by creation date. Set your pagerduty.api_key secret to 'Token token=YOUR_API_KEY'."
+  categories  = ["incidents"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["pagerduty.api_key"]
+  }
+
+  param "date_range" {
+    type        = "string"
+    required    = false
+    default     = "all"
+    description = "Set to 'all' for all incidents or omit for last 6 months"
+  }
+
+  param "sort_by" {
+    type        = "string"
+    required    = false
+    default     = "created_at:desc"
+    description = "Sort order: created_at:desc, created_at:asc, resolved_at:desc, resolved_at:asc"
+  }
+
+  param "limit" {
+    type        = "integer"
+    required    = false
+    default     = 25
+    description = "Max results per page (max 100)"
+  }
+
+  param "offset" {
+    type        = "integer"
+    required    = false
+    default     = 0
+    description = "Pagination offset"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://api.pagerduty.com/incidents"
+
+    auth {
+      kind     = "api_key"
+      location = "header"
+      name     = "Authorization"
+      secret   = "pagerduty.api_key"
+    }
+
+    query = {
+      date_range = "{{ args.date_range }}"
+      sort_by    = "{{ args.sort_by }}"
+      limit      = "{{ args.limit }}"
+      offset     = "{{ args.offset }}"
+    }
+
+    headers = {
+      Accept = "application/vnd.pagerduty+json;version=2"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Found {{ result.incidents | length }} incidents.{% for i in result.incidents %}\n- [{{ i.status | upper }}] #{{ i.incident_number }}: {{ i.title }} ({{ i.service.summary }}){% endfor %}"
+  }
+}
+
+command "get_incident" {
+  title       = "Get Incident"
+  summary     = "Get details of a specific incident"
+  description = "Retrieve full details of a PagerDuty incident by its ID."
+  categories  = ["incidents"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["pagerduty.api_key"]
+  }
+
+  param "id" {
+    type        = "string"
+    required    = true
+    description = "Incident ID (e.g. PABC123)"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://api.pagerduty.com/incidents/{{ args.id }}"
+
+    auth {
+      kind     = "api_key"
+      location = "header"
+      name     = "Authorization"
+      secret   = "pagerduty.api_key"
+    }
+
+    headers = {
+      Accept = "application/vnd.pagerduty+json;version=2"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Incident #{{ result.incident.incident_number }}: {{ result.incident.title }}\nStatus: {{ result.incident.status }} | Urgency: {{ result.incident.urgency }}\nService: {{ result.incident.service.summary }}\nEscalation Policy: {{ result.incident.escalation_policy.summary }}\nCreated: {{ result.incident.created_at }}\nURL: {{ result.incident.html_url }}"
+  }
+}
+
+command "create_incident" {
+  title       = "Create Incident"
+  summary     = "Create a new PagerDuty incident"
+  description = "Create an incident on a specified service. Requires your PagerDuty user email in the from_email parameter."
+  categories  = ["incidents"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["pagerduty.api_key"]
+  }
+
+  param "title" {
+    type        = "string"
+    required    = true
+    description = "Incident title"
+  }
+
+  param "service_id" {
+    type        = "string"
+    required    = true
+    description = "ID of the service to create the incident on"
+  }
+
+  param "from_email" {
+    type        = "string"
+    required    = true
+    description = "Email address of the PagerDuty user creating the incident"
+  }
+
+  param "urgency" {
+    type        = "string"
+    required    = false
+    default     = "high"
+    description = "Incident urgency: high or low"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "POST"
+    url      = "https://api.pagerduty.com/incidents"
+
+    auth {
+      kind     = "api_key"
+      location = "header"
+      name     = "Authorization"
+      secret   = "pagerduty.api_key"
+    }
+
+    headers = {
+      Accept = "application/vnd.pagerduty+json;version=2"
+      From   = "{{ args.from_email }}"
+    }
+
+    body {
+      kind = "json"
+      value = {
+        incident = {
+          type    = "incident"
+          title   = "{{ args.title }}"
+          urgency = "{{ args.urgency }}"
+          service = {
+            id   = "{{ args.service_id }}"
+            type = "service_reference"
+          }
+        }
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Created incident #{{ result.incident.incident_number }}: {{ result.incident.title }}\nID: {{ result.incident.id }} | Status: {{ result.incident.status }}\nService: {{ result.incident.service.summary }}\nURL: {{ result.incident.html_url }}"
+  }
+}
+
+command "update_incident" {
+  title       = "Update Incident"
+  summary     = "Acknowledge or resolve an incident"
+  description = "Update an incident's status to acknowledged or resolved."
+  categories  = ["incidents"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["pagerduty.api_key"]
+  }
+
+  param "id" {
+    type        = "string"
+    required    = true
+    description = "Incident ID"
+  }
+
+  param "status" {
+    type        = "string"
+    required    = true
+    description = "New status: acknowledged or resolved"
+  }
+
+  param "from_email" {
+    type        = "string"
+    required    = true
+    description = "Email address of the PagerDuty user making the update"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "PUT"
+    url      = "https://api.pagerduty.com/incidents/{{ args.id }}"
+
+    auth {
+      kind     = "api_key"
+      location = "header"
+      name     = "Authorization"
+      secret   = "pagerduty.api_key"
+    }
+
+    headers = {
+      Accept = "application/vnd.pagerduty+json;version=2"
+      From   = "{{ args.from_email }}"
+    }
+
+    body {
+      kind = "json"
+      value = {
+        incident = {
+          type   = "incident"
+          status = "{{ args.status }}"
+        }
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Updated incident #{{ result.incident.incident_number }}: {{ result.incident.title }}\nStatus: {{ result.incident.status }} | Urgency: {{ result.incident.urgency }}\nURL: {{ result.incident.html_url }}"
+  }
+}
+
+command "add_incident_note" {
+  title       = "Add Incident Note"
+  summary     = "Add a note to an incident"
+  description = "Post a note to the timeline of an existing incident."
+  categories  = ["incidents"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["pagerduty.api_key"]
+  }
+
+  param "id" {
+    type        = "string"
+    required    = true
+    description = "Incident ID"
+  }
+
+  param "content" {
+    type        = "string"
+    required    = true
+    description = "Note text"
+  }
+
+  param "from_email" {
+    type        = "string"
+    required    = true
+    description = "Email address of the PagerDuty user adding the note"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "POST"
+    url      = "https://api.pagerduty.com/incidents/{{ args.id }}/notes"
+
+    auth {
+      kind     = "api_key"
+      location = "header"
+      name     = "Authorization"
+      secret   = "pagerduty.api_key"
+    }
+
+    headers = {
+      Accept = "application/vnd.pagerduty+json;version=2"
+      From   = "{{ args.from_email }}"
+    }
+
+    body {
+      kind = "json"
+      value = {
+        note = {
+          content = "{{ args.content }}"
+        }
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Added note to incident {{ args.id }}\nBy: {{ result.note.user.summary }} at {{ result.note.created_at }}"
+  }
+}
+
+command "list_incident_alerts" {
+  title       = "List Incident Alerts"
+  summary     = "List alerts grouped under an incident"
+  description = "Retrieve alerts associated with a specific incident."
+  categories  = ["incidents"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["pagerduty.api_key"]
+  }
+
+  param "id" {
+    type        = "string"
+    required    = true
+    description = "Incident ID"
+  }
+
+  param "limit" {
+    type        = "integer"
+    required    = false
+    default     = 25
+    description = "Max results per page (max 100)"
+  }
+
+  param "offset" {
+    type        = "integer"
+    required    = false
+    default     = 0
+    description = "Pagination offset"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://api.pagerduty.com/incidents/{{ args.id }}/alerts"
+
+    auth {
+      kind     = "api_key"
+      location = "header"
+      name     = "Authorization"
+      secret   = "pagerduty.api_key"
+    }
+
+    query = {
+      limit  = "{{ args.limit }}"
+      offset = "{{ args.offset }}"
+    }
+
+    headers = {
+      Accept = "application/vnd.pagerduty+json;version=2"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Found {{ result.alerts | length }} alerts for incident {{ args.id }}.{% for a in result.alerts %}\n- [{{ a.status | upper }}] {{ a.summary }} (severity: {{ a.severity }}){% endfor %}"
+  }
+}
+
+command "list_incident_notes" {
+  title       = "List Incident Notes"
+  summary     = "List notes on an incident"
+  description = "Retrieve all notes posted to an incident's timeline."
+  categories  = ["incidents"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["pagerduty.api_key"]
+  }
+
+  param "id" {
+    type        = "string"
+    required    = true
+    description = "Incident ID"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://api.pagerduty.com/incidents/{{ args.id }}/notes"
+
+    auth {
+      kind     = "api_key"
+      location = "header"
+      name     = "Authorization"
+      secret   = "pagerduty.api_key"
+    }
+
+    headers = {
+      Accept = "application/vnd.pagerduty+json;version=2"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "{{ result.notes | length }} notes for incident {{ args.id }}.{% for n in result.notes %}\n- [{{ n.created_at }}] {{ n.user.summary }}: {{ n.content }}{% endfor %}"
+  }
+}
+
+command "list_services" {
+  title       = "List Services"
+  summary     = "List PagerDuty services"
+  description = "Retrieve services, optionally filtered by name."
+  categories  = ["services"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["pagerduty.api_key"]
+  }
+
+  param "query" {
+    type        = "string"
+    required    = false
+    default     = ""
+    description = "Filter by service name"
+  }
+
+  param "limit" {
+    type        = "integer"
+    required    = false
+    default     = 25
+    description = "Max results per page (max 100)"
+  }
+
+  param "offset" {
+    type        = "integer"
+    required    = false
+    default     = 0
+    description = "Pagination offset"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://api.pagerduty.com/services"
+
+    auth {
+      kind     = "api_key"
+      location = "header"
+      name     = "Authorization"
+      secret   = "pagerduty.api_key"
+    }
+
+    query = {
+      query  = "{{ args.query }}"
+      limit  = "{{ args.limit }}"
+      offset = "{{ args.offset }}"
+    }
+
+    headers = {
+      Accept = "application/vnd.pagerduty+json;version=2"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Found {{ result.services | length }} services.{% for s in result.services %}\n- [{{ s.status | upper }}] {{ s.name }} ({{ s.id }}) — {{ s.escalation_policy.summary }}{% endfor %}"
+  }
+}
+
+command "get_service" {
+  title       = "Get Service"
+  summary     = "Get details of a specific service"
+  description = "Retrieve full details of a PagerDuty service by its ID."
+  categories  = ["services"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["pagerduty.api_key"]
+  }
+
+  param "id" {
+    type        = "string"
+    required    = true
+    description = "Service ID"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://api.pagerduty.com/services/{{ args.id }}"
+
+    auth {
+      kind     = "api_key"
+      location = "header"
+      name     = "Authorization"
+      secret   = "pagerduty.api_key"
+    }
+
+    headers = {
+      Accept = "application/vnd.pagerduty+json;version=2"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Service: {{ result.service.name }} ({{ result.service.id }})\nStatus: {{ result.service.status }}\nDescription: {{ result.service.description }}\nEscalation Policy: {{ result.service.escalation_policy.summary }}\nAlert Creation: {{ result.service.alert_creation }}\nURL: {{ result.service.html_url }}"
+  }
+}
+
+command "list_users" {
+  title       = "List Users"
+  summary     = "List PagerDuty users"
+  description = "Retrieve users, optionally filtered by name or email."
+  categories  = ["users"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["pagerduty.api_key"]
+  }
+
+  param "query" {
+    type        = "string"
+    required    = false
+    default     = ""
+    description = "Filter by name or email"
+  }
+
+  param "limit" {
+    type        = "integer"
+    required    = false
+    default     = 25
+    description = "Max results per page (max 100)"
+  }
+
+  param "offset" {
+    type        = "integer"
+    required    = false
+    default     = 0
+    description = "Pagination offset"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://api.pagerduty.com/users"
+
+    auth {
+      kind     = "api_key"
+      location = "header"
+      name     = "Authorization"
+      secret   = "pagerduty.api_key"
+    }
+
+    query = {
+      query  = "{{ args.query }}"
+      limit  = "{{ args.limit }}"
+      offset = "{{ args.offset }}"
+    }
+
+    headers = {
+      Accept = "application/vnd.pagerduty+json;version=2"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Found {{ result.users | length }} users.{% for u in result.users %}\n- {{ u.name }} <{{ u.email }}> ({{ u.id }}) — {{ u.role }}{% endfor %}"
+  }
+}
+
+command "get_user" {
+  title       = "Get User"
+  summary     = "Get details of a specific user"
+  description = "Retrieve full details of a PagerDuty user by their ID."
+  categories  = ["users"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["pagerduty.api_key"]
+  }
+
+  param "id" {
+    type        = "string"
+    required    = true
+    description = "User ID"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://api.pagerduty.com/users/{{ args.id }}"
+
+    auth {
+      kind     = "api_key"
+      location = "header"
+      name     = "Authorization"
+      secret   = "pagerduty.api_key"
+    }
+
+    headers = {
+      Accept = "application/vnd.pagerduty+json;version=2"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "User: {{ result.user.name }} ({{ result.user.id }})\nEmail: {{ result.user.email }}\nRole: {{ result.user.role }}\nTimezone: {{ result.user.time_zone }}\nURL: {{ result.user.html_url }}"
+  }
+}
+
+command "list_oncalls" {
+  title       = "List On-Calls"
+  summary     = "List current on-call entries"
+  description = "Retrieve who is currently on-call, optionally filtered by schedule or escalation policy."
+  categories  = ["on-call"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["pagerduty.api_key"]
+  }
+
+  param "schedule_ids" {
+    type        = "string"
+    required    = false
+    default     = ""
+    description = "Comma-separated schedule IDs to filter by"
+  }
+
+  param "escalation_policy_ids" {
+    type        = "string"
+    required    = false
+    default     = ""
+    description = "Comma-separated escalation policy IDs to filter by"
+  }
+
+  param "limit" {
+    type        = "integer"
+    required    = false
+    default     = 25
+    description = "Max results per page (max 100)"
+  }
+
+  param "offset" {
+    type        = "integer"
+    required    = false
+    default     = 0
+    description = "Pagination offset"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://api.pagerduty.com/oncalls"
+
+    auth {
+      kind     = "api_key"
+      location = "header"
+      name     = "Authorization"
+      secret   = "pagerduty.api_key"
+    }
+
+    query = {
+      "schedule_ids[]"          = "{{ args.schedule_ids }}"
+      "escalation_policy_ids[]" = "{{ args.escalation_policy_ids }}"
+      limit                     = "{{ args.limit }}"
+      offset                    = "{{ args.offset }}"
+    }
+
+    headers = {
+      Accept = "application/vnd.pagerduty+json;version=2"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "{{ result.oncalls | length }} on-call entries.{% for o in result.oncalls %}\n- {{ o.user.summary }} — Level {{ o.escalation_level }}, Policy: {{ o.escalation_policy.summary }} ({{ o.start }} to {{ o.end }}){% endfor %}"
+  }
+}
+
+command "list_escalation_policies" {
+  title       = "List Escalation Policies"
+  summary     = "List PagerDuty escalation policies"
+  description = "Retrieve escalation policies, optionally filtered by name."
+  categories  = ["on-call"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["pagerduty.api_key"]
+  }
+
+  param "query" {
+    type        = "string"
+    required    = false
+    default     = ""
+    description = "Filter by policy name"
+  }
+
+  param "limit" {
+    type        = "integer"
+    required    = false
+    default     = 25
+    description = "Max results per page (max 100)"
+  }
+
+  param "offset" {
+    type        = "integer"
+    required    = false
+    default     = 0
+    description = "Pagination offset"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://api.pagerduty.com/escalation_policies"
+
+    auth {
+      kind     = "api_key"
+      location = "header"
+      name     = "Authorization"
+      secret   = "pagerduty.api_key"
+    }
+
+    query = {
+      query  = "{{ args.query }}"
+      limit  = "{{ args.limit }}"
+      offset = "{{ args.offset }}"
+    }
+
+    headers = {
+      Accept = "application/vnd.pagerduty+json;version=2"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Found {{ result.escalation_policies | length }} escalation policies.{% for ep in result.escalation_policies %}\n- {{ ep.name }} ({{ ep.id }}) — {{ ep.num_loops }} loops{% endfor %}"
+  }
+}
+
+command "list_schedules" {
+  title       = "List Schedules"
+  summary     = "List PagerDuty on-call schedules"
+  description = "Retrieve on-call schedules, optionally filtered by name."
+  categories  = ["on-call"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["pagerduty.api_key"]
+  }
+
+  param "query" {
+    type        = "string"
+    required    = false
+    default     = ""
+    description = "Filter by schedule name"
+  }
+
+  param "limit" {
+    type        = "integer"
+    required    = false
+    default     = 25
+    description = "Max results per page (max 100)"
+  }
+
+  param "offset" {
+    type        = "integer"
+    required    = false
+    default     = 0
+    description = "Pagination offset"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://api.pagerduty.com/schedules"
+
+    auth {
+      kind     = "api_key"
+      location = "header"
+      name     = "Authorization"
+      secret   = "pagerduty.api_key"
+    }
+
+    query = {
+      query  = "{{ args.query }}"
+      limit  = "{{ args.limit }}"
+      offset = "{{ args.offset }}"
+    }
+
+    headers = {
+      Accept = "application/vnd.pagerduty+json;version=2"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Found {{ result.schedules | length }} schedules.{% for s in result.schedules %}\n- {{ s.name }} ({{ s.id }}) — {{ s.time_zone }}{% endfor %}"
+  }
+}
+
+command "list_teams" {
+  title       = "List Teams"
+  summary     = "List PagerDuty teams"
+  description = "Retrieve teams, optionally filtered by name."
+  categories  = ["teams"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["pagerduty.api_key"]
+  }
+
+  param "query" {
+    type        = "string"
+    required    = false
+    default     = ""
+    description = "Filter by team name"
+  }
+
+  param "limit" {
+    type        = "integer"
+    required    = false
+    default     = 25
+    description = "Max results per page (max 100)"
+  }
+
+  param "offset" {
+    type        = "integer"
+    required    = false
+    default     = 0
+    description = "Pagination offset"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://api.pagerduty.com/teams"
+
+    auth {
+      kind     = "api_key"
+      location = "header"
+      name     = "Authorization"
+      secret   = "pagerduty.api_key"
+    }
+
+    query = {
+      query  = "{{ args.query }}"
+      limit  = "{{ args.limit }}"
+      offset = "{{ args.offset }}"
+    }
+
+    headers = {
+      Accept = "application/vnd.pagerduty+json;version=2"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Found {{ result.teams | length }} teams.{% for t in result.teams %}\n- {{ t.name }} ({{ t.id }}){% if t.description %} — {{ t.description }}{% endif %}{% endfor %}"
+  }
+}

--- a/examples/render.hcl
+++ b/examples/render.hcl
@@ -1,0 +1,720 @@
+version = 1
+provider = "render"
+categories = ["cloud", "hosting", "infrastructure"]
+
+command "list_services" {
+  title       = "List services"
+  summary     = "List all services in your Render account"
+  description = "List services with optional filters for name, type, region, and suspension status."
+  categories  = ["services"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["render.api_key"]
+  }
+
+  param "name" {
+    type        = "string"
+    required    = false
+    description = "Filter by service name"
+  }
+
+  param "type" {
+    type        = "string"
+    required    = false
+    description = "Filter by type (web_service, static_site, private_service, background_worker, cron_job)"
+  }
+
+  param "region" {
+    type        = "string"
+    required    = false
+    description = "Filter by region (oregon, frankfurt, singapore, ohio, virginia)"
+  }
+
+  param "suspended" {
+    type        = "string"
+    required    = false
+    description = "Filter by suspension status (suspended, not_suspended)"
+  }
+
+  param "limit" {
+    type        = "integer"
+    required    = false
+    default     = 20
+    description = "Max results to return (1-100)"
+  }
+
+  param "cursor" {
+    type        = "string"
+    required    = false
+    description = "Pagination cursor from a previous response"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://api.render.com/v1/services"
+
+    auth {
+      kind   = "bearer"
+      secret = "render.api_key"
+    }
+
+    query = {
+      name     = "{{ args.name }}"
+      type     = "{{ args.type }}"
+      region   = "{{ args.region }}"
+      suspended = "{{ args.suspended }}"
+      limit    = "{{ args.limit }}"
+      cursor   = "{{ args.cursor }}"
+    }
+
+    headers = {
+      Accept = "application/json"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Found {{ result | length }} service(s):\n{% for item in result %}\n- {{ item.service.name }} ({{ item.service.id }}) — {{ item.service.type }} / {{ item.service.serviceDetails.region }} — {{ item.service.suspended }}\n{% endfor %}"
+  }
+}
+
+command "get_service" {
+  title       = "Get service"
+  summary     = "Get details of a specific service"
+  description = "Retrieve full details for a Render service by its ID."
+  categories  = ["services"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["render.api_key"]
+  }
+
+  param "service_id" {
+    type        = "string"
+    required    = true
+    description = "Service ID (e.g. srv-...)"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://api.render.com/v1/services/{{ args.service_id }}"
+
+    auth {
+      kind   = "bearer"
+      secret = "render.api_key"
+    }
+
+    headers = {
+      Accept = "application/json"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Service: {{ result.name }} ({{ result.id }})\nType: {{ result.type }}\nRegion: {{ result.serviceDetails.region }}\nURL: {{ result.serviceDetails.url }}\nSuspended: {{ result.suspended }}\nAuto-deploy: {{ result.autoDeploy }}\nRepo: {{ result.repo }}\nBranch: {{ result.branch }}\nCreated: {{ result.createdAt }}\nUpdated: {{ result.updatedAt }}"
+  }
+}
+
+command "list_deploys" {
+  title       = "List deploys"
+  summary     = "List deploys for a service"
+  description = "List recent deploys for a Render service, showing status and commit info."
+  categories  = ["deploys"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["render.api_key"]
+  }
+
+  param "service_id" {
+    type        = "string"
+    required    = true
+    description = "Service ID"
+  }
+
+  param "limit" {
+    type        = "integer"
+    required    = false
+    default     = 20
+    description = "Max results to return (1-100)"
+  }
+
+  param "cursor" {
+    type        = "string"
+    required    = false
+    description = "Pagination cursor from a previous response"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://api.render.com/v1/services/{{ args.service_id }}/deploys"
+
+    auth {
+      kind   = "bearer"
+      secret = "render.api_key"
+    }
+
+    query = {
+      limit  = "{{ args.limit }}"
+      cursor = "{{ args.cursor }}"
+    }
+
+    headers = {
+      Accept = "application/json"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Deploys for {{ args.service_id }}:\n{% for item in result %}\n- {{ item.deploy.id }} — {{ item.deploy.status }} — commit {{ item.deploy.commit.id[:7] }} — {{ item.deploy.createdAt }}\n{% endfor %}"
+  }
+}
+
+command "get_deploy" {
+  title       = "Get deploy"
+  summary     = "Get details of a specific deploy"
+  description = "Retrieve full details for a deploy by service and deploy ID."
+  categories  = ["deploys"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["render.api_key"]
+  }
+
+  param "service_id" {
+    type        = "string"
+    required    = true
+    description = "Service ID"
+  }
+
+  param "deploy_id" {
+    type        = "string"
+    required    = true
+    description = "Deploy ID (e.g. dep-...)"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://api.render.com/v1/services/{{ args.service_id }}/deploys/{{ args.deploy_id }}"
+
+    auth {
+      kind   = "bearer"
+      secret = "render.api_key"
+    }
+
+    headers = {
+      Accept = "application/json"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Deploy: {{ result.id }}\nStatus: {{ result.status }}\nCommit: {{ result.commit.id }} — {{ result.commit.message }}\nCreated: {{ result.createdAt }}\nFinished: {{ result.finishedAt }}"
+  }
+}
+
+command "trigger_deploy" {
+  title       = "Trigger deploy"
+  summary     = "Trigger a new deploy for a service"
+  description = "Trigger a manual deploy for a Render service, optionally clearing the build cache or deploying a specific commit."
+  categories  = ["deploys"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["render.api_key"]
+  }
+
+  param "service_id" {
+    type        = "string"
+    required    = true
+    description = "Service ID"
+  }
+
+  param "clear_cache" {
+    type        = "string"
+    required    = false
+    default     = "do_not_clear"
+    description = "Whether to clear build cache (clear or do_not_clear)"
+  }
+
+  param "commit_id" {
+    type        = "string"
+    required    = false
+    description = "Specific git commit SHA to deploy"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "POST"
+    url      = "https://api.render.com/v1/services/{{ args.service_id }}/deploys"
+
+    auth {
+      kind   = "bearer"
+      secret = "render.api_key"
+    }
+
+    headers = {
+      Accept = "application/json"
+    }
+
+    body {
+      kind = "json"
+      value = {
+        clearCache = "{{ args.clear_cache }}"
+        commitId   = "{{ args.commit_id }}"
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Deploy triggered: {{ result.id }}\nStatus: {{ result.status }}"
+  }
+}
+
+command "rollback_deploy" {
+  title       = "Rollback deploy"
+  summary     = "Roll back a service to a previous deploy"
+  description = "Initiate a rollback of a service to a specific previous deploy."
+  categories  = ["deploys"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["render.api_key"]
+  }
+
+  param "service_id" {
+    type        = "string"
+    required    = true
+    description = "Service ID"
+  }
+
+  param "deploy_id" {
+    type        = "string"
+    required    = true
+    description = "Deploy ID to roll back to"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "POST"
+    url      = "https://api.render.com/v1/services/{{ args.service_id }}/rollback"
+
+    auth {
+      kind   = "bearer"
+      secret = "render.api_key"
+    }
+
+    headers = {
+      Accept = "application/json"
+    }
+
+    body {
+      kind = "json"
+      value = {
+        deployId = "{{ args.deploy_id }}"
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Rollback initiated: {{ result.id }}\nStatus: {{ result.status }}\nRolling back to deploy: {{ args.deploy_id }}"
+  }
+}
+
+command "list_env_vars" {
+  title       = "List environment variables"
+  summary     = "List environment variables for a service"
+  description = "Retrieve all environment variables configured on a Render service."
+  categories  = ["env"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["render.api_key"]
+  }
+
+  param "service_id" {
+    type        = "string"
+    required    = true
+    description = "Service ID"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://api.render.com/v1/services/{{ args.service_id }}/env-vars"
+
+    auth {
+      kind   = "bearer"
+      secret = "render.api_key"
+    }
+
+    headers = {
+      Accept = "application/json"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Environment variables for {{ args.service_id }}:\n{% for item in result %}\n- {{ item.envVar.key }} = {{ item.envVar.value }}\n{% endfor %}"
+  }
+}
+
+command "set_env_var" {
+  title       = "Set environment variable"
+  summary     = "Set an environment variable on a service"
+  description = "Create or update an environment variable on a Render service."
+  categories  = ["env"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["render.api_key"]
+  }
+
+  param "service_id" {
+    type        = "string"
+    required    = true
+    description = "Service ID"
+  }
+
+  param "key" {
+    type        = "string"
+    required    = true
+    description = "Environment variable name"
+  }
+
+  param "value" {
+    type        = "string"
+    required    = true
+    description = "Environment variable value"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "PUT"
+    url      = "https://api.render.com/v1/services/{{ args.service_id }}/env-vars/{{ args.key }}"
+
+    auth {
+      kind   = "bearer"
+      secret = "render.api_key"
+    }
+
+    headers = {
+      Accept = "application/json"
+    }
+
+    body {
+      kind = "json"
+      value = {
+        value = "{{ args.value }}"
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Set {{ result.envVar.key }} = {{ result.envVar.value }} on service {{ args.service_id }}"
+  }
+}
+
+command "restart_service" {
+  title       = "Restart service"
+  summary     = "Restart a running service"
+  description = "Restart a Render service without triggering a new build."
+  categories  = ["services"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["render.api_key"]
+  }
+
+  param "service_id" {
+    type        = "string"
+    required    = true
+    description = "Service ID"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "POST"
+    url      = "https://api.render.com/v1/services/{{ args.service_id }}/restart"
+
+    auth {
+      kind   = "bearer"
+      secret = "render.api_key"
+    }
+
+    headers = {
+      Accept = "application/json"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Service {{ args.service_id }} restart initiated."
+  }
+}
+
+command "suspend_service" {
+  title       = "Suspend service"
+  summary     = "Suspend a running service"
+  description = "Suspend a Render service, stopping it from running and incurring charges."
+  categories  = ["services"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["render.api_key"]
+  }
+
+  param "service_id" {
+    type        = "string"
+    required    = true
+    description = "Service ID"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "POST"
+    url      = "https://api.render.com/v1/services/{{ args.service_id }}/suspend"
+
+    auth {
+      kind   = "bearer"
+      secret = "render.api_key"
+    }
+
+    headers = {
+      Accept = "application/json"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Service {{ args.service_id }} suspended."
+  }
+}
+
+command "resume_service" {
+  title       = "Resume service"
+  summary     = "Resume a suspended service"
+  description = "Resume a previously suspended Render service."
+  categories  = ["services"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["render.api_key"]
+  }
+
+  param "service_id" {
+    type        = "string"
+    required    = true
+    description = "Service ID"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "POST"
+    url      = "https://api.render.com/v1/services/{{ args.service_id }}/resume"
+
+    auth {
+      kind   = "bearer"
+      secret = "render.api_key"
+    }
+
+    headers = {
+      Accept = "application/json"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Service {{ args.service_id }} resumed."
+  }
+}
+
+command "list_custom_domains" {
+  title       = "List custom domains"
+  summary     = "List custom domains for a service"
+  description = "List all custom domains configured on a Render service with verification status."
+  categories  = ["domains"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["render.api_key"]
+  }
+
+  param "service_id" {
+    type        = "string"
+    required    = true
+    description = "Service ID"
+  }
+
+  param "limit" {
+    type        = "integer"
+    required    = false
+    default     = 20
+    description = "Max results to return (1-100)"
+  }
+
+  param "cursor" {
+    type        = "string"
+    required    = false
+    description = "Pagination cursor from a previous response"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://api.render.com/v1/services/{{ args.service_id }}/custom-domains"
+
+    auth {
+      kind   = "bearer"
+      secret = "render.api_key"
+    }
+
+    query = {
+      limit  = "{{ args.limit }}"
+      cursor = "{{ args.cursor }}"
+    }
+
+    headers = {
+      Accept = "application/json"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Custom domains for {{ args.service_id }}:\n{% for item in result %}\n- {{ item.customDomain.name }} — {{ item.customDomain.domainType }} — {{ item.customDomain.verificationStatus }}\n{% endfor %}"
+  }
+}
+
+command "list_postgres" {
+  title       = "List Postgres instances"
+  summary     = "List all Postgres databases in your account"
+  description = "List Render-managed Postgres instances with their plan, region, and status."
+  categories  = ["databases"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["render.api_key"]
+  }
+
+  param "limit" {
+    type        = "integer"
+    required    = false
+    default     = 20
+    description = "Max results to return (1-100)"
+  }
+
+  param "cursor" {
+    type        = "string"
+    required    = false
+    description = "Pagination cursor from a previous response"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://api.render.com/v1/postgres"
+
+    auth {
+      kind   = "bearer"
+      secret = "render.api_key"
+    }
+
+    query = {
+      limit  = "{{ args.limit }}"
+      cursor = "{{ args.cursor }}"
+    }
+
+    headers = {
+      Accept = "application/json"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Postgres instances:\n{% for item in result %}\n- {{ item.postgres.name }} ({{ item.postgres.id }}) — {{ item.postgres.plan }} / {{ item.postgres.region }} — {{ item.postgres.status }}\n{% endfor %}"
+  }
+}
+
+command "get_postgres" {
+  title       = "Get Postgres instance"
+  summary     = "Get details of a Postgres database"
+  description = "Retrieve full details for a Render-managed Postgres instance by its ID."
+  categories  = ["databases"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["render.api_key"]
+  }
+
+  param "postgres_id" {
+    type        = "string"
+    required    = true
+    description = "Postgres instance ID (e.g. dpg-...)"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://api.render.com/v1/postgres/{{ args.postgres_id }}"
+
+    auth {
+      kind   = "bearer"
+      secret = "render.api_key"
+    }
+
+    headers = {
+      Accept = "application/json"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Postgres: {{ result.name }} ({{ result.id }})\nPlan: {{ result.plan }}\nRegion: {{ result.region }}\nStatus: {{ result.status }}\nVersion: {{ result.version }}\nCreated: {{ result.createdAt }}"
+  }
+}
+
+command "get_postgres_connection_info" {
+  title       = "Get Postgres connection info"
+  summary     = "Get connection strings for a Postgres database"
+  description = "Retrieve connection details including internal and external connection strings for a Render Postgres instance."
+  categories  = ["databases"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["render.api_key"]
+  }
+
+  param "postgres_id" {
+    type        = "string"
+    required    = true
+    description = "Postgres instance ID (e.g. dpg-...)"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://api.render.com/v1/postgres/{{ args.postgres_id }}/connection-info"
+
+    auth {
+      kind   = "bearer"
+      secret = "render.api_key"
+    }
+
+    headers = {
+      Accept = "application/json"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Connection info for {{ args.postgres_id }}:\nInternal URL: {{ result.internalConnectionString }}\nExternal URL: {{ result.externalConnectionString }}\nPSQL Command: {{ result.psqlCommand }}\nHost: {{ result.host }}\nPort: {{ result.port }}\nDatabase: {{ result.databaseName }}\nUser: {{ result.databaseUser }}"
+  }
+}

--- a/examples/resend.hcl
+++ b/examples/resend.hcl
@@ -1,0 +1,590 @@
+version = 1
+provider = "resend"
+categories = ["email", "communications"]
+
+command "send_email" {
+  title       = "Send email"
+  summary     = "Send an email via Resend"
+  description = "Send a transactional email with the specified sender, recipient, subject, and HTML body."
+  categories  = ["email"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["resend.api_key"]
+  }
+
+  param "from" {
+    type        = "string"
+    required    = true
+    description = "Sender email address (e.g. 'Name <email@domain.com>')"
+  }
+
+  param "to" {
+    type        = "string"
+    required    = true
+    description = "Recipient email address"
+  }
+
+  param "subject" {
+    type        = "string"
+    required    = true
+    description = "Email subject line"
+  }
+
+  param "html" {
+    type        = "string"
+    required    = true
+    description = "HTML body content"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "POST"
+    url      = "https://api.resend.com/emails"
+
+    auth {
+      kind   = "bearer"
+      secret = "resend.api_key"
+    }
+
+    body {
+      kind = "json"
+      value = {
+        from    = "{{ args.from }}"
+        to      = "{{ args.to }}"
+        subject = "{{ args.subject }}"
+        html    = "{{ args.html }}"
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Email sent: {{ result.id }}"
+  }
+}
+
+command "get_email" {
+  title       = "Get email"
+  summary     = "Retrieve details of a sent email"
+  description = "Fetch the full details and delivery status of a previously sent email by its ID."
+  categories  = ["email"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["resend.api_key"]
+  }
+
+  param "email_id" {
+    type        = "string"
+    required    = true
+    description = "The email ID to retrieve"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://api.resend.com/emails/{{ args.email_id }}"
+
+    auth {
+      kind   = "bearer"
+      secret = "resend.api_key"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Email {{ result.id }} — From: {{ result.from }}, Subject: {{ result.subject }}, Status: {{ result.last_event }}"
+  }
+}
+
+command "list_emails" {
+  title       = "List emails"
+  summary     = "List sent emails"
+  description = "Retrieve a paginated list of emails that have been sent."
+  categories  = ["email"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["resend.api_key"]
+  }
+
+  param "limit" {
+    type        = "integer"
+    required    = false
+    default     = 20
+    description = "Number of results to return (1-100)"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://api.resend.com/emails"
+
+    auth {
+      kind   = "bearer"
+      secret = "resend.api_key"
+    }
+
+    query = {
+      limit = "{{ args.limit }}"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "{{ result.data | length }} emails returned (has_more: {{ result.has_more }})"
+  }
+}
+
+command "cancel_email" {
+  title       = "Cancel email"
+  summary     = "Cancel a scheduled email"
+  description = "Cancel a previously scheduled email before it is sent."
+  categories  = ["email"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["resend.api_key"]
+  }
+
+  param "email_id" {
+    type        = "string"
+    required    = true
+    description = "The scheduled email ID to cancel"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "POST"
+    url      = "https://api.resend.com/emails/{{ args.email_id }}/cancel"
+
+    auth {
+      kind   = "bearer"
+      secret = "resend.api_key"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Cancelled email: {{ result.id }}"
+  }
+}
+
+command "list_domains" {
+  title       = "List domains"
+  summary     = "List all sending domains"
+  description = "Retrieve a paginated list of domains configured in your Resend account."
+  categories  = ["domains"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["resend.api_key"]
+  }
+
+  param "limit" {
+    type        = "integer"
+    required    = false
+    default     = 20
+    description = "Number of results to return (1-100)"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://api.resend.com/domains"
+
+    auth {
+      kind   = "bearer"
+      secret = "resend.api_key"
+    }
+
+    query = {
+      limit = "{{ args.limit }}"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "{{ result.data | length }} domains returned (has_more: {{ result.has_more }})"
+  }
+}
+
+command "get_domain" {
+  title       = "Get domain"
+  summary     = "Get details of a sending domain"
+  description = "Retrieve the full details, DNS records, and verification status of a domain."
+  categories  = ["domains"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["resend.api_key"]
+  }
+
+  param "domain_id" {
+    type        = "string"
+    required    = true
+    description = "The domain ID to retrieve"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://api.resend.com/domains/{{ args.domain_id }}"
+
+    auth {
+      kind   = "bearer"
+      secret = "resend.api_key"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Domain: {{ result.name }} ({{ result.id }}) — Status: {{ result.status }}, Region: {{ result.region }}"
+  }
+}
+
+command "create_domain" {
+  title       = "Create domain"
+  summary     = "Add a new sending domain"
+  description = "Register a new domain for sending emails through Resend."
+  categories  = ["domains"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["resend.api_key"]
+  }
+
+  param "name" {
+    type        = "string"
+    required    = true
+    description = "Domain name (e.g. 'example.com')"
+  }
+
+  param "region" {
+    type        = "string"
+    required    = false
+    default     = "us-east-1"
+    description = "Region: us-east-1, eu-west-1, sa-east-1, or ap-northeast-1"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "POST"
+    url      = "https://api.resend.com/domains"
+
+    auth {
+      kind   = "bearer"
+      secret = "resend.api_key"
+    }
+
+    body {
+      kind = "json"
+      value = {
+        name   = "{{ args.name }}"
+        region = "{{ args.region }}"
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Created domain: {{ result.name }} ({{ result.id }}) — Status: {{ result.status }}"
+  }
+}
+
+command "verify_domain" {
+  title       = "Verify domain"
+  summary     = "Trigger DNS verification for a domain"
+  description = "Initiate the DNS verification process for a domain to enable email sending."
+  categories  = ["domains"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["resend.api_key"]
+  }
+
+  param "domain_id" {
+    type        = "string"
+    required    = true
+    description = "The domain ID to verify"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "POST"
+    url      = "https://api.resend.com/domains/{{ args.domain_id }}/verify"
+
+    auth {
+      kind   = "bearer"
+      secret = "resend.api_key"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Verification initiated for domain: {{ result.id }}"
+  }
+}
+
+command "delete_domain" {
+  title       = "Delete domain"
+  summary     = "Remove a sending domain"
+  description = "Permanently delete a domain from your Resend account."
+  categories  = ["domains"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["resend.api_key"]
+  }
+
+  param "domain_id" {
+    type        = "string"
+    required    = true
+    description = "The domain ID to delete"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "DELETE"
+    url      = "https://api.resend.com/domains/{{ args.domain_id }}"
+
+    auth {
+      kind   = "bearer"
+      secret = "resend.api_key"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Deleted domain: {{ result.id }}"
+  }
+}
+
+command "list_contacts" {
+  title       = "List contacts"
+  summary     = "List all contacts"
+  description = "Retrieve a paginated list of contacts in your Resend account."
+  categories  = ["contacts"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["resend.api_key"]
+  }
+
+  param "limit" {
+    type        = "integer"
+    required    = false
+    default     = 20
+    description = "Number of results to return (1-100)"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://api.resend.com/contacts"
+
+    auth {
+      kind   = "bearer"
+      secret = "resend.api_key"
+    }
+
+    query = {
+      limit = "{{ args.limit }}"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "{{ result.data | length }} contacts returned (has_more: {{ result.has_more }})"
+  }
+}
+
+command "get_contact" {
+  title       = "Get contact"
+  summary     = "Retrieve a contact by ID"
+  description = "Fetch the full details of a contact by their ID or email address."
+  categories  = ["contacts"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["resend.api_key"]
+  }
+
+  param "contact_id" {
+    type        = "string"
+    required    = true
+    description = "Contact ID or email address"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://api.resend.com/contacts/{{ args.contact_id }}"
+
+    auth {
+      kind   = "bearer"
+      secret = "resend.api_key"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Contact: {{ result.email }} ({{ result.id }}) — {{ result.first_name }} {{ result.last_name }}, Unsubscribed: {{ result.unsubscribed }}"
+  }
+}
+
+command "create_contact" {
+  title       = "Create contact"
+  summary     = "Add a new contact"
+  description = "Create a new contact with an email address and optional name."
+  categories  = ["contacts"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["resend.api_key"]
+  }
+
+  param "email" {
+    type        = "string"
+    required    = true
+    description = "Contact email address"
+  }
+
+  param "first_name" {
+    type        = "string"
+    required    = false
+    default     = ""
+    description = "Contact first name"
+  }
+
+  param "last_name" {
+    type        = "string"
+    required    = false
+    default     = ""
+    description = "Contact last name"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "POST"
+    url      = "https://api.resend.com/contacts"
+
+    auth {
+      kind   = "bearer"
+      secret = "resend.api_key"
+    }
+
+    body {
+      kind = "json"
+      value = {
+        email      = "{{ args.email }}"
+        first_name = "{{ args.first_name }}"
+        last_name  = "{{ args.last_name }}"
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Created contact: {{ result.id }}"
+  }
+}
+
+command "update_contact" {
+  title       = "Update contact"
+  summary     = "Update an existing contact"
+  description = "Update the name or subscription status of a contact."
+  categories  = ["contacts"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["resend.api_key"]
+  }
+
+  param "contact_id" {
+    type        = "string"
+    required    = true
+    description = "Contact ID or email address"
+  }
+
+  param "first_name" {
+    type        = "string"
+    required    = false
+    default     = ""
+    description = "Updated first name"
+  }
+
+  param "last_name" {
+    type        = "string"
+    required    = false
+    default     = ""
+    description = "Updated last name"
+  }
+
+  param "unsubscribed" {
+    type        = "boolean"
+    required    = false
+    default     = false
+    description = "Set to true to unsubscribe from all broadcasts"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "PATCH"
+    url      = "https://api.resend.com/contacts/{{ args.contact_id }}"
+
+    auth {
+      kind   = "bearer"
+      secret = "resend.api_key"
+    }
+
+    body {
+      kind = "json"
+      value = {
+        first_name   = "{{ args.first_name }}"
+        last_name    = "{{ args.last_name }}"
+        unsubscribed = "{{ args.unsubscribed }}"
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Updated contact: {{ result.id }}"
+  }
+}
+
+command "delete_contact" {
+  title       = "Delete contact"
+  summary     = "Remove a contact"
+  description = "Permanently delete a contact by their ID or email address."
+  categories  = ["contacts"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["resend.api_key"]
+  }
+
+  param "contact_id" {
+    type        = "string"
+    required    = true
+    description = "Contact ID or email address to delete"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "DELETE"
+    url      = "https://api.resend.com/contacts/{{ args.contact_id }}"
+
+    auth {
+      kind   = "bearer"
+      secret = "resend.api_key"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Deleted contact: {{ result.contact }}"
+  }
+}

--- a/examples/sendgrid.hcl
+++ b/examples/sendgrid.hcl
@@ -1,0 +1,570 @@
+version = 1
+provider = "sendgrid"
+categories = ["email", "marketing"]
+
+command "send_mail" {
+  title       = "Send email"
+  summary     = "Send an email via SendGrid"
+  description = "Send a transactional email through the SendGrid Mail Send API. Returns 202 on success."
+  categories  = ["email"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["sendgrid.api_key"]
+  }
+
+  param "to" {
+    type        = "string"
+    required    = true
+    description = "Recipient email address"
+  }
+
+  param "from" {
+    type        = "string"
+    required    = true
+    description = "Verified sender email address"
+  }
+
+  param "subject" {
+    type        = "string"
+    required    = true
+    description = "Email subject line"
+  }
+
+  param "body_text" {
+    type        = "string"
+    required    = true
+    description = "Plain text email body"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "POST"
+    url      = "https://api.sendgrid.com/v3/mail/send"
+
+    auth {
+      kind   = "bearer"
+      secret = "sendgrid.api_key"
+    }
+
+    body {
+      kind = "json"
+      value = {
+        personalizations = [
+          {
+            to = [
+              {
+                email = "{{ args.to }}"
+              }
+            ]
+          }
+        ]
+        from = {
+          email = "{{ args.from }}"
+        }
+        subject = "{{ args.subject }}"
+        content = [
+          {
+            type  = "text/plain"
+            value = "{{ args.body_text }}"
+          }
+        ]
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Email sent to {{ args.to }} from {{ args.from }} (subject: \"{{ args.subject }}\")"
+  }
+}
+
+command "search_contacts" {
+  title       = "Search contacts"
+  summary     = "Search contacts using SGQL query"
+  description = "Search marketing contacts using SendGrid Query Language (SGQL). Example: email LIKE '%example.com' or first_name = 'John'."
+  categories  = ["marketing"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["sendgrid.api_key"]
+  }
+
+  param "query" {
+    type        = "string"
+    required    = true
+    description = "SGQL query (e.g. \"email LIKE '%example.com'\")"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "POST"
+    url      = "https://api.sendgrid.com/v3/marketing/contacts/search"
+
+    auth {
+      kind   = "bearer"
+      secret = "sendgrid.api_key"
+    }
+
+    body {
+      kind = "json"
+      value = {
+        query = "{{ args.query }}"
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Found {{ result.contact_count }} contacts:\n{% for c in result.result %}- {{ c.email }} ({{ c.first_name }} {{ c.last_name }}) [ID: {{ c.id }}]\n{% endfor %}"
+  }
+}
+
+command "get_contact" {
+  title       = "Get contact"
+  summary     = "Get a contact by ID"
+  description = "Retrieve a single marketing contact by its UUID."
+  categories  = ["marketing"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["sendgrid.api_key"]
+  }
+
+  param "id" {
+    type        = "string"
+    required    = true
+    description = "Contact UUID"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://api.sendgrid.com/v3/marketing/contacts/{{ args.id }}"
+
+    auth {
+      kind   = "bearer"
+      secret = "sendgrid.api_key"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Contact: {{ result.email }}\nName: {{ result.first_name }} {{ result.last_name }}\nCreated: {{ result.created_at }}\nUpdated: {{ result.updated_at }}"
+  }
+}
+
+command "upsert_contacts" {
+  title       = "Upsert contacts"
+  summary     = "Create or update a contact"
+  description = "Add or update a marketing contact. The email address is the upsert key."
+  categories  = ["marketing"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["sendgrid.api_key"]
+  }
+
+  param "email" {
+    type        = "string"
+    required    = true
+    description = "Contact email address (upsert key)"
+  }
+
+  param "first_name" {
+    type        = "string"
+    required    = false
+    default     = ""
+    description = "Contact first name"
+  }
+
+  param "last_name" {
+    type        = "string"
+    required    = false
+    default     = ""
+    description = "Contact last name"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "PUT"
+    url      = "https://api.sendgrid.com/v3/marketing/contacts"
+
+    auth {
+      kind   = "bearer"
+      secret = "sendgrid.api_key"
+    }
+
+    body {
+      kind = "json"
+      value = {
+        contacts = [
+          {
+            email      = "{{ args.email }}"
+            first_name = "{{ args.first_name }}"
+            last_name  = "{{ args.last_name }}"
+          }
+        ]
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Contact upsert queued. Job ID: {{ result.job_id }}"
+  }
+}
+
+command "delete_contacts" {
+  title       = "Delete contacts"
+  summary     = "Delete contacts by IDs"
+  description = "Delete one or more marketing contacts by their UUIDs."
+  categories  = ["marketing"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["sendgrid.api_key"]
+  }
+
+  param "ids" {
+    type        = "string"
+    required    = true
+    description = "Comma-separated contact UUIDs to delete"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "DELETE"
+    url      = "https://api.sendgrid.com/v3/marketing/contacts"
+
+    auth {
+      kind   = "bearer"
+      secret = "sendgrid.api_key"
+    }
+
+    query = {
+      ids = "{{ args.ids }}"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Contact deletion queued. Job ID: {{ result.job_id }}"
+  }
+}
+
+command "list_contact_lists" {
+  title       = "List contact lists"
+  summary     = "List all marketing contact lists"
+  description = "Retrieve all marketing contact lists with their contact counts."
+  categories  = ["marketing"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["sendgrid.api_key"]
+  }
+
+  param "page_size" {
+    type        = "integer"
+    required    = false
+    default     = 100
+    description = "Results per page (1-1000)"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://api.sendgrid.com/v3/marketing/lists"
+
+    auth {
+      kind   = "bearer"
+      secret = "sendgrid.api_key"
+    }
+
+    query = {
+      page_size = "{{ args.page_size }}"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "{{ result.result | length }} contact lists:\n{% for l in result.result %}- {{ l.name }} ({{ l.contact_count }} contacts) [ID: {{ l.id }}]\n{% endfor %}"
+  }
+}
+
+command "list_templates" {
+  title       = "List templates"
+  summary     = "List email templates"
+  description = "Retrieve transactional and dynamic email templates."
+  categories  = ["email"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["sendgrid.api_key"]
+  }
+
+  param "generations" {
+    type        = "string"
+    required    = false
+    default     = "legacy,dynamic"
+    description = "Filter by generation: legacy, dynamic, or both"
+  }
+
+  param "page_size" {
+    type        = "integer"
+    required    = false
+    default     = 50
+    description = "Results per page (1-200)"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://api.sendgrid.com/v3/templates"
+
+    auth {
+      kind   = "bearer"
+      secret = "sendgrid.api_key"
+    }
+
+    query = {
+      generations = "{{ args.generations }}"
+      page_size   = "{{ args.page_size }}"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "{{ result.result | length }} templates:\n{% for t in result.result %}- {{ t.name }} ({{ t.generation }}) [ID: {{ t.id }}]\n{% endfor %}"
+  }
+}
+
+command "get_global_stats" {
+  title       = "Get global stats"
+  summary     = "Get email sending statistics"
+  description = "Retrieve global email statistics for a date range including requests, deliveries, opens, clicks, bounces, and spam reports."
+  categories  = ["email"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["sendgrid.api_key"]
+  }
+
+  param "start_date" {
+    type        = "string"
+    required    = true
+    description = "Start date in YYYY-MM-DD format"
+  }
+
+  param "end_date" {
+    type        = "string"
+    required    = false
+    description = "End date in YYYY-MM-DD format (defaults to today)"
+  }
+
+  param "aggregated_by" {
+    type        = "string"
+    required    = false
+    description = "Aggregation period: day, week, or month"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://api.sendgrid.com/v3/stats"
+
+    auth {
+      kind   = "bearer"
+      secret = "sendgrid.api_key"
+    }
+
+    query = {
+      start_date = "{{ args.start_date }}"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Email stats from {{ args.start_date }}:\n{% for day in result %}{{ day.date }}: {{ day.stats[0].metrics.requests }} sent, {{ day.stats[0].metrics.delivered }} delivered, {{ day.stats[0].metrics.opens }} opens, {{ day.stats[0].metrics.clicks }} clicks, {{ day.stats[0].metrics.bounces }} bounces\n{% endfor %}"
+  }
+}
+
+command "list_email_activity" {
+  title       = "List email activity"
+  summary     = "Search recent email activity"
+  description = "Query recent email activity using SGQL. Filterable by from_email, to_email, subject, status (delivered/not_delivered/processing), and last_event_time. Requires the Email Activity History add-on."
+  categories  = ["email"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["sendgrid.api_key"]
+  }
+
+  param "query" {
+    type        = "string"
+    required    = true
+    description = "SGQL query for email activity (e.g. \"status = 'delivered'\")"
+  }
+
+  param "limit" {
+    type        = "integer"
+    required    = false
+    default     = 10
+    description = "Number of messages to return"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://api.sendgrid.com/v3/messages"
+
+    auth {
+      kind   = "bearer"
+      secret = "sendgrid.api_key"
+    }
+
+    query = {
+      query = "{{ args.query }}"
+      limit = "{{ args.limit }}"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "{% for m in result.messages %}- {{ m.status | upper }}: {{ m.from_email }} -> {{ m.to_email }} \"{{ m.subject }}\" ({{ m.last_event_time }})\n{% endfor %}"
+  }
+}
+
+command "list_bounces" {
+  title       = "List bounces"
+  summary     = "List bounced email addresses"
+  description = "Retrieve email addresses that have bounced, with the bounce reason and status."
+  categories  = ["email"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["sendgrid.api_key"]
+  }
+
+  param "limit" {
+    type        = "integer"
+    required    = false
+    default     = 100
+    description = "Maximum number of results (1-500)"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://api.sendgrid.com/v3/suppression/bounces"
+
+    auth {
+      kind   = "bearer"
+      secret = "sendgrid.api_key"
+    }
+
+    query = {
+      limit = "{{ args.limit }}"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "{{ result | length }} bounces:\n{% for b in result %}- {{ b.email }} -- {{ b.reason }} ({{ b.created }})\n{% endfor %}"
+  }
+}
+
+command "list_global_suppressions" {
+  title       = "List global suppressions"
+  summary     = "List globally unsubscribed emails"
+  description = "Retrieve email addresses that have globally unsubscribed from all emails."
+  categories  = ["email"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["sendgrid.api_key"]
+  }
+
+  param "limit" {
+    type        = "integer"
+    required    = false
+    default     = 100
+    description = "Maximum number of results (1-500)"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://api.sendgrid.com/v3/suppression/unsubscribes"
+
+    auth {
+      kind   = "bearer"
+      secret = "sendgrid.api_key"
+    }
+
+    query = {
+      limit = "{{ args.limit }}"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "{{ result | length }} global suppressions:\n{% for s in result %}- {{ s.email }} (suppressed {{ s.created }})\n{% endfor %}"
+  }
+}
+
+command "list_verified_senders" {
+  title       = "List verified senders"
+  summary     = "List verified sender identities"
+  description = "Retrieve all verified sender identities and their verification status."
+  categories  = ["email"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["sendgrid.api_key"]
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://api.sendgrid.com/v3/verified_senders"
+
+    auth {
+      kind   = "bearer"
+      secret = "sendgrid.api_key"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "{% for s in result.results %}- {{ s.from_name }} <{{ s.from_email }}> [ID: {{ s.id }}]\n{% endfor %}"
+  }
+}
+
+command "list_api_keys" {
+  title       = "List API keys"
+  summary     = "List all API keys"
+  description = "Retrieve all API keys associated with the account."
+  categories  = ["email"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["sendgrid.api_key"]
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://api.sendgrid.com/v3/api_keys"
+
+    auth {
+      kind   = "bearer"
+      secret = "sendgrid.api_key"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "{{ result.result | length }} API keys:\n{% for k in result.result %}- {{ k.name }} [ID: {{ k.api_key_id }}]\n{% endfor %}"
+  }
+}

--- a/examples/sentry.hcl
+++ b/examples/sentry.hcl
@@ -1,0 +1,636 @@
+version = 1
+provider = "sentry"
+categories = ["monitoring", "observability", "error-tracking"]
+
+command "list_projects" {
+  title       = "List projects"
+  summary     = "List all projects in a Sentry organization"
+  description = "Retrieve all projects belonging to the specified organization."
+  categories  = ["projects"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["sentry.auth_token"]
+  }
+
+  param "organization" {
+    type        = "string"
+    required    = true
+    description = "Organization slug"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://sentry.io/api/0/organizations/{{ args.organization }}/projects/"
+
+    auth {
+      kind   = "bearer"
+      secret = "sentry.auth_token"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Found {{ result | length }} projects."
+  }
+}
+
+command "get_project" {
+  title       = "Get project"
+  summary     = "Get details of a specific project"
+  description = "Retrieve detailed information about a Sentry project."
+  categories  = ["projects"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["sentry.auth_token"]
+  }
+
+  param "organization" {
+    type        = "string"
+    required    = true
+    description = "Organization slug"
+  }
+
+  param "project" {
+    type        = "string"
+    required    = true
+    description = "Project slug"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://sentry.io/api/0/projects/{{ args.organization }}/{{ args.project }}/"
+
+    auth {
+      kind   = "bearer"
+      secret = "sentry.auth_token"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "{{ result.name }} ({{ result.slug }}) | Platform: {{ result.platform }} | Created: {{ result.dateCreated }}"
+  }
+}
+
+command "create_project" {
+  title       = "Create project"
+  summary     = "Create a new project under a team"
+  description = "Create a new Sentry project under the specified team in an organization."
+  categories  = ["projects"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["sentry.auth_token"]
+  }
+
+  param "organization" {
+    type        = "string"
+    required    = true
+    description = "Organization slug"
+  }
+
+  param "team" {
+    type        = "string"
+    required    = true
+    description = "Team slug to create the project under"
+  }
+
+  param "name" {
+    type        = "string"
+    required    = true
+    description = "Project name"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "POST"
+    url      = "https://sentry.io/api/0/teams/{{ args.organization }}/{{ args.team }}/projects/"
+
+    auth {
+      kind   = "bearer"
+      secret = "sentry.auth_token"
+    }
+
+    body {
+      kind = "json"
+      value = {
+        name = "{{ args.name }}"
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Created project {{ result.name }} ({{ result.slug }}) with ID {{ result.id }}."
+  }
+}
+
+command "delete_project" {
+  title       = "Delete project"
+  summary     = "Delete a project from an organization"
+  description = "Permanently delete a Sentry project and all its data."
+  categories  = ["projects"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["sentry.auth_token"]
+  }
+
+  param "organization" {
+    type        = "string"
+    required    = true
+    description = "Organization slug"
+  }
+
+  param "project" {
+    type        = "string"
+    required    = true
+    description = "Project slug"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "DELETE"
+    url      = "https://sentry.io/api/0/projects/{{ args.organization }}/{{ args.project }}/"
+
+    auth {
+      kind   = "bearer"
+      secret = "sentry.auth_token"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Deleted project {{ args.project }} from organization {{ args.organization }}."
+  }
+}
+
+command "list_issues" {
+  title       = "List issues"
+  summary     = "Search and list issues in an organization"
+  description = "List issues across an organization with optional search query, sorting, and filtering."
+  categories  = ["issues"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["sentry.auth_token"]
+  }
+
+  param "organization" {
+    type        = "string"
+    required    = true
+    description = "Organization slug"
+  }
+
+  param "query" {
+    type        = "string"
+    required    = false
+    default     = "is:unresolved"
+    description = "Search query (e.g. 'is:unresolved', 'assigned:me', 'level:error')"
+  }
+
+  param "sort" {
+    type        = "string"
+    required    = false
+    default     = "date"
+    description = "Sort by: date, freq, new, trends, or user"
+  }
+
+  param "limit" {
+    type        = "integer"
+    required    = false
+    default     = 25
+    description = "Maximum number of results (up to 100)"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://sentry.io/api/0/organizations/{{ args.organization }}/issues/"
+
+    auth {
+      kind   = "bearer"
+      secret = "sentry.auth_token"
+    }
+
+    query = {
+      query = "{{ args.query }}"
+      sort  = "{{ args.sort }}"
+      limit = "{{ args.limit }}"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Found {{ result | length }} issues."
+  }
+}
+
+command "get_issue" {
+  title       = "Get issue"
+  summary     = "Get details of a specific issue"
+  description = "Retrieve detailed information about a Sentry issue including event count, user count, and assignment."
+  categories  = ["issues"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["sentry.auth_token"]
+  }
+
+  param "organization" {
+    type        = "string"
+    required    = true
+    description = "Organization slug"
+  }
+
+  param "issue_id" {
+    type        = "string"
+    required    = true
+    description = "Numeric issue ID"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://sentry.io/api/0/organizations/{{ args.organization }}/issues/{{ args.issue_id }}/"
+
+    auth {
+      kind   = "bearer"
+      secret = "sentry.auth_token"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "[{{ result.shortId }}] {{ result.title }} | Status: {{ result.status }} | Level: {{ result.level }} | Events: {{ result.count }}"
+  }
+}
+
+command "update_issue" {
+  title       = "Update issue"
+  summary     = "Update the status of an issue"
+  description = "Update a Sentry issue status to resolved, unresolved, ignored, or resolvedInNextRelease."
+  categories  = ["issues"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["sentry.auth_token"]
+  }
+
+  param "organization" {
+    type        = "string"
+    required    = true
+    description = "Organization slug"
+  }
+
+  param "issue_id" {
+    type        = "string"
+    required    = true
+    description = "Numeric issue ID"
+  }
+
+  param "status" {
+    type        = "string"
+    required    = true
+    description = "New status: resolved, resolvedInNextRelease, unresolved, or ignored"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "PUT"
+    url      = "https://sentry.io/api/0/organizations/{{ args.organization }}/issues/{{ args.issue_id }}/"
+
+    auth {
+      kind   = "bearer"
+      secret = "sentry.auth_token"
+    }
+
+    body {
+      kind = "json"
+      value = {
+        status = "{{ args.status }}"
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Updated issue [{{ result.shortId }}] to status {{ result.status }}."
+  }
+}
+
+command "list_issue_events" {
+  title       = "List issue events"
+  summary     = "List events for a specific issue"
+  description = "Retrieve the list of events associated with a Sentry issue."
+  categories  = ["issues"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["sentry.auth_token"]
+  }
+
+  param "organization" {
+    type        = "string"
+    required    = true
+    description = "Organization slug"
+  }
+
+  param "issue_id" {
+    type        = "string"
+    required    = true
+    description = "Numeric issue ID"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://sentry.io/api/0/organizations/{{ args.organization }}/issues/{{ args.issue_id }}/events/"
+
+    auth {
+      kind   = "bearer"
+      secret = "sentry.auth_token"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Found {{ result | length }} events for issue {{ args.issue_id }}."
+  }
+}
+
+command "get_event" {
+  title       = "Get event"
+  summary     = "Get full event details with stacktrace"
+  description = "Retrieve the full details of an event including tags, user info, and exception stacktrace."
+  categories  = ["events"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["sentry.auth_token"]
+  }
+
+  param "organization" {
+    type        = "string"
+    required    = true
+    description = "Organization slug"
+  }
+
+  param "project" {
+    type        = "string"
+    required    = true
+    description = "Project slug"
+  }
+
+  param "event_id" {
+    type        = "string"
+    required    = true
+    description = "Hexadecimal event ID"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://sentry.io/api/0/projects/{{ args.organization }}/{{ args.project }}/events/{{ args.event_id }}/"
+
+    auth {
+      kind   = "bearer"
+      secret = "sentry.auth_token"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Event {{ result.eventID }} | {{ result.title }} | Platform: {{ result.platform }} | Received: {{ result.dateReceived }}"
+  }
+}
+
+command "list_releases" {
+  title       = "List releases"
+  summary     = "List releases for an organization"
+  description = "Retrieve all releases for a Sentry organization, optionally filtered by version prefix."
+  categories  = ["releases"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["sentry.auth_token"]
+  }
+
+  param "organization" {
+    type        = "string"
+    required    = true
+    description = "Organization slug"
+  }
+
+  param "query" {
+    type        = "string"
+    required    = false
+    default     = ""
+    description = "Version prefix to filter by"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://sentry.io/api/0/organizations/{{ args.organization }}/releases/"
+
+    auth {
+      kind   = "bearer"
+      secret = "sentry.auth_token"
+    }
+
+    query = {
+      query = "{{ args.query }}"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Found {{ result | length }} releases."
+  }
+}
+
+command "create_release" {
+  title       = "Create release"
+  summary     = "Create a new release"
+  description = "Create a new release for a Sentry organization with the specified version and project slugs."
+  categories  = ["releases"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["sentry.auth_token"]
+  }
+
+  param "organization" {
+    type        = "string"
+    required    = true
+    description = "Organization slug"
+  }
+
+  param "version" {
+    type        = "string"
+    required    = true
+    description = "Release version identifier (semver, SHA, etc.)"
+  }
+
+  param "projects" {
+    type        = "array"
+    required    = true
+    description = "List of project slugs for this release"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "POST"
+    url      = "https://sentry.io/api/0/organizations/{{ args.organization }}/releases/"
+
+    auth {
+      kind   = "bearer"
+      secret = "sentry.auth_token"
+    }
+
+    body {
+      kind = "json"
+      value = {
+        version  = "{{ args.version }}"
+        projects = "{{ args.projects }}"
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Created release {{ result.version }}."
+  }
+}
+
+command "create_deploy" {
+  title       = "Create deploy"
+  summary     = "Record a deployment for a release"
+  description = "Record a deployment of a release to an environment in Sentry."
+  categories  = ["releases"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["sentry.auth_token"]
+  }
+
+  param "organization" {
+    type        = "string"
+    required    = true
+    description = "Organization slug"
+  }
+
+  param "version" {
+    type        = "string"
+    required    = true
+    description = "Release version to deploy"
+  }
+
+  param "environment" {
+    type        = "string"
+    required    = true
+    description = "Target environment (e.g. production, staging)"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "POST"
+    url      = "https://sentry.io/api/0/organizations/{{ args.organization }}/releases/{{ args.version }}/deploys/"
+
+    auth {
+      kind   = "bearer"
+      secret = "sentry.auth_token"
+    }
+
+    body {
+      kind = "json"
+      value = {
+        environment = "{{ args.environment }}"
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Deployed release {{ args.version }} to {{ result.environment }}."
+  }
+}
+
+command "list_teams" {
+  title       = "List teams"
+  summary     = "List teams in an organization"
+  description = "Retrieve all teams belonging to a Sentry organization."
+  categories  = ["teams"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["sentry.auth_token"]
+  }
+
+  param "organization" {
+    type        = "string"
+    required    = true
+    description = "Organization slug"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://sentry.io/api/0/organizations/{{ args.organization }}/teams/"
+
+    auth {
+      kind   = "bearer"
+      secret = "sentry.auth_token"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Found {{ result | length }} teams."
+  }
+}
+
+command "resolve_short_id" {
+  title       = "Resolve short ID"
+  summary     = "Resolve a short issue ID to its full details"
+  description = "Resolve a Sentry short ID (e.g. PROJECT-123) to the full issue ID and details."
+  categories  = ["issues"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["sentry.auth_token"]
+  }
+
+  param "organization" {
+    type        = "string"
+    required    = true
+    description = "Organization slug"
+  }
+
+  param "short_id" {
+    type        = "string"
+    required    = true
+    description = "Short issue ID (e.g. PROJECT-123)"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://sentry.io/api/0/organizations/{{ args.organization }}/shortids/{{ args.short_id }}/"
+
+    auth {
+      kind   = "bearer"
+      secret = "sentry.auth_token"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "{{ result.shortId }} -> Issue {{ result.groupId }} in {{ result.projectSlug }}: {{ result.group.title }} ({{ result.group.status }})"
+  }
+}

--- a/examples/shopify.hcl
+++ b/examples/shopify.hcl
@@ -1,0 +1,916 @@
+version = 1
+provider = "shopify"
+categories = ["ecommerce", "commerce"]
+
+command "get_shop" {
+  title       = "Get shop info"
+  summary     = "Get store configuration and metadata"
+  description = "Retrieve shop details including name, owner, plan, currency, and contact information. Requires the SHOPIFY_STORE environment variable to be set to your store subdomain."
+  categories  = ["shop"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["shopify.access_token"]
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://{{ env.SHOPIFY_STORE }}.myshopify.com/admin/api/2025-01/shop.json"
+
+    auth {
+      kind     = "api_key"
+      location = "header"
+      name     = "X-Shopify-Access-Token"
+      secret   = "shopify.access_token"
+    }
+
+    headers = {
+      Accept = "application/json"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = <<-EOF
+    Store: {{ result.shop.name }} ({{ result.shop.myshopify_domain }})
+    Owner: {{ result.shop.shop_owner }} <{{ result.shop.email }}>
+    Plan: {{ result.shop.plan_display_name }}
+    Currency: {{ result.shop.currency }}
+    Country: {{ result.shop.country_name }}
+    EOF
+  }
+}
+
+command "list_products" {
+  title       = "List products"
+  summary     = "List products in the store"
+  description = "Retrieve a list of products with optional filters for status and result limit."
+  categories  = ["products"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["shopify.access_token"]
+  }
+
+  param "limit" {
+    type        = "integer"
+    required    = false
+    default     = 50
+    description = "Maximum number of results (max 250)"
+  }
+
+  param "status" {
+    type        = "string"
+    required    = false
+    description = "Filter by status: active, draft, or archived"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://{{ env.SHOPIFY_STORE }}.myshopify.com/admin/api/2025-01/products.json"
+
+    auth {
+      kind     = "api_key"
+      location = "header"
+      name     = "X-Shopify-Access-Token"
+      secret   = "shopify.access_token"
+    }
+
+    query = {
+      limit  = "{{ args.limit }}"
+      status = "{{ args.status | default('') }}"
+    }
+
+    headers = {
+      Accept = "application/json"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = <<-EOF
+    {% for p in result.products %}
+    [{{ p.id }}] {{ p.title }} — {{ p.status }} — {{ p.vendor }} — {{ p.variants[0].price }} ({{ p.variants | length }} variants)
+    {% endfor %}
+    Found {{ result.products | length }} products.
+    EOF
+  }
+}
+
+command "get_product" {
+  title       = "Get product"
+  summary     = "Get a single product by ID"
+  description = "Retrieve detailed information about a specific product including all its variants."
+  categories  = ["products"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["shopify.access_token"]
+  }
+
+  param "product_id" {
+    type        = "integer"
+    required    = true
+    description = "Product ID"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://{{ env.SHOPIFY_STORE }}.myshopify.com/admin/api/2025-01/products/{{ args.product_id }}.json"
+
+    auth {
+      kind     = "api_key"
+      location = "header"
+      name     = "X-Shopify-Access-Token"
+      secret   = "shopify.access_token"
+    }
+
+    headers = {
+      Accept = "application/json"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = <<-EOF
+    Product: {{ result.product.title }} [{{ result.product.id }}]
+    Status: {{ result.product.status }}
+    Vendor: {{ result.product.vendor }}
+    Type: {{ result.product.product_type }}
+    Tags: {{ result.product.tags }}
+    Created: {{ result.product.created_at }}
+
+    Variants:
+    {% for v in result.product.variants %}
+      - {{ v.title }}: {{ v.price }} (SKU: {{ v.sku }}, Stock: {{ v.inventory_quantity }})
+    {% endfor %}
+    EOF
+  }
+}
+
+command "create_product" {
+  title       = "Create product"
+  summary     = "Create a new product"
+  description = "Create a new product in the store with a title, description, vendor, and other details."
+  categories  = ["products"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["shopify.access_token"]
+  }
+
+  param "title" {
+    type        = "string"
+    required    = true
+    description = "Product name"
+  }
+
+  param "body_html" {
+    type        = "string"
+    required    = false
+    default     = ""
+    description = "HTML description"
+  }
+
+  param "vendor" {
+    type        = "string"
+    required    = false
+    default     = ""
+    description = "Manufacturer or vendor"
+  }
+
+  param "product_type" {
+    type        = "string"
+    required    = false
+    default     = ""
+    description = "Product category"
+  }
+
+  param "status" {
+    type        = "string"
+    required    = false
+    default     = "active"
+    description = "Product status: active, draft, or archived"
+  }
+
+  param "tags" {
+    type        = "string"
+    required    = false
+    default     = ""
+    description = "Comma-separated tags"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "POST"
+    url      = "https://{{ env.SHOPIFY_STORE }}.myshopify.com/admin/api/2025-01/products.json"
+
+    auth {
+      kind     = "api_key"
+      location = "header"
+      name     = "X-Shopify-Access-Token"
+      secret   = "shopify.access_token"
+    }
+
+    headers = {
+      Accept = "application/json"
+    }
+
+    body {
+      kind = "json"
+      value = {
+        product = {
+          title        = "{{ args.title }}"
+          body_html    = "{{ args.body_html }}"
+          vendor       = "{{ args.vendor }}"
+          product_type = "{{ args.product_type }}"
+          status       = "{{ args.status }}"
+          tags         = "{{ args.tags }}"
+        }
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    output = <<-EOF
+    Created product: {{ result.product.title }} [{{ result.product.id }}]
+    Handle: {{ result.product.handle }}
+    Status: {{ result.product.status }}
+    EOF
+  }
+}
+
+command "update_product" {
+  title       = "Update product"
+  summary     = "Update an existing product"
+  description = "Update fields on an existing product. Only provide the fields you want to change."
+  categories  = ["products"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["shopify.access_token"]
+  }
+
+  param "product_id" {
+    type        = "integer"
+    required    = true
+    description = "Product ID to update"
+  }
+
+  param "title" {
+    type        = "string"
+    required    = false
+    description = "New title"
+  }
+
+  param "body_html" {
+    type        = "string"
+    required    = false
+    description = "New HTML description"
+  }
+
+  param "vendor" {
+    type        = "string"
+    required    = false
+    description = "New vendor"
+  }
+
+  param "product_type" {
+    type        = "string"
+    required    = false
+    description = "New product type"
+  }
+
+  param "status" {
+    type        = "string"
+    required    = false
+    description = "New status: active, draft, or archived"
+  }
+
+  param "tags" {
+    type        = "string"
+    required    = false
+    description = "Comma-separated tags"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "PUT"
+    url      = "https://{{ env.SHOPIFY_STORE }}.myshopify.com/admin/api/2025-01/products/{{ args.product_id }}.json"
+
+    auth {
+      kind     = "api_key"
+      location = "header"
+      name     = "X-Shopify-Access-Token"
+      secret   = "shopify.access_token"
+    }
+
+    headers = {
+      Accept = "application/json"
+    }
+
+    body {
+      kind = "json"
+      value = {
+        product = {
+          title        = "{{ args.title | default('') }}"
+          body_html    = "{{ args.body_html | default('') }}"
+          vendor       = "{{ args.vendor | default('') }}"
+          product_type = "{{ args.product_type | default('') }}"
+          status       = "{{ args.status | default('') }}"
+          tags         = "{{ args.tags | default('') }}"
+        }
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    output = <<-EOF
+    Updated product: {{ result.product.title }} [{{ result.product.id }}]
+    Status: {{ result.product.status }}
+    Updated at: {{ result.product.updated_at }}
+    EOF
+  }
+}
+
+command "delete_product" {
+  title       = "Delete product"
+  summary     = "Delete a product"
+  description = "Permanently delete a product from the store."
+  categories  = ["products"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["shopify.access_token"]
+  }
+
+  param "product_id" {
+    type        = "integer"
+    required    = true
+    description = "Product ID to delete"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "DELETE"
+    url      = "https://{{ env.SHOPIFY_STORE }}.myshopify.com/admin/api/2025-01/products/{{ args.product_id }}.json"
+
+    auth {
+      kind     = "api_key"
+      location = "header"
+      name     = "X-Shopify-Access-Token"
+      secret   = "shopify.access_token"
+    }
+
+    headers = {
+      Accept = "application/json"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Deleted product {{ args.product_id }}."
+  }
+}
+
+command "list_orders" {
+  title       = "List orders"
+  summary     = "List orders with optional filters"
+  description = "Retrieve a list of orders filtered by status, financial status, or fulfillment status."
+  categories  = ["orders"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["shopify.access_token"]
+  }
+
+  param "limit" {
+    type        = "integer"
+    required    = false
+    default     = 50
+    description = "Maximum number of results (max 250)"
+  }
+
+  param "status" {
+    type        = "string"
+    required    = false
+    default     = "open"
+    description = "Order status: open, closed, cancelled, or any"
+  }
+
+  param "financial_status" {
+    type        = "string"
+    required    = false
+    description = "Financial status: paid, pending, refunded, authorized, or any"
+  }
+
+  param "fulfillment_status" {
+    type        = "string"
+    required    = false
+    description = "Fulfillment status: shipped, unshipped, partial, or any"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://{{ env.SHOPIFY_STORE }}.myshopify.com/admin/api/2025-01/orders.json"
+
+    auth {
+      kind     = "api_key"
+      location = "header"
+      name     = "X-Shopify-Access-Token"
+      secret   = "shopify.access_token"
+    }
+
+    query = {
+      limit              = "{{ args.limit }}"
+      status             = "{{ args.status }}"
+      financial_status   = "{{ args.financial_status | default('') }}"
+      fulfillment_status = "{{ args.fulfillment_status | default('') }}"
+    }
+
+    headers = {
+      Accept = "application/json"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = <<-EOF
+    {% for o in result.orders %}
+    {{ o.name }} [{{ o.id }}] — {{ o.financial_status }}/{{ o.fulfillment_status | default("unfulfilled") }} — {{ o.total_price }} {{ o.currency }} — {{ o.created_at }}
+      Customer: {{ o.customer.first_name }} {{ o.customer.last_name }} <{{ o.email }}>
+      Items: {{ o.line_items | length }}
+    {% endfor %}
+    Found {{ result.orders | length }} orders.
+    EOF
+  }
+}
+
+command "get_order" {
+  title       = "Get order"
+  summary     = "Get a single order by ID"
+  description = "Retrieve detailed information about a specific order including line items and shipping address."
+  categories  = ["orders"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["shopify.access_token"]
+  }
+
+  param "order_id" {
+    type        = "integer"
+    required    = true
+    description = "Order ID"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://{{ env.SHOPIFY_STORE }}.myshopify.com/admin/api/2025-01/orders/{{ args.order_id }}.json"
+
+    auth {
+      kind     = "api_key"
+      location = "header"
+      name     = "X-Shopify-Access-Token"
+      secret   = "shopify.access_token"
+    }
+
+    headers = {
+      Accept = "application/json"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = <<-EOF
+    Order: {{ result.order.name }} [{{ result.order.id }}]
+    Status: {{ result.order.financial_status }} / {{ result.order.fulfillment_status | default("unfulfilled") }}
+    Total: {{ result.order.total_price }} {{ result.order.currency }}
+    Customer: {{ result.order.customer.first_name }} {{ result.order.customer.last_name }} <{{ result.order.email }}>
+    Created: {{ result.order.created_at }}
+
+    Line Items:
+    {% for li in result.order.line_items %}
+      - {{ li.title }} x{{ li.quantity }} — {{ li.price }} (SKU: {{ li.sku }})
+    {% endfor %}
+
+    Shipping: {{ result.order.shipping_address.address1 }}, {{ result.order.shipping_address.city }}, {{ result.order.shipping_address.province }} {{ result.order.shipping_address.zip }}
+    EOF
+  }
+}
+
+command "close_order" {
+  title       = "Close order"
+  summary     = "Close an open order"
+  description = "Mark an open order as closed."
+  categories  = ["orders"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["shopify.access_token"]
+  }
+
+  param "order_id" {
+    type        = "integer"
+    required    = true
+    description = "Order ID to close"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "POST"
+    url      = "https://{{ env.SHOPIFY_STORE }}.myshopify.com/admin/api/2025-01/orders/{{ args.order_id }}/close.json"
+
+    auth {
+      kind     = "api_key"
+      location = "header"
+      name     = "X-Shopify-Access-Token"
+      secret   = "shopify.access_token"
+    }
+
+    headers = {
+      Accept = "application/json"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Closed order {{ result.order.name }} [{{ result.order.id }}] at {{ result.order.closed_at }}."
+  }
+}
+
+command "cancel_order" {
+  title       = "Cancel order"
+  summary     = "Cancel an order"
+  description = "Cancel an order with an optional reason. Valid reasons: customer, fraud, inventory, declined, other."
+  categories  = ["orders"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["shopify.access_token"]
+  }
+
+  param "order_id" {
+    type        = "integer"
+    required    = true
+    description = "Order ID to cancel"
+  }
+
+  param "reason" {
+    type        = "string"
+    required    = false
+    default     = "other"
+    description = "Cancellation reason: customer, fraud, inventory, declined, or other"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "POST"
+    url      = "https://{{ env.SHOPIFY_STORE }}.myshopify.com/admin/api/2025-01/orders/{{ args.order_id }}/cancel.json"
+
+    auth {
+      kind     = "api_key"
+      location = "header"
+      name     = "X-Shopify-Access-Token"
+      secret   = "shopify.access_token"
+    }
+
+    headers = {
+      Accept = "application/json"
+    }
+
+    body {
+      kind = "json"
+      value = {
+        reason = "{{ args.reason }}"
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Cancelled order {{ result.order.name }} [{{ result.order.id }}]. Reason: {{ args.reason }}."
+  }
+}
+
+command "list_customers" {
+  title       = "List customers"
+  summary     = "List customers in the store"
+  description = "Retrieve a list of customers with order count and total spend."
+  categories  = ["customers"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["shopify.access_token"]
+  }
+
+  param "limit" {
+    type        = "integer"
+    required    = false
+    default     = 50
+    description = "Maximum number of results (max 250)"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://{{ env.SHOPIFY_STORE }}.myshopify.com/admin/api/2025-01/customers.json"
+
+    auth {
+      kind     = "api_key"
+      location = "header"
+      name     = "X-Shopify-Access-Token"
+      secret   = "shopify.access_token"
+    }
+
+    query = {
+      limit = "{{ args.limit }}"
+    }
+
+    headers = {
+      Accept = "application/json"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = <<-EOF
+    {% for c in result.customers %}
+    [{{ c.id }}] {{ c.first_name }} {{ c.last_name }} <{{ c.email }}> — {{ c.orders_count }} orders, {{ c.total_spent }} spent — {{ c.state }}
+    {% endfor %}
+    Found {{ result.customers | length }} customers.
+    EOF
+  }
+}
+
+command "search_customers" {
+  title       = "Search customers"
+  summary     = "Search customers by query"
+  description = "Search customers using Shopify query syntax (e.g. email:bob@example.com, country:Canada, orders_count:>5)."
+  categories  = ["customers"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["shopify.access_token"]
+  }
+
+  param "query" {
+    type        = "string"
+    required    = true
+    description = "Search query (e.g. email:bob@example.com, first_name:Bob, orders_count:>5)"
+  }
+
+  param "limit" {
+    type        = "integer"
+    required    = false
+    default     = 50
+    description = "Maximum number of results (max 250)"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://{{ env.SHOPIFY_STORE }}.myshopify.com/admin/api/2025-01/customers/search.json"
+
+    auth {
+      kind     = "api_key"
+      location = "header"
+      name     = "X-Shopify-Access-Token"
+      secret   = "shopify.access_token"
+    }
+
+    query = {
+      query = "{{ args.query }}"
+      limit = "{{ args.limit }}"
+    }
+
+    headers = {
+      Accept = "application/json"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = <<-EOF
+    {% for c in result.customers %}
+    [{{ c.id }}] {{ c.first_name }} {{ c.last_name }} <{{ c.email }}> — {{ c.orders_count }} orders, {{ c.total_spent }} spent
+    {% endfor %}
+    Found {{ result.customers | length }} customers matching "{{ args.query }}".
+    EOF
+  }
+}
+
+command "create_customer" {
+  title       = "Create customer"
+  summary     = "Create a new customer"
+  description = "Create a new customer record with email, name, phone, and tags."
+  categories  = ["customers"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["shopify.access_token"]
+  }
+
+  param "email" {
+    type        = "string"
+    required    = true
+    description = "Customer email (must be unique)"
+  }
+
+  param "first_name" {
+    type        = "string"
+    required    = false
+    default     = ""
+    description = "First name"
+  }
+
+  param "last_name" {
+    type        = "string"
+    required    = false
+    default     = ""
+    description = "Last name"
+  }
+
+  param "phone" {
+    type        = "string"
+    required    = false
+    default     = ""
+    description = "Phone number in E.164 format"
+  }
+
+  param "tags" {
+    type        = "string"
+    required    = false
+    default     = ""
+    description = "Comma-separated tags"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "POST"
+    url      = "https://{{ env.SHOPIFY_STORE }}.myshopify.com/admin/api/2025-01/customers.json"
+
+    auth {
+      kind     = "api_key"
+      location = "header"
+      name     = "X-Shopify-Access-Token"
+      secret   = "shopify.access_token"
+    }
+
+    headers = {
+      Accept = "application/json"
+    }
+
+    body {
+      kind = "json"
+      value = {
+        customer = {
+          email      = "{{ args.email }}"
+          first_name = "{{ args.first_name }}"
+          last_name  = "{{ args.last_name }}"
+          phone      = "{{ args.phone }}"
+          tags       = "{{ args.tags }}"
+        }
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Created customer: {{ result.customer.first_name }} {{ result.customer.last_name }} [{{ result.customer.id }}] <{{ result.customer.email }}>"
+  }
+}
+
+command "adjust_inventory" {
+  title       = "Adjust inventory"
+  summary     = "Adjust inventory level for an item at a location"
+  description = "Adjust the available inventory quantity for an inventory item at a specific location. Use positive values to add stock and negative values to subtract."
+  categories  = ["inventory"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["shopify.access_token"]
+  }
+
+  param "inventory_item_id" {
+    type        = "integer"
+    required    = true
+    description = "Inventory item ID (from a product variant's inventory_item_id)"
+  }
+
+  param "location_id" {
+    type        = "integer"
+    required    = true
+    description = "Location ID"
+  }
+
+  param "available_adjustment" {
+    type        = "integer"
+    required    = true
+    description = "Amount to adjust (positive to add, negative to subtract)"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "POST"
+    url      = "https://{{ env.SHOPIFY_STORE }}.myshopify.com/admin/api/2025-01/inventory_levels/adjust.json"
+
+    auth {
+      kind     = "api_key"
+      location = "header"
+      name     = "X-Shopify-Access-Token"
+      secret   = "shopify.access_token"
+    }
+
+    headers = {
+      Accept = "application/json"
+    }
+
+    body {
+      kind = "json"
+      value = {
+        inventory_item_id    = "{{ args.inventory_item_id }}"
+        location_id          = "{{ args.location_id }}"
+        available_adjustment = "{{ args.available_adjustment }}"
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    output = <<-EOF
+    Adjusted inventory for item {{ result.inventory_level.inventory_item_id }} at location {{ result.inventory_level.location_id }}.
+    New available quantity: {{ result.inventory_level.available }}
+    EOF
+  }
+}
+
+command "create_webhook" {
+  title       = "Create webhook"
+  summary     = "Create a webhook subscription"
+  description = "Subscribe to a Shopify event topic with an HTTPS callback URL. Common topics: orders/create, orders/paid, products/update, customers/create, inventory_levels/update."
+  categories  = ["webhooks"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["shopify.access_token"]
+  }
+
+  param "topic" {
+    type        = "string"
+    required    = true
+    description = "Event topic (e.g. orders/create, products/update, customers/create)"
+  }
+
+  param "address" {
+    type        = "string"
+    required    = true
+    description = "HTTPS callback URL"
+  }
+
+  param "format" {
+    type        = "string"
+    required    = false
+    default     = "json"
+    description = "Payload format: json or xml"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "POST"
+    url      = "https://{{ env.SHOPIFY_STORE }}.myshopify.com/admin/api/2025-01/webhooks.json"
+
+    auth {
+      kind     = "api_key"
+      location = "header"
+      name     = "X-Shopify-Access-Token"
+      secret   = "shopify.access_token"
+    }
+
+    headers = {
+      Accept = "application/json"
+    }
+
+    body {
+      kind = "json"
+      value = {
+        webhook = {
+          topic   = "{{ args.topic }}"
+          address = "{{ args.address }}"
+          format  = "{{ args.format }}"
+        }
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Created webhook [{{ result.webhook.id }}]: {{ result.webhook.topic }} -> {{ result.webhook.address }} ({{ result.webhook.format }})"
+  }
+}

--- a/examples/slack.hcl
+++ b/examples/slack.hcl
@@ -1,0 +1,858 @@
+version = 1
+provider = "slack"
+categories = ["messaging", "collaboration"]
+
+command "send_message" {
+  title       = "Send message"
+  summary     = "Post a message to a Slack channel or DM"
+  description = "Send a message to a channel, DM, or group conversation using the Slack chat.postMessage API."
+  categories  = ["messaging"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["slack.bot_token"]
+  }
+
+  param "channel" {
+    type        = "string"
+    required    = true
+    description = "Channel ID, DM ID, or user ID to post to"
+  }
+
+  param "text" {
+    type        = "string"
+    required    = true
+    description = "Message body text"
+  }
+
+  param "thread_ts" {
+    type        = "string"
+    required    = false
+    description = "Parent message timestamp to reply in a thread"
+  }
+
+  param "unfurl_links" {
+    type        = "boolean"
+    required    = false
+    default     = true
+    description = "Enable link previews"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "POST"
+    url      = "https://slack.com/api/chat.postMessage"
+
+    auth {
+      kind   = "bearer"
+      secret = "slack.bot_token"
+    }
+
+    headers = {
+      Content-Type = "application/json; charset=utf-8"
+    }
+
+    body {
+      kind = "json"
+      value = {
+        channel      = "{{ args.channel }}"
+        text         = "{{ args.text }}"
+        thread_ts    = "{{ args.thread_ts }}"
+        unfurl_links = "{{ args.unfurl_links }}"
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Message sent to {{ result.channel }} at ts={{ result.ts }}"
+  }
+}
+
+command "update_message" {
+  title       = "Update message"
+  summary     = "Edit an existing Slack message"
+  description = "Update the text or blocks of a previously sent message using chat.update."
+  categories  = ["messaging"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["slack.bot_token"]
+  }
+
+  param "channel" {
+    type        = "string"
+    required    = true
+    description = "Channel containing the message"
+  }
+
+  param "ts" {
+    type        = "string"
+    required    = true
+    description = "Timestamp of the message to update"
+  }
+
+  param "text" {
+    type        = "string"
+    required    = true
+    description = "New message text"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "POST"
+    url      = "https://slack.com/api/chat.update"
+
+    auth {
+      kind   = "bearer"
+      secret = "slack.bot_token"
+    }
+
+    headers = {
+      Content-Type = "application/json; charset=utf-8"
+    }
+
+    body {
+      kind = "json"
+      value = {
+        channel = "{{ args.channel }}"
+        ts      = "{{ args.ts }}"
+        text    = "{{ args.text }}"
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Message updated in {{ result.channel }} at ts={{ result.ts }}"
+  }
+}
+
+command "delete_message" {
+  title       = "Delete message"
+  summary     = "Delete a message from a Slack channel"
+  description = "Delete a message from a conversation using chat.delete."
+  categories  = ["messaging"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["slack.bot_token"]
+  }
+
+  param "channel" {
+    type        = "string"
+    required    = true
+    description = "Channel containing the message"
+  }
+
+  param "ts" {
+    type        = "string"
+    required    = true
+    description = "Timestamp of the message to delete"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "POST"
+    url      = "https://slack.com/api/chat.delete"
+
+    auth {
+      kind   = "bearer"
+      secret = "slack.bot_token"
+    }
+
+    headers = {
+      Content-Type = "application/json; charset=utf-8"
+    }
+
+    body {
+      kind = "json"
+      value = {
+        channel = "{{ args.channel }}"
+        ts      = "{{ args.ts }}"
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Message deleted from {{ result.channel }} at ts={{ result.ts }}"
+  }
+}
+
+command "list_conversations" {
+  title       = "List conversations"
+  summary     = "List Slack channels and conversations"
+  description = "List public and private channels, direct messages, and group conversations the bot has access to."
+  categories  = ["channels"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["slack.bot_token"]
+  }
+
+  param "types" {
+    type        = "string"
+    required    = false
+    default     = "public_channel"
+    description = "Comma-separated types: public_channel, private_channel, mpim, im"
+  }
+
+  param "exclude_archived" {
+    type        = "boolean"
+    required    = false
+    default     = false
+    description = "Exclude archived channels from results"
+  }
+
+  param "limit" {
+    type        = "integer"
+    required    = false
+    default     = 100
+    description = "Maximum number of results per page (max 1000)"
+  }
+
+  param "cursor" {
+    type        = "string"
+    required    = false
+    description = "Pagination cursor for next page of results"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "POST"
+    url      = "https://slack.com/api/conversations.list"
+
+    auth {
+      kind   = "bearer"
+      secret = "slack.bot_token"
+    }
+
+    headers = {
+      Content-Type = "application/json; charset=utf-8"
+    }
+
+    body {
+      kind = "json"
+      value = {
+        types            = "{{ args.types }}"
+        exclude_archived = "{{ args.exclude_archived }}"
+        limit            = "{{ args.limit }}"
+        cursor           = "{{ args.cursor }}"
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Found {{ result.channels | length }} channels{% for c in result.channels %}\n  #{{ c.name }} ({{ c.id }}) — {{ c.num_members }} members{% endfor %}"
+  }
+}
+
+command "get_conversation_info" {
+  title       = "Get conversation info"
+  summary     = "Get details about a Slack channel or conversation"
+  description = "Retrieve detailed information about a channel, DM, or group conversation."
+  categories  = ["channels"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["slack.bot_token"]
+  }
+
+  param "channel" {
+    type        = "string"
+    required    = true
+    description = "Conversation ID"
+  }
+
+  param "include_num_members" {
+    type        = "boolean"
+    required    = false
+    default     = true
+    description = "Include the member count in the response"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "POST"
+    url      = "https://slack.com/api/conversations.info"
+
+    auth {
+      kind   = "bearer"
+      secret = "slack.bot_token"
+    }
+
+    headers = {
+      Content-Type = "application/json; charset=utf-8"
+    }
+
+    body {
+      kind = "json"
+      value = {
+        channel             = "{{ args.channel }}"
+        include_num_members = "{{ args.include_num_members }}"
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "#{{ result.channel.name }} ({{ result.channel.id }})\n  Topic: {{ result.channel.topic.value }}\n  Purpose: {{ result.channel.purpose.value }}\n  Members: {{ result.channel.num_members }}"
+  }
+}
+
+command "get_conversation_history" {
+  title       = "Get conversation history"
+  summary     = "Fetch recent messages from a Slack channel"
+  description = "Retrieve message history from a channel, DM, or group conversation."
+  categories  = ["messaging"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["slack.bot_token"]
+  }
+
+  param "channel" {
+    type        = "string"
+    required    = true
+    description = "Conversation ID"
+  }
+
+  param "limit" {
+    type        = "integer"
+    required    = false
+    default     = 15
+    description = "Maximum number of messages to return"
+  }
+
+  param "oldest" {
+    type        = "string"
+    required    = false
+    description = "Only messages after this Unix timestamp"
+  }
+
+  param "latest" {
+    type        = "string"
+    required    = false
+    description = "Only messages before this Unix timestamp"
+  }
+
+  param "cursor" {
+    type        = "string"
+    required    = false
+    description = "Pagination cursor for next page of results"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "POST"
+    url      = "https://slack.com/api/conversations.history"
+
+    auth {
+      kind   = "bearer"
+      secret = "slack.bot_token"
+    }
+
+    headers = {
+      Content-Type = "application/json; charset=utf-8"
+    }
+
+    body {
+      kind = "json"
+      value = {
+        channel = "{{ args.channel }}"
+        limit   = "{{ args.limit }}"
+        oldest  = "{{ args.oldest }}"
+        latest  = "{{ args.latest }}"
+        cursor  = "{{ args.cursor }}"
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "{{ result.messages | length }} messages{% for m in result.messages %}\n  [{{ m.ts }}] {{ m.text | truncate(120) }}{% endfor %}{% if result.has_more %}\n  (more messages available){% endif %}"
+  }
+}
+
+command "get_thread_replies" {
+  title       = "Get thread replies"
+  summary     = "Fetch replies in a message thread"
+  description = "Retrieve all replies to a specific message thread using conversations.replies."
+  categories  = ["messaging"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["slack.bot_token"]
+  }
+
+  param "channel" {
+    type        = "string"
+    required    = true
+    description = "Conversation ID containing the thread"
+  }
+
+  param "ts" {
+    type        = "string"
+    required    = true
+    description = "Parent message timestamp"
+  }
+
+  param "limit" {
+    type        = "integer"
+    required    = false
+    default     = 15
+    description = "Maximum number of replies to return"
+  }
+
+  param "cursor" {
+    type        = "string"
+    required    = false
+    description = "Pagination cursor for next page of results"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "POST"
+    url      = "https://slack.com/api/conversations.replies"
+
+    auth {
+      kind   = "bearer"
+      secret = "slack.bot_token"
+    }
+
+    headers = {
+      Content-Type = "application/json; charset=utf-8"
+    }
+
+    body {
+      kind = "json"
+      value = {
+        channel = "{{ args.channel }}"
+        ts      = "{{ args.ts }}"
+        limit   = "{{ args.limit }}"
+        cursor  = "{{ args.cursor }}"
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "{{ result.messages | length }} replies in thread{% for m in result.messages %}\n  [{{ m.ts }}] {{ m.text | truncate(120) }}{% endfor %}{% if result.has_more %}\n  (more replies available){% endif %}"
+  }
+}
+
+command "create_conversation" {
+  title       = "Create conversation"
+  summary     = "Create a new Slack channel"
+  description = "Create a new public or private channel in the workspace."
+  categories  = ["channels"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["slack.bot_token"]
+  }
+
+  param "name" {
+    type        = "string"
+    required    = true
+    description = "Channel name (lowercase, numbers, hyphens, underscores; max 80 chars)"
+  }
+
+  param "is_private" {
+    type        = "boolean"
+    required    = false
+    default     = false
+    description = "Create a private channel instead of public"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "POST"
+    url      = "https://slack.com/api/conversations.create"
+
+    auth {
+      kind   = "bearer"
+      secret = "slack.bot_token"
+    }
+
+    headers = {
+      Content-Type = "application/json; charset=utf-8"
+    }
+
+    body {
+      kind = "json"
+      value = {
+        name       = "{{ args.name }}"
+        is_private = "{{ args.is_private }}"
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Created channel #{{ result.channel.name }} ({{ result.channel.id }})"
+  }
+}
+
+command "invite_to_conversation" {
+  title       = "Invite to conversation"
+  summary     = "Invite users to a Slack channel"
+  description = "Invite one or more users to a channel by their user IDs."
+  categories  = ["channels"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["slack.bot_token"]
+  }
+
+  param "channel" {
+    type        = "string"
+    required    = true
+    description = "Channel ID to invite users to"
+  }
+
+  param "users" {
+    type        = "string"
+    required    = true
+    description = "Comma-separated list of user IDs to invite"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "POST"
+    url      = "https://slack.com/api/conversations.invite"
+
+    auth {
+      kind   = "bearer"
+      secret = "slack.bot_token"
+    }
+
+    headers = {
+      Content-Type = "application/json; charset=utf-8"
+    }
+
+    body {
+      kind = "json"
+      value = {
+        channel = "{{ args.channel }}"
+        users   = "{{ args.users }}"
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Invited users to #{{ result.channel.name }} ({{ result.channel.id }})"
+  }
+}
+
+command "archive_conversation" {
+  title       = "Archive conversation"
+  summary     = "Archive a Slack channel"
+  description = "Archive a channel so it is read-only and hidden from the default channel list."
+  categories  = ["channels"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["slack.bot_token"]
+  }
+
+  param "channel" {
+    type        = "string"
+    required    = true
+    description = "Channel ID to archive"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "POST"
+    url      = "https://slack.com/api/conversations.archive"
+
+    auth {
+      kind   = "bearer"
+      secret = "slack.bot_token"
+    }
+
+    headers = {
+      Content-Type = "application/json; charset=utf-8"
+    }
+
+    body {
+      kind = "json"
+      value = {
+        channel = "{{ args.channel }}"
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Channel archived successfully"
+  }
+}
+
+command "set_conversation_topic" {
+  title       = "Set conversation topic"
+  summary     = "Set the topic of a Slack channel"
+  description = "Update the topic text displayed at the top of a channel."
+  categories  = ["channels"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["slack.bot_token"]
+  }
+
+  param "channel" {
+    type        = "string"
+    required    = true
+    description = "Channel ID"
+  }
+
+  param "topic" {
+    type        = "string"
+    required    = true
+    description = "New topic text for the channel"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "POST"
+    url      = "https://slack.com/api/conversations.setTopic"
+
+    auth {
+      kind   = "bearer"
+      secret = "slack.bot_token"
+    }
+
+    headers = {
+      Content-Type = "application/json; charset=utf-8"
+    }
+
+    body {
+      kind = "json"
+      value = {
+        channel = "{{ args.channel }}"
+        topic   = "{{ args.topic }}"
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Topic set for #{{ result.channel.name }}: {{ result.channel.topic.value }}"
+  }
+}
+
+command "list_users" {
+  title       = "List users"
+  summary     = "List all users in the Slack workspace"
+  description = "Retrieve a paginated list of all users in the workspace, including deactivated accounts."
+  categories  = ["users"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["slack.bot_token"]
+  }
+
+  param "limit" {
+    type        = "integer"
+    required    = false
+    default     = 100
+    description = "Maximum number of results per page (max 1000)"
+  }
+
+  param "cursor" {
+    type        = "string"
+    required    = false
+    description = "Pagination cursor for next page of results"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "POST"
+    url      = "https://slack.com/api/users.list"
+
+    auth {
+      kind   = "bearer"
+      secret = "slack.bot_token"
+    }
+
+    headers = {
+      Content-Type = "application/json; charset=utf-8"
+    }
+
+    body {
+      kind = "json"
+      value = {
+        limit  = "{{ args.limit }}"
+        cursor = "{{ args.cursor }}"
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "{{ result.members | length }} users{% for u in result.members %}\n  {{ u.real_name }} (@{{ u.name }}, {{ u.id }}){% if u.deleted %} [deactivated]{% endif %}{% endfor %}"
+  }
+}
+
+command "get_user_info" {
+  title       = "Get user info"
+  summary     = "Get detailed information about a Slack user"
+  description = "Retrieve profile details for a specific user by their user ID."
+  categories  = ["users"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["slack.bot_token"]
+  }
+
+  param "user" {
+    type        = "string"
+    required    = true
+    description = "User ID to look up"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "POST"
+    url      = "https://slack.com/api/users.info"
+
+    auth {
+      kind   = "bearer"
+      secret = "slack.bot_token"
+    }
+
+    headers = {
+      Content-Type = "application/json; charset=utf-8"
+    }
+
+    body {
+      kind = "json"
+      value = {
+        user = "{{ args.user }}"
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "{{ result.user.real_name }} (@{{ result.user.name }})\n  Email: {{ result.user.profile.email }}\n  Title: {{ result.user.profile.title }}\n  Status: {{ result.user.profile.status_emoji }} {{ result.user.profile.status_text }}"
+  }
+}
+
+command "lookup_user_by_email" {
+  title       = "Lookup user by email"
+  summary     = "Find a Slack user by their email address"
+  description = "Look up a user's profile and ID using their email address."
+  categories  = ["users"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["slack.bot_token"]
+  }
+
+  param "email" {
+    type        = "string"
+    required    = true
+    description = "Email address to look up"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "POST"
+    url      = "https://slack.com/api/users.lookupByEmail"
+
+    auth {
+      kind   = "bearer"
+      secret = "slack.bot_token"
+    }
+
+    headers = {
+      Content-Type = "application/json; charset=utf-8"
+    }
+
+    body {
+      kind = "json"
+      value = {
+        email = "{{ args.email }}"
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "{{ result.user.real_name }} (@{{ result.user.name }}, {{ result.user.id }})\n  Email: {{ result.user.profile.email }}"
+  }
+}
+
+command "search_messages" {
+  title       = "Search messages"
+  summary     = "Search for messages across Slack channels"
+  description = "Search messages across the workspace. Supports modifiers like in:#channel, from:@user. Requires a user token (xoxp-), not a bot token."
+  categories  = ["search"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["slack.user_token"]
+  }
+
+  param "query" {
+    type        = "string"
+    required    = true
+    description = "Search query (supports modifiers like in:#channel, from:@user)"
+  }
+
+  param "count" {
+    type        = "integer"
+    required    = false
+    default     = 20
+    description = "Number of results per page (max 100)"
+  }
+
+  param "sort" {
+    type        = "string"
+    required    = false
+    default     = "score"
+    description = "Sort order: score or timestamp"
+  }
+
+  param "sort_dir" {
+    type        = "string"
+    required    = false
+    default     = "desc"
+    description = "Sort direction: asc or desc"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "POST"
+    url      = "https://slack.com/api/search.messages"
+
+    auth {
+      kind   = "bearer"
+      secret = "slack.user_token"
+    }
+
+    headers = {
+      Content-Type = "application/json; charset=utf-8"
+    }
+
+    body {
+      kind = "json"
+      value = {
+        query    = "{{ args.query }}"
+        count    = "{{ args.count }}"
+        sort     = "{{ args.sort }}"
+        sort_dir = "{{ args.sort_dir }}"
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "{{ result.messages.total }} results for \"{{ args.query }}\"{% for m in result.messages.matches %}\n  [#{{ m.channel.name }}] {{ m.text | truncate(120) }}{% endfor %}"
+  }
+}

--- a/examples/stripe.hcl
+++ b/examples/stripe.hcl
@@ -1,0 +1,792 @@
+version = 1
+provider = "stripe"
+categories = ["payments", "billing", "commerce"]
+
+command "list_customers" {
+  title       = "List customers"
+  summary     = "List Stripe customers with optional filters"
+  description = "Retrieve a paginated list of customers. Filter by email or creation date."
+  categories  = ["customers"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["stripe.api_key"]
+  }
+
+  param "limit" {
+    type        = "integer"
+    required    = false
+    default     = 10
+    description = "Number of results to return (1-100)"
+  }
+
+  param "email" {
+    type        = "string"
+    required    = false
+    description = "Filter by exact email address (case-sensitive)"
+  }
+
+  param "starting_after" {
+    type        = "string"
+    required    = false
+    description = "Cursor for pagination: customer ID to start after"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://api.stripe.com/v1/customers"
+
+    auth {
+      kind   = "bearer"
+      secret = "stripe.api_key"
+    }
+
+    query = {
+      limit          = "{{ args.limit }}"
+      email          = "{{ args.email }}"
+      starting_after = "{{ args.starting_after }}"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Found {{ result.data | length }} customers (has_more: {{ result.has_more }}).\n{% for c in result.data %}- {{ c.id }}: {{ c.name | default('(no name)') }} <{{ c.email | default('(no email)') }}>\n{% endfor %}"
+  }
+}
+
+command "get_customer" {
+  title       = "Get customer"
+  summary     = "Retrieve a single customer by ID"
+  description = "Fetch full details for a Stripe customer by their ID."
+  categories  = ["customers"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["stripe.api_key"]
+  }
+
+  param "customer_id" {
+    type        = "string"
+    required    = true
+    description = "Stripe customer ID (e.g. cus_xxx)"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://api.stripe.com/v1/customers/{{ args.customer_id }}"
+
+    auth {
+      kind   = "bearer"
+      secret = "stripe.api_key"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Customer {{ result.id }}:\n  Name: {{ result.name | default('(not set)') }}\n  Email: {{ result.email | default('(not set)') }}\n  Phone: {{ result.phone | default('(not set)') }}\n  Balance: {{ result.balance }} {{ result.currency | default('usd') }}\n  Created: {{ result.created }}\n  Default source: {{ result.default_source | default('none') }}"
+  }
+}
+
+command "create_customer" {
+  title       = "Create customer"
+  summary     = "Create a new Stripe customer"
+  description = "Create a customer record in Stripe with optional name, email, phone, and description."
+  categories  = ["customers"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["stripe.api_key"]
+  }
+
+  param "name" {
+    type        = "string"
+    required    = false
+    description = "Customer's full name"
+  }
+
+  param "email" {
+    type        = "string"
+    required    = false
+    description = "Customer's email address"
+  }
+
+  param "phone" {
+    type        = "string"
+    required    = false
+    description = "Customer's phone number"
+  }
+
+  param "description" {
+    type        = "string"
+    required    = false
+    description = "Arbitrary description for the customer"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "POST"
+    url      = "https://api.stripe.com/v1/customers"
+
+    auth {
+      kind   = "bearer"
+      secret = "stripe.api_key"
+    }
+
+    body {
+      kind = "form_urlencoded"
+      fields = {
+        name        = "{{ args.name }}"
+        email       = "{{ args.email }}"
+        phone       = "{{ args.phone }}"
+        description = "{{ args.description }}"
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Created customer {{ result.id }}:\n  Name: {{ result.name | default('(not set)') }}\n  Email: {{ result.email | default('(not set)') }}"
+  }
+}
+
+command "update_customer" {
+  title       = "Update customer"
+  summary     = "Update an existing customer's details"
+  description = "Update fields on an existing Stripe customer by ID."
+  categories  = ["customers"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["stripe.api_key"]
+  }
+
+  param "customer_id" {
+    type        = "string"
+    required    = true
+    description = "Stripe customer ID to update"
+  }
+
+  param "name" {
+    type        = "string"
+    required    = false
+    description = "Updated full name"
+  }
+
+  param "email" {
+    type        = "string"
+    required    = false
+    description = "Updated email address"
+  }
+
+  param "phone" {
+    type        = "string"
+    required    = false
+    description = "Updated phone number"
+  }
+
+  param "description" {
+    type        = "string"
+    required    = false
+    description = "Updated description"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "POST"
+    url      = "https://api.stripe.com/v1/customers/{{ args.customer_id }}"
+
+    auth {
+      kind   = "bearer"
+      secret = "stripe.api_key"
+    }
+
+    body {
+      kind = "form_urlencoded"
+      fields = {
+        name        = "{{ args.name }}"
+        email       = "{{ args.email }}"
+        phone       = "{{ args.phone }}"
+        description = "{{ args.description }}"
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Updated customer {{ result.id }}:\n  Name: {{ result.name | default('(not set)') }}\n  Email: {{ result.email | default('(not set)') }}"
+  }
+}
+
+command "create_payment_intent" {
+  title       = "Create payment intent"
+  summary     = "Create a new PaymentIntent for collecting a payment"
+  description = "Create a PaymentIntent to initiate a payment flow. Amount is in smallest currency unit (e.g. cents for USD)."
+  categories  = ["payments"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["stripe.api_key"]
+  }
+
+  param "amount" {
+    type        = "integer"
+    required    = true
+    description = "Amount in smallest currency unit (e.g. 1000 = $10.00 USD)"
+  }
+
+  param "currency" {
+    type        = "string"
+    required    = true
+    description = "Three-letter ISO currency code, lowercase (e.g. usd, eur)"
+  }
+
+  param "customer" {
+    type        = "string"
+    required    = false
+    description = "Customer ID to associate the payment with"
+  }
+
+  param "description" {
+    type        = "string"
+    required    = false
+    description = "Arbitrary description for the payment"
+  }
+
+  param "confirm" {
+    type        = "boolean"
+    required    = false
+    default     = false
+    description = "Whether to confirm the PaymentIntent immediately"
+  }
+
+  param "payment_method" {
+    type        = "string"
+    required    = false
+    description = "PaymentMethod ID to use for this payment"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "POST"
+    url      = "https://api.stripe.com/v1/payment_intents"
+
+    auth {
+      kind   = "bearer"
+      secret = "stripe.api_key"
+    }
+
+    body {
+      kind = "form_urlencoded"
+      fields = {
+        amount         = "{{ args.amount }}"
+        currency       = "{{ args.currency }}"
+        customer       = "{{ args.customer }}"
+        description    = "{{ args.description }}"
+        confirm        = "{{ args.confirm }}"
+        payment_method = "{{ args.payment_method }}"
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "PaymentIntent {{ result.id }}:\n  Status: {{ result.status }}\n  Amount: {{ result.amount }} {{ result.currency }}\n  Customer: {{ result.customer | default('none') }}\n  Client secret: {{ result.client_secret }}"
+  }
+}
+
+command "list_payment_intents" {
+  title       = "List payment intents"
+  summary     = "List PaymentIntents with optional filters"
+  description = "Retrieve a paginated list of PaymentIntents. Filter by customer or creation date."
+  categories  = ["payments"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["stripe.api_key"]
+  }
+
+  param "limit" {
+    type        = "integer"
+    required    = false
+    default     = 10
+    description = "Number of results to return (1-100)"
+  }
+
+  param "customer" {
+    type        = "string"
+    required    = false
+    description = "Filter by customer ID"
+  }
+
+  param "starting_after" {
+    type        = "string"
+    required    = false
+    description = "Cursor for pagination: PaymentIntent ID to start after"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://api.stripe.com/v1/payment_intents"
+
+    auth {
+      kind   = "bearer"
+      secret = "stripe.api_key"
+    }
+
+    query = {
+      limit          = "{{ args.limit }}"
+      customer       = "{{ args.customer }}"
+      starting_after = "{{ args.starting_after }}"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Found {{ result.data | length }} payment intents (has_more: {{ result.has_more }}).\n{% for pi in result.data %}- {{ pi.id }}: {{ pi.status }} — {{ pi.amount }} {{ pi.currency }}\n{% endfor %}"
+  }
+}
+
+command "create_refund" {
+  title       = "Create refund"
+  summary     = "Refund a payment in full or partially"
+  description = "Create a refund for a PaymentIntent or Charge. Omit amount for a full refund."
+  categories  = ["payments"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["stripe.api_key"]
+  }
+
+  param "payment_intent" {
+    type        = "string"
+    required    = true
+    description = "PaymentIntent ID to refund (e.g. pi_xxx)"
+  }
+
+  param "amount" {
+    type        = "integer"
+    required    = false
+    description = "Partial refund amount in smallest currency unit; omit for full refund"
+  }
+
+  param "reason" {
+    type        = "string"
+    required    = false
+    description = "Reason: duplicate, fraudulent, or requested_by_customer"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "POST"
+    url      = "https://api.stripe.com/v1/refunds"
+
+    auth {
+      kind   = "bearer"
+      secret = "stripe.api_key"
+    }
+
+    body {
+      kind = "form_urlencoded"
+      fields = {
+        payment_intent = "{{ args.payment_intent }}"
+        amount         = "{{ args.amount }}"
+        reason         = "{{ args.reason }}"
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Refund {{ result.id }}:\n  Status: {{ result.status }}\n  Amount: {{ result.amount }} {{ result.currency }}\n  Reason: {{ result.reason | default('none') }}\n  Payment intent: {{ result.payment_intent | default('n/a') }}"
+  }
+}
+
+command "list_products" {
+  title       = "List products"
+  summary     = "List products in your Stripe catalog"
+  description = "Retrieve a paginated list of products. Optionally filter by active status."
+  categories  = ["products"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["stripe.api_key"]
+  }
+
+  param "limit" {
+    type        = "integer"
+    required    = false
+    default     = 10
+    description = "Number of results to return (1-100)"
+  }
+
+  param "active" {
+    type        = "boolean"
+    required    = false
+    description = "Filter by active status (true or false)"
+  }
+
+  param "starting_after" {
+    type        = "string"
+    required    = false
+    description = "Cursor for pagination: product ID to start after"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://api.stripe.com/v1/products"
+
+    auth {
+      kind   = "bearer"
+      secret = "stripe.api_key"
+    }
+
+    query = {
+      limit          = "{{ args.limit }}"
+      active         = "{{ args.active }}"
+      starting_after = "{{ args.starting_after }}"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Found {{ result.data | length }} products (has_more: {{ result.has_more }}).\n{% for p in result.data %}- {{ p.id }}: {{ p.name }} (active: {{ p.active }}){% if p.description %} — {{ p.description }}{% endif %}\n{% endfor %}"
+  }
+}
+
+command "create_product" {
+  title       = "Create product"
+  summary     = "Create a new product in Stripe"
+  description = "Create a product in your catalog. Products can be used with Prices for checkout or subscriptions."
+  categories  = ["products"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["stripe.api_key"]
+  }
+
+  param "name" {
+    type        = "string"
+    required    = true
+    description = "Product name, displayed to the customer"
+  }
+
+  param "description" {
+    type        = "string"
+    required    = false
+    description = "Product description"
+  }
+
+  param "active" {
+    type        = "boolean"
+    required    = false
+    default     = true
+    description = "Whether the product is available for purchase"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "POST"
+    url      = "https://api.stripe.com/v1/products"
+
+    auth {
+      kind   = "bearer"
+      secret = "stripe.api_key"
+    }
+
+    body {
+      kind = "form_urlencoded"
+      fields = {
+        name        = "{{ args.name }}"
+        description = "{{ args.description }}"
+        active      = "{{ args.active }}"
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Created product {{ result.id }}:\n  Name: {{ result.name }}\n  Active: {{ result.active }}\n  Description: {{ result.description | default('(none)') }}"
+  }
+}
+
+command "list_invoices" {
+  title       = "List invoices"
+  summary     = "List invoices with optional filters"
+  description = "Retrieve a paginated list of invoices. Filter by customer, status, or subscription."
+  categories  = ["billing"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["stripe.api_key"]
+  }
+
+  param "limit" {
+    type        = "integer"
+    required    = false
+    default     = 10
+    description = "Number of results to return (1-100)"
+  }
+
+  param "customer" {
+    type        = "string"
+    required    = false
+    description = "Filter by customer ID"
+  }
+
+  param "status" {
+    type        = "string"
+    required    = false
+    description = "Filter by status: draft, open, paid, uncollectible, or void"
+  }
+
+  param "subscription" {
+    type        = "string"
+    required    = false
+    description = "Filter by subscription ID"
+  }
+
+  param "starting_after" {
+    type        = "string"
+    required    = false
+    description = "Cursor for pagination: invoice ID to start after"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://api.stripe.com/v1/invoices"
+
+    auth {
+      kind   = "bearer"
+      secret = "stripe.api_key"
+    }
+
+    query = {
+      limit          = "{{ args.limit }}"
+      customer       = "{{ args.customer }}"
+      status         = "{{ args.status }}"
+      subscription   = "{{ args.subscription }}"
+      starting_after = "{{ args.starting_after }}"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Found {{ result.data | length }} invoices (has_more: {{ result.has_more }}).\n{% for inv in result.data %}- {{ inv.id }}: {{ inv.status }} — {{ inv.amount_due }} {{ inv.currency }} (customer: {{ inv.customer }})\n{% endfor %}"
+  }
+}
+
+command "create_subscription" {
+  title       = "Create subscription"
+  summary     = "Subscribe a customer to a recurring price"
+  description = "Create a subscription for a customer with a given price. Optionally set a trial period or quantity."
+  categories  = ["billing"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["stripe.api_key"]
+  }
+
+  param "customer" {
+    type        = "string"
+    required    = true
+    description = "Customer ID to subscribe"
+  }
+
+  param "price" {
+    type        = "string"
+    required    = true
+    description = "Price ID for the subscription item (e.g. price_xxx)"
+  }
+
+  param "quantity" {
+    type        = "integer"
+    required    = false
+    default     = 1
+    description = "Quantity for the subscription item"
+  }
+
+  param "trial_period_days" {
+    type        = "integer"
+    required    = false
+    description = "Number of free trial days before first charge"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "POST"
+    url      = "https://api.stripe.com/v1/subscriptions"
+
+    auth {
+      kind   = "bearer"
+      secret = "stripe.api_key"
+    }
+
+    body {
+      kind = "form_urlencoded"
+      fields = {
+        customer            = "{{ args.customer }}"
+        "items[0][price]"   = "{{ args.price }}"
+        "items[0][quantity]" = "{{ args.quantity }}"
+        trial_period_days   = "{{ args.trial_period_days }}"
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Created subscription {{ result.id }}:\n  Status: {{ result.status }}\n  Customer: {{ result.customer }}\n  Current period: {{ result.current_period_start }} — {{ result.current_period_end }}\n  Collection: {{ result.collection_method }}"
+  }
+}
+
+command "list_subscriptions" {
+  title       = "List subscriptions"
+  summary     = "List subscriptions with optional filters"
+  description = "Retrieve a paginated list of subscriptions. Filter by customer or status."
+  categories  = ["billing"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["stripe.api_key"]
+  }
+
+  param "limit" {
+    type        = "integer"
+    required    = false
+    default     = 10
+    description = "Number of results to return (1-100)"
+  }
+
+  param "customer" {
+    type        = "string"
+    required    = false
+    description = "Filter by customer ID"
+  }
+
+  param "status" {
+    type        = "string"
+    required    = false
+    description = "Filter: active, past_due, canceled, unpaid, trialing, or all"
+  }
+
+  param "starting_after" {
+    type        = "string"
+    required    = false
+    description = "Cursor for pagination: subscription ID to start after"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://api.stripe.com/v1/subscriptions"
+
+    auth {
+      kind   = "bearer"
+      secret = "stripe.api_key"
+    }
+
+    query = {
+      limit          = "{{ args.limit }}"
+      customer       = "{{ args.customer }}"
+      status         = "{{ args.status }}"
+      starting_after = "{{ args.starting_after }}"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Found {{ result.data | length }} subscriptions (has_more: {{ result.has_more }}).\n{% for sub in result.data %}- {{ sub.id }}: {{ sub.status }} (customer: {{ sub.customer }})\n{% endfor %}"
+  }
+}
+
+command "get_balance" {
+  title       = "Get balance"
+  summary     = "Retrieve your Stripe account balance"
+  description = "Fetch the current balance for your Stripe account, showing available and pending amounts by currency."
+  categories  = ["reporting"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["stripe.api_key"]
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://api.stripe.com/v1/balance"
+
+    auth {
+      kind   = "bearer"
+      secret = "stripe.api_key"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Stripe Balance:\n{% for b in result.available %}  Available: {{ b.amount }} {{ b.currency }}\n{% endfor %}{% for b in result.pending %}  Pending: {{ b.amount }} {{ b.currency }}\n{% endfor %}"
+  }
+}
+
+command "list_balance_transactions" {
+  title       = "List balance transactions"
+  summary     = "List balance transactions with optional filters"
+  description = "Retrieve a paginated list of balance transactions (charges, refunds, payouts, etc.)."
+  categories  = ["reporting"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["stripe.api_key"]
+  }
+
+  param "limit" {
+    type        = "integer"
+    required    = false
+    default     = 10
+    description = "Number of results to return (1-100)"
+  }
+
+  param "type" {
+    type        = "string"
+    required    = false
+    description = "Filter by type: charge, refund, transfer, payout, etc."
+  }
+
+  param "currency" {
+    type        = "string"
+    required    = false
+    description = "Filter by three-letter ISO currency code, lowercase"
+  }
+
+  param "starting_after" {
+    type        = "string"
+    required    = false
+    description = "Cursor for pagination: transaction ID to start after"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://api.stripe.com/v1/balance_transactions"
+
+    auth {
+      kind   = "bearer"
+      secret = "stripe.api_key"
+    }
+
+    query = {
+      limit          = "{{ args.limit }}"
+      type           = "{{ args.type }}"
+      currency       = "{{ args.currency }}"
+      starting_after = "{{ args.starting_after }}"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Found {{ result.data | length }} transactions (has_more: {{ result.has_more }}).\n{% for txn in result.data %}- {{ txn.id }}: {{ txn.type }} — {{ txn.amount }} {{ txn.currency }} (net: {{ txn.net }}, fee: {{ txn.fee }})\n{% endfor %}"
+  }
+}

--- a/examples/supabase.hcl
+++ b/examples/supabase.hcl
@@ -1,0 +1,598 @@
+version = 1
+provider = "supabase"
+categories = ["database", "backend", "infrastructure"]
+
+command "list_projects" {
+  title       = "List projects"
+  summary     = "List all Supabase projects"
+  description = "List all projects accessible with the current access token."
+  categories  = ["projects"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["supabase.access_token"]
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://api.supabase.com/v1/projects"
+
+    auth {
+      kind   = "bearer"
+      secret = "supabase.access_token"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Found {{ result | length }} projects."
+  }
+}
+
+command "get_project" {
+  title       = "Get project"
+  summary     = "Get details of a Supabase project"
+  description = "Retrieve detailed information about a specific Supabase project including region, status, and database configuration."
+  categories  = ["projects"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["supabase.access_token"]
+  }
+
+  param "project_ref" {
+    type        = "string"
+    required    = true
+    description = "Project reference ID"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://api.supabase.com/v1/projects/{{ args.project_ref }}"
+
+    auth {
+      kind   = "bearer"
+      secret = "supabase.access_token"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Project: {{ result.name }} ({{ result.ref }}) [{{ result.status }}] — {{ result.region }}"
+  }
+}
+
+command "create_project" {
+  title       = "Create project"
+  summary     = "Create a new Supabase project"
+  description = "Create a new Supabase project in the specified organization with a database password and region."
+  categories  = ["projects"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["supabase.access_token"]
+  }
+
+  param "name" {
+    type        = "string"
+    required    = true
+    description = "Project name"
+  }
+
+  param "organization_slug" {
+    type        = "string"
+    required    = true
+    description = "Organization slug"
+  }
+
+  param "db_pass" {
+    type        = "string"
+    required    = true
+    description = "Database password"
+  }
+
+  param "region" {
+    type        = "string"
+    required    = false
+    default     = "us-east-1"
+    description = "AWS region (e.g. us-east-1, eu-west-1, ap-southeast-1)"
+  }
+
+  param "plan" {
+    type        = "string"
+    required    = false
+    default     = "free"
+    description = "Plan tier: free or pro"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "POST"
+    url      = "https://api.supabase.com/v1/projects"
+
+    auth {
+      kind   = "bearer"
+      secret = "supabase.access_token"
+    }
+
+    body {
+      kind = "json"
+      value = {
+        name              = "{{ args.name }}"
+        organization_slug = "{{ args.organization_slug }}"
+        db_pass           = "{{ args.db_pass }}"
+        region            = "{{ args.region }}"
+        plan              = "{{ args.plan }}"
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Created project: {{ result.name }} ({{ result.ref }}) [{{ result.region }}]"
+  }
+}
+
+command "get_project_health" {
+  title       = "Get project health"
+  summary     = "Check health of project services"
+  description = "Check the health status of auth, REST, database, and storage services for a Supabase project."
+  categories  = ["projects"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["supabase.access_token"]
+  }
+
+  param "project_ref" {
+    type        = "string"
+    required    = true
+    description = "Project reference ID"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://api.supabase.com/v1/projects/{{ args.project_ref }}/health?services=auth&services=rest&services=db&services=storage"
+
+    auth {
+      kind   = "bearer"
+      secret = "supabase.access_token"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Health check returned {{ result | length }} service(s) for {{ args.project_ref }}."
+  }
+}
+
+command "run_sql" {
+  title       = "Run SQL query"
+  summary     = "Execute a SQL query against a project database"
+  description = "Run an arbitrary SQL query against the Postgres database of a Supabase project via the Management API."
+  categories  = ["database"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["supabase.access_token"]
+  }
+
+  param "project_ref" {
+    type        = "string"
+    required    = true
+    description = "Project reference ID"
+  }
+
+  param "query" {
+    type        = "string"
+    required    = true
+    description = "SQL query to execute"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "POST"
+    url      = "https://api.supabase.com/v1/projects/{{ args.project_ref }}/database/query"
+
+    auth {
+      kind   = "bearer"
+      secret = "supabase.access_token"
+    }
+
+    body {
+      kind = "json"
+      value = {
+        query = "{{ args.query }}"
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Query returned {{ result | length }} rows."
+  }
+}
+
+command "list_secrets" {
+  title       = "List secrets"
+  summary     = "List all secrets for a project"
+  description = "List all environment variable secrets configured for a Supabase project. Values are not returned, only names and metadata."
+  categories  = ["secrets"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["supabase.access_token"]
+  }
+
+  param "project_ref" {
+    type        = "string"
+    required    = true
+    description = "Project reference ID"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://api.supabase.com/v1/projects/{{ args.project_ref }}/secrets"
+
+    auth {
+      kind   = "bearer"
+      secret = "supabase.access_token"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Found {{ result | length }} secret(s) for {{ args.project_ref }}."
+  }
+}
+
+command "list_edge_functions" {
+  title       = "List edge functions"
+  summary     = "List all edge functions for a project"
+  description = "List all deployed edge functions for a Supabase project including name, slug, status, and version."
+  categories  = ["functions"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["supabase.access_token"]
+  }
+
+  param "project_ref" {
+    type        = "string"
+    required    = true
+    description = "Project reference ID"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://api.supabase.com/v1/projects/{{ args.project_ref }}/functions"
+
+    auth {
+      kind   = "bearer"
+      secret = "supabase.access_token"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Found {{ result | length }} edge function(s) for {{ args.project_ref }}."
+  }
+}
+
+command "generate_types" {
+  title       = "Generate TypeScript types"
+  summary     = "Generate TypeScript types from database schema"
+  description = "Generate TypeScript type definitions from the database schema of a Supabase project. Useful for type-safe client usage."
+  categories  = ["development"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["supabase.access_token"]
+  }
+
+  param "project_ref" {
+    type        = "string"
+    required    = true
+    description = "Project reference ID"
+  }
+
+  param "included_schemas" {
+    type        = "string"
+    required    = false
+    default     = "public"
+    description = "Comma-separated schema names to include"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://api.supabase.com/v1/projects/{{ args.project_ref }}/types/typescript"
+
+    auth {
+      kind   = "bearer"
+      secret = "supabase.access_token"
+    }
+
+    query = {
+      included_schemas = "{{ args.included_schemas }}"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "{{ result.types }}"
+  }
+}
+
+command "list_users" {
+  title       = "List users"
+  summary     = "List auth users for a project"
+  description = "List all authentication users for a Supabase project via the Auth Admin API. Requires the project's service role key."
+  categories  = ["auth"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["supabase.service_role_key"]
+  }
+
+  param "project_ref" {
+    type        = "string"
+    required    = true
+    description = "Project reference ID"
+  }
+
+  param "page" {
+    type        = "integer"
+    required    = false
+    default     = 1
+    description = "Page number"
+  }
+
+  param "per_page" {
+    type        = "integer"
+    required    = false
+    default     = 50
+    description = "Users per page"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://{{ args.project_ref }}.supabase.co/auth/v1/admin/users"
+
+    auth {
+      kind   = "bearer"
+      secret = "supabase.service_role_key"
+    }
+
+    query = {
+      page     = "{{ args.page }}"
+      per_page = "{{ args.per_page }}"
+    }
+
+    headers = {
+      apikey = "{{ secrets.supabase_service_role_key }}"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Found {{ result.users | length }} user(s)."
+  }
+}
+
+command "create_user" {
+  title       = "Create user"
+  summary     = "Create a new auth user"
+  description = "Create a new authentication user for a Supabase project via the Auth Admin API. The user is auto-confirmed by default."
+  categories  = ["auth"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["supabase.service_role_key"]
+  }
+
+  param "project_ref" {
+    type        = "string"
+    required    = true
+    description = "Project reference ID"
+  }
+
+  param "email" {
+    type        = "string"
+    required    = true
+    description = "User email address"
+  }
+
+  param "email_confirm" {
+    type        = "boolean"
+    required    = false
+    default     = true
+    description = "Auto-confirm the email address"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "POST"
+    url      = "https://{{ args.project_ref }}.supabase.co/auth/v1/admin/users"
+
+    auth {
+      kind   = "bearer"
+      secret = "supabase.service_role_key"
+    }
+
+    headers = {
+      apikey = "{{ secrets.supabase_service_role_key }}"
+    }
+
+    body {
+      kind = "json"
+      value = {
+        email         = "{{ args.email }}"
+        email_confirm = "{{ args.email_confirm }}"
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Created user: {{ result.email }} ({{ result.id }})"
+  }
+}
+
+command "delete_user" {
+  title       = "Delete user"
+  summary     = "Delete an auth user"
+  description = "Permanently delete an authentication user from a Supabase project by their UUID."
+  categories  = ["auth"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["supabase.service_role_key"]
+  }
+
+  param "project_ref" {
+    type        = "string"
+    required    = true
+    description = "Project reference ID"
+  }
+
+  param "user_id" {
+    type        = "string"
+    required    = true
+    description = "User UUID"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "DELETE"
+    url      = "https://{{ args.project_ref }}.supabase.co/auth/v1/admin/users/{{ args.user_id }}"
+
+    auth {
+      kind   = "bearer"
+      secret = "supabase.service_role_key"
+    }
+
+    headers = {
+      apikey = "{{ secrets.supabase_service_role_key }}"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Deleted user {{ args.user_id }}."
+  }
+}
+
+command "query_table" {
+  title       = "Query table"
+  summary     = "Query rows from a table via PostgREST"
+  description = "Query rows from a table or view using the PostgREST API. Supports column selection and row limits. For filtering, append PostgREST operators as query params (e.g. status=eq.active)."
+  categories  = ["database"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["supabase.service_role_key"]
+  }
+
+  param "project_ref" {
+    type        = "string"
+    required    = true
+    description = "Project reference ID"
+  }
+
+  param "table" {
+    type        = "string"
+    required    = true
+    description = "Table or view name"
+  }
+
+  param "select" {
+    type        = "string"
+    required    = false
+    default     = "*"
+    description = "Column selection (e.g. id,name,email)"
+  }
+
+  param "limit" {
+    type        = "integer"
+    required    = false
+    default     = 100
+    description = "Maximum number of rows to return"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://{{ args.project_ref }}.supabase.co/rest/v1/{{ args.table }}"
+
+    auth {
+      kind   = "bearer"
+      secret = "supabase.service_role_key"
+    }
+
+    query = {
+      select = "{{ args.select }}"
+      limit  = "{{ args.limit }}"
+    }
+
+    headers = {
+      apikey = "{{ secrets.supabase_service_role_key }}"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Returned {{ result | length }} rows from {{ args.table }}."
+  }
+}
+
+command "invoke_function" {
+  title       = "Invoke edge function"
+  summary     = "Invoke a deployed edge function"
+  description = "Invoke a deployed Supabase edge function by its slug. Sends an empty JSON body by default — modify the template to pass custom payloads."
+  categories  = ["functions"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["supabase.service_role_key"]
+  }
+
+  param "project_ref" {
+    type        = "string"
+    required    = true
+    description = "Project reference ID"
+  }
+
+  param "function_name" {
+    type        = "string"
+    required    = true
+    description = "Edge function slug"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "POST"
+    url      = "https://{{ args.project_ref }}.supabase.co/functions/v1/{{ args.function_name }}"
+
+    auth {
+      kind   = "bearer"
+      secret = "supabase.service_role_key"
+    }
+
+    body {
+      kind = "json"
+      value = {}
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Function {{ args.function_name }} invoked successfully."
+  }
+}

--- a/examples/twilio.hcl
+++ b/examples/twilio.hcl
@@ -1,0 +1,723 @@
+version = 1
+provider = "twilio"
+categories = ["messaging", "voice", "telephony"]
+
+command "send_message" {
+  title       = "Send SMS/MMS"
+  summary     = "Send a text message or MMS to a phone number"
+  description = "Send an SMS or MMS message via Twilio. Requires To, From (E.164 format), and Body. Optionally attach media for MMS."
+  categories  = ["messaging"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["twilio.account_sid", "twilio.auth_token"]
+  }
+
+  param "to" {
+    type        = "string"
+    required    = true
+    description = "Recipient phone number in E.164 format (e.g. +14155551234)"
+  }
+
+  param "from" {
+    type        = "string"
+    required    = true
+    description = "Sender phone number in E.164 format (must be a Twilio number)"
+  }
+
+  param "body" {
+    type        = "string"
+    required    = true
+    description = "Message text (max 1600 characters)"
+  }
+
+  param "media_url" {
+    type        = "string"
+    required    = false
+    description = "URL of media to attach (sends as MMS)"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "POST"
+    url      = "https://api.twilio.com/2010-04-01/Accounts/{{ secrets.twilio_account_sid }}/Messages.json"
+
+    auth {
+      kind            = "basic"
+      username        = "{{ secrets.twilio_account_sid }}"
+      password_secret = "twilio.auth_token"
+    }
+
+    body {
+      kind = "form_urlencoded"
+      fields = {
+        To       = "{{ args.to }}"
+        From     = "{{ args.from }}"
+        Body     = "{{ args.body }}"
+        MediaUrl = "{{ args.media_url }}"
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Message {{ result.sid }} {{ result.status }}\nFrom: {{ result.from }} → To: {{ result.to }}\nBody: {{ result.body }}\nSegments: {{ result.num_segments }} | Price: {{ result.price }} {{ result.price_unit }}"
+  }
+}
+
+command "list_messages" {
+  title       = "List messages"
+  summary     = "List recent SMS/MMS messages"
+  description = "Retrieve a list of messages sent from or received by your Twilio account. Supports filtering by sender, recipient, and date."
+  categories  = ["messaging"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["twilio.account_sid", "twilio.auth_token"]
+  }
+
+  param "to" {
+    type        = "string"
+    required    = false
+    description = "Filter by recipient phone number"
+  }
+
+  param "from" {
+    type        = "string"
+    required    = false
+    description = "Filter by sender phone number"
+  }
+
+  param "page_size" {
+    type        = "integer"
+    required    = false
+    default     = 20
+    description = "Number of results per page (1-1000)"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://api.twilio.com/2010-04-01/Accounts/{{ secrets.twilio_account_sid }}/Messages.json"
+
+    auth {
+      kind            = "basic"
+      username        = "{{ secrets.twilio_account_sid }}"
+      password_secret = "twilio.auth_token"
+    }
+
+    query = {
+      To       = "{{ args.to }}"
+      From     = "{{ args.from }}"
+      PageSize = "{{ args.page_size }}"
+    }
+  }
+
+  result {
+    decode = "json"
+    extract { json_pointer = "/messages" }
+    output = "{{ result | length }} messages returned"
+  }
+}
+
+command "get_message" {
+  title       = "Get message"
+  summary     = "Get details of a specific message by SID"
+  description = "Retrieve full details of a single SMS/MMS message by its SID."
+  categories  = ["messaging"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["twilio.account_sid", "twilio.auth_token"]
+  }
+
+  param "message_sid" {
+    type        = "string"
+    required    = true
+    description = "Message SID (starts with SM or MM)"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://api.twilio.com/2010-04-01/Accounts/{{ secrets.twilio_account_sid }}/Messages/{{ args.message_sid }}.json"
+
+    auth {
+      kind            = "basic"
+      username        = "{{ secrets.twilio_account_sid }}"
+      password_secret = "twilio.auth_token"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Message {{ result.sid }} ({{ result.status }})\nDirection: {{ result.direction }}\nFrom: {{ result.from }} → To: {{ result.to }}\nBody: {{ result.body }}\nSent: {{ result.date_sent }} | Segments: {{ result.num_segments }} | Price: {{ result.price }} {{ result.price_unit }}"
+  }
+}
+
+command "delete_message" {
+  title       = "Delete message"
+  summary     = "Delete a message by SID"
+  description = "Permanently delete an SMS/MMS message from your account by its SID."
+  categories  = ["messaging"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["twilio.account_sid", "twilio.auth_token"]
+  }
+
+  param "message_sid" {
+    type        = "string"
+    required    = true
+    description = "Message SID to delete (starts with SM or MM)"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "DELETE"
+    url      = "https://api.twilio.com/2010-04-01/Accounts/{{ secrets.twilio_account_sid }}/Messages/{{ args.message_sid }}.json"
+
+    auth {
+      kind            = "basic"
+      username        = "{{ secrets.twilio_account_sid }}"
+      password_secret = "twilio.auth_token"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Deleted message {{ args.message_sid }}"
+  }
+}
+
+command "create_call" {
+  title       = "Create call"
+  summary     = "Initiate an outbound phone call"
+  description = "Place an outbound call via Twilio. Provide TwiML instructions inline or via a URL to control call behavior."
+  categories  = ["voice"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["twilio.account_sid", "twilio.auth_token"]
+  }
+
+  param "to" {
+    type        = "string"
+    required    = true
+    description = "Recipient phone number in E.164 format"
+  }
+
+  param "from" {
+    type        = "string"
+    required    = true
+    description = "Caller phone number (must be a Twilio number or verified caller ID)"
+  }
+
+  param "twiml" {
+    type        = "string"
+    required    = false
+    description = "Inline TwiML instructions (e.g. '<Response><Say>Hello</Say></Response>')"
+  }
+
+  param "url" {
+    type        = "string"
+    required    = false
+    description = "URL returning TwiML (alternative to twiml param)"
+  }
+
+  param "timeout" {
+    type        = "integer"
+    required    = false
+    default     = 60
+    description = "Seconds to wait for the call to be answered"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "POST"
+    url      = "https://api.twilio.com/2010-04-01/Accounts/{{ secrets.twilio_account_sid }}/Calls.json"
+
+    auth {
+      kind            = "basic"
+      username        = "{{ secrets.twilio_account_sid }}"
+      password_secret = "twilio.auth_token"
+    }
+
+    body {
+      kind = "form_urlencoded"
+      fields = {
+        To      = "{{ args.to }}"
+        From    = "{{ args.from }}"
+        Twiml   = "{{ args.twiml }}"
+        Url     = "{{ args.url }}"
+        Timeout = "{{ args.timeout }}"
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Call {{ result.sid }} {{ result.status }}\nFrom: {{ result.from_formatted }} → To: {{ result.to_formatted }}\nDirection: {{ result.direction }}"
+  }
+}
+
+command "list_calls" {
+  title       = "List calls"
+  summary     = "List recent phone calls"
+  description = "Retrieve a list of calls made to or from your Twilio account. Supports filtering by phone number and status."
+  categories  = ["voice"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["twilio.account_sid", "twilio.auth_token"]
+  }
+
+  param "to" {
+    type        = "string"
+    required    = false
+    description = "Filter by recipient phone number"
+  }
+
+  param "from" {
+    type        = "string"
+    required    = false
+    description = "Filter by caller phone number"
+  }
+
+  param "status" {
+    type        = "string"
+    required    = false
+    description = "Filter by status: queued, ringing, in-progress, completed, busy, failed, no-answer, canceled"
+  }
+
+  param "page_size" {
+    type        = "integer"
+    required    = false
+    default     = 20
+    description = "Number of results per page (1-1000)"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://api.twilio.com/2010-04-01/Accounts/{{ secrets.twilio_account_sid }}/Calls.json"
+
+    auth {
+      kind            = "basic"
+      username        = "{{ secrets.twilio_account_sid }}"
+      password_secret = "twilio.auth_token"
+    }
+
+    query = {
+      To       = "{{ args.to }}"
+      From     = "{{ args.from }}"
+      Status   = "{{ args.status }}"
+      PageSize = "{{ args.page_size }}"
+    }
+  }
+
+  result {
+    decode = "json"
+    extract { json_pointer = "/calls" }
+    output = "{{ result | length }} calls returned"
+  }
+}
+
+command "get_call" {
+  title       = "Get call"
+  summary     = "Get details of a specific call by SID"
+  description = "Retrieve full details of a phone call by its SID, including duration, price, and status."
+  categories  = ["voice"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["twilio.account_sid", "twilio.auth_token"]
+  }
+
+  param "call_sid" {
+    type        = "string"
+    required    = true
+    description = "Call SID (starts with CA)"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://api.twilio.com/2010-04-01/Accounts/{{ secrets.twilio_account_sid }}/Calls/{{ args.call_sid }}.json"
+
+    auth {
+      kind            = "basic"
+      username        = "{{ secrets.twilio_account_sid }}"
+      password_secret = "twilio.auth_token"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Call {{ result.sid }} ({{ result.status }})\nFrom: {{ result.from_formatted }} → To: {{ result.to_formatted }}\nDirection: {{ result.direction }} | Start: {{ result.start_time }} | End: {{ result.end_time }}\nDuration: {{ result.duration }}s | Price: {{ result.price }} {{ result.price_unit }}"
+  }
+}
+
+command "update_call" {
+  title       = "Update call"
+  summary     = "Modify or end a live call"
+  description = "Update a live call by redirecting it to new TwiML, or end it by setting status to completed or canceled."
+  categories  = ["voice"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["twilio.account_sid", "twilio.auth_token"]
+  }
+
+  param "call_sid" {
+    type        = "string"
+    required    = true
+    description = "Call SID to update (starts with CA)"
+  }
+
+  param "status" {
+    type        = "string"
+    required    = false
+    description = "Set to 'completed' to hang up or 'canceled' to cancel a queued call"
+  }
+
+  param "twiml" {
+    type        = "string"
+    required    = false
+    description = "New TwiML instructions to redirect the live call"
+  }
+
+  param "url" {
+    type        = "string"
+    required    = false
+    description = "New TwiML URL to redirect the live call"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "POST"
+    url      = "https://api.twilio.com/2010-04-01/Accounts/{{ secrets.twilio_account_sid }}/Calls/{{ args.call_sid }}.json"
+
+    auth {
+      kind            = "basic"
+      username        = "{{ secrets.twilio_account_sid }}"
+      password_secret = "twilio.auth_token"
+    }
+
+    body {
+      kind = "form_urlencoded"
+      fields = {
+        Status = "{{ args.status }}"
+        Twiml  = "{{ args.twiml }}"
+        Url    = "{{ args.url }}"
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Call {{ result.sid }} updated → {{ result.status }}"
+  }
+}
+
+command "list_incoming_numbers" {
+  title       = "List phone numbers"
+  summary     = "List your Twilio phone numbers"
+  description = "List all phone numbers owned by your Twilio account, with their capabilities and configuration."
+  categories  = ["telephony"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["twilio.account_sid", "twilio.auth_token"]
+  }
+
+  param "phone_number" {
+    type        = "string"
+    required    = false
+    description = "Filter by exact phone number (E.164)"
+  }
+
+  param "friendly_name" {
+    type        = "string"
+    required    = false
+    description = "Filter by friendly name"
+  }
+
+  param "page_size" {
+    type        = "integer"
+    required    = false
+    default     = 20
+    description = "Number of results per page (1-1000)"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://api.twilio.com/2010-04-01/Accounts/{{ secrets.twilio_account_sid }}/IncomingPhoneNumbers.json"
+
+    auth {
+      kind            = "basic"
+      username        = "{{ secrets.twilio_account_sid }}"
+      password_secret = "twilio.auth_token"
+    }
+
+    query = {
+      PhoneNumber  = "{{ args.phone_number }}"
+      FriendlyName = "{{ args.friendly_name }}"
+      PageSize     = "{{ args.page_size }}"
+    }
+  }
+
+  result {
+    decode = "json"
+    extract { json_pointer = "/incoming_phone_numbers" }
+    output = "{{ result | length }} phone numbers"
+  }
+}
+
+command "list_available_numbers" {
+  title       = "Search available numbers"
+  summary     = "Search for phone numbers available for purchase"
+  description = "Search Twilio's inventory of available local phone numbers by country, area code, or capabilities."
+  categories  = ["telephony"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["twilio.account_sid", "twilio.auth_token"]
+  }
+
+  param "country_code" {
+    type        = "string"
+    required    = true
+    description = "ISO 3166-1 alpha-2 country code (e.g. US, GB, CA)"
+  }
+
+  param "area_code" {
+    type        = "integer"
+    required    = false
+    description = "Filter by area code (US/Canada)"
+  }
+
+  param "contains" {
+    type        = "string"
+    required    = false
+    description = "Pattern match (* = any digit, e.g. *867*)"
+  }
+
+  param "in_region" {
+    type        = "string"
+    required    = false
+    description = "State or province abbreviation (e.g. CA, NY)"
+  }
+
+  param "sms_enabled" {
+    type        = "boolean"
+    required    = false
+    description = "Only return SMS-capable numbers"
+  }
+
+  param "page_size" {
+    type        = "integer"
+    required    = false
+    default     = 20
+    description = "Number of results per page"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://api.twilio.com/2010-04-01/Accounts/{{ secrets.twilio_account_sid }}/AvailablePhoneNumbers/{{ args.country_code }}/Local.json"
+
+    auth {
+      kind            = "basic"
+      username        = "{{ secrets.twilio_account_sid }}"
+      password_secret = "twilio.auth_token"
+    }
+
+    query = {
+      AreaCode   = "{{ args.area_code }}"
+      Contains   = "{{ args.contains }}"
+      InRegion   = "{{ args.in_region }}"
+      SmsEnabled = "{{ args.sms_enabled }}"
+      PageSize   = "{{ args.page_size }}"
+    }
+  }
+
+  result {
+    decode = "json"
+    extract { json_pointer = "/available_phone_numbers" }
+    output = "{{ result | length }} numbers available"
+  }
+}
+
+command "purchase_number" {
+  title       = "Purchase number"
+  summary     = "Buy a phone number from Twilio's inventory"
+  description = "Purchase an available phone number and add it to your Twilio account."
+  categories  = ["telephony"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["twilio.account_sid", "twilio.auth_token"]
+  }
+
+  param "phone_number" {
+    type        = "string"
+    required    = true
+    description = "Phone number to purchase in E.164 format"
+  }
+
+  param "friendly_name" {
+    type        = "string"
+    required    = false
+    description = "Human-readable label for this number (max 64 chars)"
+  }
+
+  param "voice_url" {
+    type        = "string"
+    required    = false
+    description = "Webhook URL for incoming voice calls"
+  }
+
+  param "sms_url" {
+    type        = "string"
+    required    = false
+    description = "Webhook URL for incoming SMS"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "POST"
+    url      = "https://api.twilio.com/2010-04-01/Accounts/{{ secrets.twilio_account_sid }}/IncomingPhoneNumbers.json"
+
+    auth {
+      kind            = "basic"
+      username        = "{{ secrets.twilio_account_sid }}"
+      password_secret = "twilio.auth_token"
+    }
+
+    body {
+      kind = "form_urlencoded"
+      fields = {
+        PhoneNumber  = "{{ args.phone_number }}"
+        FriendlyName = "{{ args.friendly_name }}"
+        VoiceUrl     = "{{ args.voice_url }}"
+        SmsUrl       = "{{ args.sms_url }}"
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Purchased {{ result.phone_number }} ({{ result.friendly_name }})\nSID: {{ result.sid }}\nVoice: {{ result.capabilities.voice }} | SMS: {{ result.capabilities.sms }} | MMS: {{ result.capabilities.mms }}"
+  }
+}
+
+command "release_number" {
+  title       = "Release number"
+  summary     = "Release a phone number from your account"
+  description = "Remove a phone number from your Twilio account. This cannot be undone."
+  categories  = ["telephony"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["twilio.account_sid", "twilio.auth_token"]
+  }
+
+  param "phone_sid" {
+    type        = "string"
+    required    = true
+    description = "SID of the phone number to release (starts with PN)"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "DELETE"
+    url      = "https://api.twilio.com/2010-04-01/Accounts/{{ secrets.twilio_account_sid }}/IncomingPhoneNumbers/{{ args.phone_sid }}.json"
+
+    auth {
+      kind            = "basic"
+      username        = "{{ secrets.twilio_account_sid }}"
+      password_secret = "twilio.auth_token"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Released phone number {{ args.phone_sid }}"
+  }
+}
+
+command "lookup_phone_number" {
+  title       = "Lookup phone number"
+  summary     = "Look up information about a phone number"
+  description = "Query the Twilio Lookup API for carrier, caller name, and validation data on any phone number."
+  categories  = ["telephony"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["twilio.account_sid", "twilio.auth_token"]
+  }
+
+  param "phone_number" {
+    type        = "string"
+    required    = true
+    description = "Phone number to look up in E.164 format"
+  }
+
+  param "fields" {
+    type        = "string"
+    required    = false
+    description = "Comma-separated data fields: validation, line_type_intelligence, caller_name, sim_swap, sms_pumping_risk"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://lookups.twilio.com/v2/PhoneNumbers/{{ args.phone_number }}"
+
+    auth {
+      kind            = "basic"
+      username        = "{{ secrets.twilio_account_sid }}"
+      password_secret = "twilio.auth_token"
+    }
+
+    query = {
+      Fields = "{{ args.fields }}"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "{{ result.phone_number }} ({{ result.national_format }})\nCountry: {{ result.country_code }} | Valid: {{ result.valid }}"
+  }
+}
+
+command "get_account" {
+  title       = "Get account info"
+  summary     = "Get your Twilio account details"
+  description = "Retrieve details about your Twilio account including name, status, and type."
+  categories  = ["telephony"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["twilio.account_sid", "twilio.auth_token"]
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://api.twilio.com/2010-04-01/Accounts/{{ secrets.twilio_account_sid }}.json"
+
+    auth {
+      kind            = "basic"
+      username        = "{{ secrets.twilio_account_sid }}"
+      password_secret = "twilio.auth_token"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Account {{ result.sid }}\nName: {{ result.friendly_name }}\nStatus: {{ result.status }} | Type: {{ result.type }}\nCreated: {{ result.date_created }}"
+  }
+}

--- a/examples/vercel.hcl
+++ b/examples/vercel.hcl
@@ -1,0 +1,790 @@
+version = 1
+provider = "vercel"
+categories = ["hosting", "deployment", "infrastructure"]
+
+command "get_user" {
+  title       = "Get user"
+  summary     = "Get the authenticated user's profile"
+  description = "Retrieve profile information for the currently authenticated Vercel user."
+  categories  = ["read"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["vercel.token"]
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://api.vercel.com/v2/user"
+
+    auth {
+      kind   = "bearer"
+      secret = "vercel.token"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "User: {{ result.user.username }} ({{ result.user.uid }}), Email: {{ result.user.email }}, Name: {{ result.user.name }}"
+  }
+}
+
+command "list_projects" {
+  title       = "List projects"
+  summary     = "List Vercel projects"
+  description = "Retrieve a list of projects, optionally filtered by name or repository."
+  categories  = ["read", "projects"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["vercel.token"]
+  }
+
+  param "search" {
+    type        = "string"
+    required    = false
+    description = "Search projects by name"
+  }
+
+  param "limit" {
+    type        = "integer"
+    required    = false
+    default     = 20
+    description = "Maximum number of projects to return"
+  }
+
+  param "teamId" {
+    type        = "string"
+    required    = false
+    description = "Team identifier to scope the request"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://api.vercel.com/v10/projects"
+
+    auth {
+      kind   = "bearer"
+      secret = "vercel.token"
+    }
+
+    query = {
+      search = "{{ args.search }}"
+      limit  = "{{ args.limit }}"
+      teamId = "{{ args.teamId }}"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Found {{ result.projects | length }} projects."
+  }
+}
+
+command "get_project" {
+  title       = "Get project"
+  summary     = "Get details of a Vercel project"
+  description = "Retrieve detailed information about a specific project by ID or name."
+  categories  = ["read", "projects"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["vercel.token"]
+  }
+
+  param "id" {
+    type        = "string"
+    required    = true
+    description = "Project ID or name"
+  }
+
+  param "teamId" {
+    type        = "string"
+    required    = false
+    description = "Team identifier to scope the request"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://api.vercel.com/v10/projects/{{ args.id }}"
+
+    auth {
+      kind   = "bearer"
+      secret = "vercel.token"
+    }
+
+    query = {
+      teamId = "{{ args.teamId }}"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Project: {{ result.name }} ({{ result.id }}), Framework: {{ result.framework }}, Node: {{ result.nodeVersion }}, Updated: {{ result.updatedAt }}"
+  }
+}
+
+command "create_project" {
+  title       = "Create project"
+  summary     = "Create a new Vercel project"
+  description = "Create a new project in Vercel with the specified name and optional configuration."
+  categories  = ["write", "projects"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["vercel.token"]
+  }
+
+  param "name" {
+    type        = "string"
+    required    = true
+    description = "Project name"
+  }
+
+  param "framework" {
+    type        = "string"
+    required    = false
+    description = "Framework preset (e.g. nextjs, vite, remix)"
+  }
+
+  param "buildCommand" {
+    type        = "string"
+    required    = false
+    description = "Custom build command"
+  }
+
+  param "outputDirectory" {
+    type        = "string"
+    required    = false
+    description = "Custom output directory"
+  }
+
+  param "teamId" {
+    type        = "string"
+    required    = false
+    description = "Team identifier to scope the request"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "POST"
+    url      = "https://api.vercel.com/v11/projects"
+
+    auth {
+      kind   = "bearer"
+      secret = "vercel.token"
+    }
+
+    query = {
+      teamId = "{{ args.teamId }}"
+    }
+
+    body {
+      kind = "json"
+      value = {
+        name            = "{{ args.name }}"
+        framework       = "{{ args.framework }}"
+        buildCommand    = "{{ args.buildCommand }}"
+        outputDirectory = "{{ args.outputDirectory }}"
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Project created: {{ result.name }} ({{ result.id }}), Framework: {{ result.framework }}"
+  }
+}
+
+command "delete_project" {
+  title       = "Delete project"
+  summary     = "Delete a Vercel project"
+  description = "Permanently delete a project by ID or name. This action cannot be undone."
+  categories  = ["write", "projects"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["vercel.token"]
+  }
+
+  param "id" {
+    type        = "string"
+    required    = true
+    description = "Project ID or name"
+  }
+
+  param "teamId" {
+    type        = "string"
+    required    = false
+    description = "Team identifier to scope the request"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "DELETE"
+    url      = "https://api.vercel.com/v10/projects/{{ args.id }}"
+
+    auth {
+      kind   = "bearer"
+      secret = "vercel.token"
+    }
+
+    query = {
+      teamId = "{{ args.teamId }}"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Project \"{{ args.id }}\" deleted."
+  }
+}
+
+command "list_deployments" {
+  title       = "List deployments"
+  summary     = "List Vercel deployments"
+  description = "Retrieve a list of deployments, optionally filtered by project, state, or target environment."
+  categories  = ["read", "deployments"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["vercel.token"]
+  }
+
+  param "projectId" {
+    type        = "string"
+    required    = false
+    description = "Filter by project ID or name"
+  }
+
+  param "state" {
+    type        = "string"
+    required    = false
+    description = "Filter by state: BUILDING, ERROR, INITIALIZING, QUEUED, READY, CANCELED"
+  }
+
+  param "target" {
+    type        = "string"
+    required    = false
+    description = "Filter by environment (production or preview)"
+  }
+
+  param "limit" {
+    type        = "integer"
+    required    = false
+    default     = 20
+    description = "Maximum number of deployments to return"
+  }
+
+  param "teamId" {
+    type        = "string"
+    required    = false
+    description = "Team identifier to scope the request"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://api.vercel.com/v6/deployments"
+
+    auth {
+      kind   = "bearer"
+      secret = "vercel.token"
+    }
+
+    query = {
+      projectId = "{{ args.projectId }}"
+      state     = "{{ args.state }}"
+      target    = "{{ args.target }}"
+      limit     = "{{ args.limit }}"
+      teamId    = "{{ args.teamId }}"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Found {{ result.deployments | length }} deployments."
+  }
+}
+
+command "get_deployment" {
+  title       = "Get deployment"
+  summary     = "Get details of a specific deployment"
+  description = "Retrieve detailed information about a deployment by its ID or hostname."
+  categories  = ["read", "deployments"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["vercel.token"]
+  }
+
+  param "id" {
+    type        = "string"
+    required    = true
+    description = "Deployment ID or hostname"
+  }
+
+  param "teamId" {
+    type        = "string"
+    required    = false
+    description = "Team identifier to scope the request"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://api.vercel.com/v13/deployments/{{ args.id }}"
+
+    auth {
+      kind   = "bearer"
+      secret = "vercel.token"
+    }
+
+    query = {
+      teamId = "{{ args.teamId }}"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Deployment {{ result.id }}: {{ result.name }}, URL: {{ result.url }}, Status: {{ result.readyState }}, Target: {{ result.target }}, Created: {{ result.createdAt }}"
+  }
+}
+
+command "create_deployment" {
+  title       = "Create deployment"
+  summary     = "Create a new Vercel deployment"
+  description = "Trigger a new deployment for a project. Can optionally target a specific environment or redeploy an existing deployment."
+  categories  = ["write", "deployments"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["vercel.token"]
+  }
+
+  param "name" {
+    type        = "string"
+    required    = true
+    description = "Project name used in the deployment URL"
+  }
+
+  param "project" {
+    type        = "string"
+    required    = false
+    description = "Target project identifier"
+  }
+
+  param "target" {
+    type        = "string"
+    required    = false
+    description = "Target environment: staging, production, or a custom environment ID"
+  }
+
+  param "deploymentId" {
+    type        = "string"
+    required    = false
+    description = "Existing deployment ID to redeploy"
+  }
+
+  param "teamId" {
+    type        = "string"
+    required    = false
+    description = "Team identifier to scope the request"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "POST"
+    url      = "https://api.vercel.com/v13/deployments"
+
+    auth {
+      kind   = "bearer"
+      secret = "vercel.token"
+    }
+
+    query = {
+      teamId = "{{ args.teamId }}"
+    }
+
+    body {
+      kind = "json"
+      value = {
+        name         = "{{ args.name }}"
+        project      = "{{ args.project }}"
+        target       = "{{ args.target }}"
+        deploymentId = "{{ args.deploymentId }}"
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Deployment created: {{ result.id }}, URL: {{ result.url }}, Status: {{ result.readyState }}, Project: {{ result.name }}"
+  }
+}
+
+command "cancel_deployment" {
+  title       = "Cancel deployment"
+  summary     = "Cancel a running deployment"
+  description = "Cancel a deployment that is currently building or queued."
+  categories  = ["write", "deployments"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["vercel.token"]
+  }
+
+  param "id" {
+    type        = "string"
+    required    = true
+    description = "Deployment ID to cancel"
+  }
+
+  param "teamId" {
+    type        = "string"
+    required    = false
+    description = "Team identifier to scope the request"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "PATCH"
+    url      = "https://api.vercel.com/v12/deployments/{{ args.id }}/cancel"
+
+    auth {
+      kind   = "bearer"
+      secret = "vercel.token"
+    }
+
+    query = {
+      teamId = "{{ args.teamId }}"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Deployment {{ result.id }} canceled. State: {{ result.readyState }}"
+  }
+}
+
+command "delete_deployment" {
+  title       = "Delete deployment"
+  summary     = "Delete a Vercel deployment"
+  description = "Permanently delete a deployment by ID. This action cannot be undone."
+  categories  = ["write", "deployments"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["vercel.token"]
+  }
+
+  param "id" {
+    type        = "string"
+    required    = true
+    description = "Deployment ID to delete"
+  }
+
+  param "teamId" {
+    type        = "string"
+    required    = false
+    description = "Team identifier to scope the request"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "DELETE"
+    url      = "https://api.vercel.com/v13/deployments/{{ args.id }}"
+
+    auth {
+      kind   = "bearer"
+      secret = "vercel.token"
+    }
+
+    query = {
+      teamId = "{{ args.teamId }}"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Deployment {{ args.id }} deleted."
+  }
+}
+
+command "rollback_deployment" {
+  title       = "Rollback deployment"
+  summary     = "Rollback a project to a previous deployment"
+  description = "Rollback a project's production deployment to a previously successful deployment."
+  categories  = ["write", "deployments"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["vercel.token"]
+  }
+
+  param "project_id" {
+    type        = "string"
+    required    = true
+    description = "Project ID"
+  }
+
+  param "deployment_id" {
+    type        = "string"
+    required    = true
+    description = "Deployment ID to rollback to"
+  }
+
+  param "description" {
+    type        = "string"
+    required    = false
+    description = "Reason for the rollback"
+  }
+
+  param "teamId" {
+    type        = "string"
+    required    = false
+    description = "Team identifier to scope the request"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "POST"
+    url      = "https://api.vercel.com/v1/projects/{{ args.project_id }}/rollback/{{ args.deployment_id }}"
+
+    auth {
+      kind   = "bearer"
+      secret = "vercel.token"
+    }
+
+    query = {
+      teamId = "{{ args.teamId }}"
+    }
+
+    body {
+      kind = "json"
+      value = {
+        description = "{{ args.description }}"
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Rolled back project {{ args.project_id }} to deployment {{ args.deployment_id }}."
+  }
+}
+
+command "list_env_vars" {
+  title       = "List environment variables"
+  summary     = "List environment variables for a project"
+  description = "Retrieve all environment variables configured for a specific project."
+  categories  = ["read", "projects"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["vercel.token"]
+  }
+
+  param "project_id" {
+    type        = "string"
+    required    = true
+    description = "Project ID or name"
+  }
+
+  param "decrypt" {
+    type        = "string"
+    required    = false
+    description = "Set to 'true' to decrypt secret values"
+  }
+
+  param "teamId" {
+    type        = "string"
+    required    = false
+    description = "Team identifier to scope the request"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://api.vercel.com/v10/projects/{{ args.project_id }}/env"
+
+    auth {
+      kind   = "bearer"
+      secret = "vercel.token"
+    }
+
+    query = {
+      decrypt = "{{ args.decrypt }}"
+      teamId  = "{{ args.teamId }}"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Found {{ result.envs | length }} environment variables for project {{ args.project_id }}."
+  }
+}
+
+command "create_env_var" {
+  title       = "Create environment variable"
+  summary     = "Create an environment variable for a project"
+  description = "Add a new environment variable to a Vercel project for the specified target environments."
+  categories  = ["write", "projects"]
+
+  annotations {
+    mode    = "write"
+    secrets = ["vercel.token"]
+  }
+
+  param "project_id" {
+    type        = "string"
+    required    = true
+    description = "Project ID or name"
+  }
+
+  param "key" {
+    type        = "string"
+    required    = true
+    description = "Environment variable name"
+  }
+
+  param "value" {
+    type        = "string"
+    required    = true
+    description = "Environment variable value"
+  }
+
+  param "type" {
+    type        = "string"
+    required    = true
+    description = "Variable type: plain, secret, or system"
+  }
+
+  param "teamId" {
+    type        = "string"
+    required    = false
+    description = "Team identifier to scope the request"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "POST"
+    url      = "https://api.vercel.com/v10/projects/{{ args.project_id }}/env"
+
+    auth {
+      kind   = "bearer"
+      secret = "vercel.token"
+    }
+
+    query = {
+      teamId = "{{ args.teamId }}"
+    }
+
+    body {
+      kind = "json"
+      value = {
+        key   = "{{ args.key }}"
+        value = "{{ args.value }}"
+        type  = "{{ args.type }}"
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Environment variable created: {{ result.created.key }} ({{ result.created.id }}), Type: {{ result.created.type }}"
+  }
+}
+
+command "list_domains" {
+  title       = "List domains"
+  summary     = "List domains on the account"
+  description = "Retrieve all domains registered with the Vercel account or team."
+  categories  = ["read", "domains"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["vercel.token"]
+  }
+
+  param "limit" {
+    type        = "integer"
+    required    = false
+    default     = 20
+    description = "Maximum number of domains to return"
+  }
+
+  param "teamId" {
+    type        = "string"
+    required    = false
+    description = "Team identifier to scope the request"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://api.vercel.com/v6/domains"
+
+    auth {
+      kind   = "bearer"
+      secret = "vercel.token"
+    }
+
+    query = {
+      limit  = "{{ args.limit }}"
+      teamId = "{{ args.teamId }}"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Found {{ result.domains | length }} domains."
+  }
+}
+
+command "get_domain" {
+  title       = "Get domain"
+  summary     = "Get details of a domain"
+  description = "Retrieve detailed information about a specific domain including verification and nameserver status."
+  categories  = ["read", "domains"]
+
+  annotations {
+    mode    = "read"
+    secrets = ["vercel.token"]
+  }
+
+  param "domain" {
+    type        = "string"
+    required    = true
+    description = "Domain name"
+  }
+
+  param "teamId" {
+    type        = "string"
+    required    = false
+    description = "Team identifier to scope the request"
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://api.vercel.com/v6/domains/{{ args.domain }}"
+
+    auth {
+      kind   = "bearer"
+      secret = "vercel.token"
+    }
+
+    query = {
+      teamId = "{{ args.teamId }}"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Domain: {{ result.domain.name }}, Verified: {{ result.domain.verified }}, Created: {{ result.domain.createdAt }}"
+  }
+}


### PR DESCRIPTION
## Summary

- Adds 25 pre-built Earl template files in `examples/` covering popular SaaS APIs
- 349 total commands across all providers with CRUD, search, and action operations
- All templates validated with `earl templates validate`

### Companies included

| Category | Companies |
|----------|-----------|
| Dev Tools | GitHub, GitLab, Jira, Linear, PagerDuty |
| Communication | Slack, Discord, Twilio, SendGrid |
| Cloud | Cloudflare, Vercel, Render |
| Payments | Stripe, Shopify |
| CRM | HubSpot, Mailchimp |
| Analytics | Datadog, Sentry |
| AI/ML | OpenAI, Anthropic |
| Productivity | Notion, Airtable |
| Auth | Auth0 |
| Storage | Supabase, Resend |

## Test plan

- [x] All 25 templates pass `earl templates validate`
- [ ] Spot-check a few templates against live API docs for accuracy
- [ ] Verify auth patterns match each provider's documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)