### PR TITLE
feat: add streaming support for HTTP, gRPC, and Bash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1364,6 +1364,7 @@ dependencies = [
  "reqwest 0.13.2",
  "serde",
  "serde_json",
+ "tokio",
  "url",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1412,6 +1412,7 @@ dependencies = [
  "reqwest 0.13.2",
  "serde",
  "serde_json",
+ "tokio",
  "url",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -241,9 +241,9 @@ dependencies = [
 
 [[package]]
 name = "async-executor"
-version = "1.13.3"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "497c00e0fd83a72a79a39fcbd8e3e2f055d6f6c7e025f3b3d91f4f8e76527fb8"
+checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
 dependencies = [
  "async-task",
  "concurrent-queue",
@@ -255,9 +255,9 @@ dependencies = [
 
 [[package]]
 name = "async-fs"
-version = "2.1.3"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09f7e37c0ed80b2a977691c47dae8625cfb21e205827106c64f7c588766b2e50"
+checksum = "8034a681df4aed8b8edbd7fbe472401ecf009251c8b40556b304567052e294c5"
 dependencies = [
  "async-lock",
  "blocking",
@@ -2348,9 +2348,9 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "200072f5d0e3614556f94a9930d5dc3e0662a652823904c3a75dc3b0af7fee47"
+checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
 dependencies = [
  "displaydoc",
  "potential_utf",
@@ -2367,7 +2367,6 @@ checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
 dependencies = [
  "displaydoc",
  "litemap",
- "serde",
  "tinystr",
  "writeable",
  "zerovec",
@@ -2375,11 +2374,10 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.0.1"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b24a59706036ba941c9476a55cd57b82b77f38a3c667d637ee7cabbc85eaedc"
+checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
 dependencies = [
- "displaydoc",
  "icu_collections",
  "icu_normalizer_data",
  "icu_properties",
@@ -2390,31 +2388,29 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00210d6893afc98edb752b664b8890f0ef174c8adbb8d0be9710fa66fbbf72d3"
+checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
 
 [[package]]
 name = "icu_properties"
-version = "2.0.2"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5a97b8ac6235e69506e8dacfb2adf38461d2ce6d3e9bd9c94c4cbc3cd4400a4"
+checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
 dependencies = [
- "displaydoc",
  "icu_collections",
  "icu_locale_core",
  "icu_properties_data",
  "icu_provider",
- "potential_utf",
  "zerotrie",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_properties_data"
-version = "2.0.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "298459143998310acd25ffe6810ed544932242d3f07083eee1084d83a71bd632"
+checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
 
 [[package]]
 name = "icu_provider"
@@ -2424,8 +2420,6 @@ checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
- "serde",
- "stable_deref_trait",
  "writeable",
  "yoke",
  "zerofrom",
@@ -2667,9 +2661,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.85"
+version = "0.3.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
+checksum = "c7e709f3e3d22866f9c25b3aff01af289b18422cc8b4262fb19103ee80fe513d"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -2806,9 +2800,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
@@ -2975,9 +2969,9 @@ dependencies = [
 
 [[package]]
 name = "minijinja"
-version = "2.15.1"
+version = "2.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b479616bb6f0779fb0f3964246beda02d4b01144e1b0d5519616e012ccc2a245"
+checksum = "5c54f3bcc034dd74496b5ca929fd0b710186672d5ff0b0f255a9ceb259042ece"
 dependencies = [
  "memo-map",
  "self_cell",
@@ -3382,9 +3376,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-src"
-version = "300.5.3+3.5.4"
+version = "300.5.5+3.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc6bad8cd0233b63971e232cc9c5e83039375b8586d2312f31fda85db8f888c2"
+checksum = "3f1787d533e03597a7934fd0a765f0d28e94ecc5fb7789f8053b1e699a56f709"
 dependencies = [
  "cc",
 ]
@@ -4331,9 +4325,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
  "bitflags",
  "errno",
@@ -5338,7 +5332,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
 dependencies = [
  "displaydoc",
- "serde_core",
  "zerovec",
 ]
 
@@ -5998,9 +5991,9 @@ checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.108"
+version = "0.2.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64024a30ec1e37399cf85a7ffefebdb72205ca1c972291c51512360d90bd8566"
+checksum = "ec1adf1535672f5b7824f817792b1afd731d7e843d2d04ec8f27e8cb51edd8ac"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -6011,9 +6004,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.58"
+version = "0.4.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70a6e77fd0ae8029c9ea0063f87c46fde723e7d887703d74ad2616d792e51e6f"
+checksum = "fe88540d1c934c4ec8e6db0afa536876c5441289d7f9f9123d4f065ac1250a6b"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -6025,9 +6018,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.108"
+version = "0.2.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "008b239d9c740232e71bd39e8ef6429d27097518b6b30bdf9086833bd5b6d608"
+checksum = "19e638317c08b21663aed4d2b9a2091450548954695ff4efa75bff5fa546b3b1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -6035,9 +6028,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.108"
+version = "0.2.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5256bae2d58f54820e6490f9839c49780dff84c65aeab9e772f15d5f0e913a55"
+checksum = "2c64760850114d03d5f65457e96fc988f11f01d38fbaa51b254e4ab5809102af"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -6048,9 +6041,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.108"
+version = "0.2.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
+checksum = "60eecd4fe26177cfa3339eb00b4a36445889ba3ad37080c2429879718e20ca41"
 dependencies = [
  "unicode-ident",
 ]
@@ -6104,9 +6097,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.85"
+version = "0.3.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "312e32e551d92129218ea9a2452120f4aabc03529ef03e4d0d82fb2780608598"
+checksum = "9d6bb20ed2d9572df8584f6dc81d68a41a625cadc6f15999d649a70ce7e3597a"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -6890,7 +6883,6 @@ version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
 dependencies = [
- "serde",
  "yoke",
  "zerofrom",
  "zerovec-derive",

--- a/crates/earl-core/Cargo.toml
+++ b/crates/earl-core/Cargo.toml
@@ -14,4 +14,8 @@ base64 = "0.22"
 reqwest = { version = "0.13.2", default-features = false, features = ["rustls"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+tokio = { version = "1", features = ["sync"] }
 url = "2.5"
+
+[dev-dependencies]
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync"] }

--- a/crates/earl-core/src/lib.rs
+++ b/crates/earl-core/src/lib.rs
@@ -56,6 +56,20 @@ pub struct RawExecutionResult {
     pub content_type: Option<String>,
 }
 
+/// A single chunk from a streaming response.
+#[derive(Debug, Clone)]
+pub struct StreamChunk {
+    pub data: Vec<u8>,
+    pub content_type: Option<String>,
+}
+
+/// Metadata returned when a streaming execution completes.
+#[derive(Debug, Clone)]
+pub struct StreamMeta {
+    pub status: u16,
+    pub url: String,
+}
+
 /// Shared execution context passed to all protocol executors alongside
 /// their protocol-specific prepared data.
 #[derive(Debug, Clone)]
@@ -84,4 +98,28 @@ pub trait ProtocolExecutor {
         data: &Self::PreparedData,
         context: &ExecutionContext,
     ) -> impl Future<Output = anyhow::Result<RawExecutionResult>> + Send;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn stream_chunk_can_be_created() {
+        let chunk = StreamChunk {
+            data: b"hello".to_vec(),
+            content_type: Some("application/json".to_string()),
+        };
+        assert_eq!(chunk.data, b"hello");
+        assert_eq!(chunk.content_type.as_deref(), Some("application/json"));
+    }
+
+    #[test]
+    fn stream_meta_can_be_created() {
+        let meta = StreamMeta {
+            status: 200,
+            url: "https://example.com".to_string(),
+        };
+        assert_eq!(meta.status, 200);
+    }
 }

--- a/crates/earl-core/src/lib.rs
+++ b/crates/earl-core/src/lib.rs
@@ -100,6 +100,24 @@ pub trait ProtocolExecutor {
     ) -> impl Future<Output = anyhow::Result<RawExecutionResult>> + Send;
 }
 
+/// Contract for protocol executors that support streaming output.
+///
+/// Instead of buffering the full response, the executor sends individual
+/// chunks through the provided `mpsc::Sender` as they arrive.
+pub trait StreamingProtocolExecutor {
+    /// Protocol-specific prepared data.
+    type PreparedData: Clone + std::fmt::Debug + Send + Sync;
+
+    /// Execute a streaming request, sending chunks through `sender`.
+    /// Returns metadata about the completed stream.
+    fn execute_stream(
+        &mut self,
+        data: &Self::PreparedData,
+        context: &ExecutionContext,
+        sender: tokio::sync::mpsc::Sender<StreamChunk>,
+    ) -> impl Future<Output = anyhow::Result<StreamMeta>> + Send;
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -121,5 +139,73 @@ mod tests {
             url: "https://example.com".to_string(),
         };
         assert_eq!(meta.status, 200);
+    }
+}
+
+#[cfg(test)]
+mod streaming_tests {
+    use super::*;
+    use serde_json::Map;
+    use std::time::Duration;
+    use tokio::sync::mpsc;
+
+    struct MockStreamExecutor;
+
+    impl StreamingProtocolExecutor for MockStreamExecutor {
+        type PreparedData = String;
+
+        async fn execute_stream(
+            &mut self,
+            _data: &String,
+            _context: &ExecutionContext,
+            sender: mpsc::Sender<StreamChunk>,
+        ) -> anyhow::Result<StreamMeta> {
+            sender
+                .send(StreamChunk {
+                    data: b"chunk1".to_vec(),
+                    content_type: None,
+                })
+                .await
+                .unwrap();
+            Ok(StreamMeta {
+                status: 200,
+                url: "https://example.com".to_string(),
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn mock_streaming_executor_sends_chunks() {
+        let (tx, mut rx) = mpsc::channel(16);
+        let mut executor = MockStreamExecutor;
+        let context = ExecutionContext {
+            key: "test".to_string(),
+            mode: CommandMode::Read,
+            allow_rules: vec![],
+            transport: ResolvedTransport {
+                timeout: Duration::from_secs(30),
+                follow_redirects: true,
+                max_redirect_hops: 10,
+                retry_max_attempts: 0,
+                retry_backoff: Duration::from_millis(100),
+                retry_on_status: vec![],
+                compression: false,
+                tls_min_version: None,
+                proxy_url: None,
+                max_response_bytes: 10_000_000,
+            },
+            result_template: ResultTemplate::default(),
+            args: Map::new(),
+            redactor: Redactor::new(vec![]),
+        };
+
+        let meta = executor
+            .execute_stream(&"test".to_string(), &context, tx)
+            .await
+            .unwrap();
+
+        assert_eq!(meta.status, 200);
+        let chunk = rx.recv().await.unwrap();
+        assert_eq!(chunk.data, b"chunk1");
     }
 }

--- a/crates/earl-protocol-bash/src/executor.rs
+++ b/crates/earl-protocol-bash/src/executor.rs
@@ -2,9 +2,9 @@ use std::process::Stdio;
 use std::time::Duration;
 
 use anyhow::{Context, Result, bail};
-use tokio::io::{AsyncRead, AsyncReadExt, AsyncWriteExt};
+use tokio::io::{AsyncBufReadExt, AsyncRead, AsyncReadExt, AsyncWriteExt, BufReader};
 
-use earl_core::{ExecutionContext, RawExecutionResult};
+use earl_core::{ExecutionContext, RawExecutionResult, StreamChunk, StreamMeta};
 
 use crate::PreparedBashScript;
 use crate::sandbox::{build_sandboxed_command, sandbox_available, sandbox_tool_name};
@@ -127,7 +127,8 @@ pub async fn execute_bash_once(
     })
 }
 
-use earl_core::ProtocolExecutor;
+use earl_core::{ProtocolExecutor, StreamingProtocolExecutor};
+use tokio::sync::mpsc;
 
 /// Bash protocol executor.
 pub struct BashExecutor;
@@ -141,6 +142,162 @@ impl ProtocolExecutor for BashExecutor {
         ctx: &ExecutionContext,
     ) -> anyhow::Result<RawExecutionResult> {
         execute_bash_once(data, ctx).await
+    }
+}
+
+/// Streaming bash protocol executor.
+///
+/// Reuses the same sandboxed process setup as [`BashExecutor`] but streams
+/// stdout line-by-line through an `mpsc::Sender<StreamChunk>` instead of
+/// buffering the entire output.
+pub struct BashStreamExecutor;
+
+impl StreamingProtocolExecutor for BashStreamExecutor {
+    type PreparedData = PreparedBashScript;
+
+    async fn execute_stream(
+        &mut self,
+        data: &PreparedBashScript,
+        ctx: &ExecutionContext,
+        sender: mpsc::Sender<StreamChunk>,
+    ) -> anyhow::Result<StreamMeta> {
+        if !sandbox_available() {
+            bail!(
+                "bash sandbox tool ({}) is not available on this system; \
+                 install it or disable the bash feature",
+                sandbox_tool_name()
+            );
+        }
+
+        let mut command = build_sandboxed_command(
+            &data.script,
+            &data.env,
+            data.cwd.as_deref(),
+            &data.sandbox,
+        )?;
+
+        command.stdout(Stdio::piped());
+        command.stderr(Stdio::piped());
+
+        if data.stdin.is_some() {
+            command.stdin(Stdio::piped());
+        } else {
+            command.stdin(Stdio::null());
+        }
+
+        // SAFETY: setsid() creates a new session / process group so that we
+        // can kill the entire group on timeout without leaking children.
+        unsafe {
+            command.pre_exec(|| {
+                libc::setsid();
+                Ok(())
+            });
+        }
+
+        let mut child = command
+            .spawn()
+            .context("failed spawning sandboxed bash command")?;
+
+        let pid = child
+            .id()
+            .ok_or_else(|| anyhow::anyhow!("failed to obtain PID of spawned bash process"))?;
+
+        let stdout = child
+            .stdout
+            .take()
+            .ok_or_else(|| anyhow::anyhow!("failed capturing bash stdout"))?;
+        let stderr = child
+            .stderr
+            .take()
+            .ok_or_else(|| anyhow::anyhow!("failed capturing bash stderr"))?;
+
+        // Use sandbox output limit if set, otherwise fall back to transport limit.
+        let max_bytes = data
+            .sandbox
+            .max_output_bytes
+            .unwrap_or(ctx.transport.max_response_bytes);
+
+        // Drain stderr in a background task so the child process does not block.
+        let stderr_task =
+            tokio::spawn(async move { read_stream_limited(stderr, max_bytes, "stderr").await });
+
+        // Write stdin if present, then drop the handle so the child sees EOF.
+        if let Some(input) = &data.stdin
+            && let Some(mut stdin_handle) = child.stdin.take()
+        {
+            stdin_handle
+                .write_all(input.as_bytes())
+                .await
+                .context("failed writing stdin to bash process")?;
+        }
+
+        // Stream stdout line-by-line.
+        let mut reader = BufReader::new(stdout);
+        let mut line = String::new();
+        let mut total_bytes: usize = 0;
+
+        loop {
+            line.clear();
+            let bytes_read = reader
+                .read_line(&mut line)
+                .await
+                .context("failed reading bash stdout")?;
+            if bytes_read == 0 {
+                break;
+            }
+
+            total_bytes = total_bytes.saturating_add(bytes_read);
+            if total_bytes > max_bytes {
+                bail!(
+                    "bash stdout exceeded configured max output bytes ({max_bytes} bytes)"
+                );
+            }
+
+            let chunk = StreamChunk {
+                data: line.as_bytes().to_vec(),
+                content_type: None,
+            };
+            if sender.send(chunk).await.is_err() {
+                // Receiver dropped — stop streaming gracefully.
+                break;
+            }
+        }
+
+        // Drop the sender so the consumer sees the end of the stream.
+        drop(sender);
+
+        // Use sandbox timeout if set, otherwise fall back to transport timeout.
+        let timeout = data
+            .sandbox
+            .max_time_ms
+            .map(Duration::from_millis)
+            .unwrap_or(ctx.transport.timeout);
+
+        let status = match tokio::time::timeout(timeout, child.wait()).await {
+            Ok(wait_result) => wait_result.context("failed waiting for bash process")?,
+            Err(_) => {
+                // Timeout: kill the entire process group.
+                if let Ok(pgid) = i32::try_from(pid) {
+                    unsafe { libc::killpg(pgid, libc::SIGKILL) };
+                }
+                let _ = child.kill().await;
+                let _ = child.wait().await;
+                bail!("bash script timed out after {timeout:?}");
+            }
+        };
+
+        // Wait for stderr drain to finish (ignore errors — we don't stream stderr).
+        let _ = stderr_task.await;
+
+        let exit_code = status
+            .code()
+            .map(|c| c.clamp(0, u16::MAX as i32) as u16)
+            .unwrap_or(1);
+
+        Ok(StreamMeta {
+            status: exit_code,
+            url: "bash://script".into(),
+        })
     }
 }
 

--- a/crates/earl-protocol-bash/src/executor.rs
+++ b/crates/earl-protocol-bash/src/executor.rs
@@ -169,12 +169,8 @@ impl StreamingProtocolExecutor for BashStreamExecutor {
             );
         }
 
-        let mut command = build_sandboxed_command(
-            &data.script,
-            &data.env,
-            data.cwd.as_deref(),
-            &data.sandbox,
-        )?;
+        let mut command =
+            build_sandboxed_command(&data.script, &data.env, data.cwd.as_deref(), &data.sandbox)?;
 
         command.stdout(Stdio::piped());
         command.stderr(Stdio::piped());
@@ -248,9 +244,7 @@ impl StreamingProtocolExecutor for BashStreamExecutor {
 
             total_bytes = total_bytes.saturating_add(bytes_read);
             if total_bytes > max_bytes {
-                bail!(
-                    "bash stdout exceeded configured max output bytes ({max_bytes} bytes)"
-                );
+                bail!("bash stdout exceeded configured max output bytes ({max_bytes} bytes)");
             }
 
             let chunk = StreamChunk {

--- a/crates/earl-protocol-bash/src/executor.rs
+++ b/crates/earl-protocol-bash/src/executor.rs
@@ -227,39 +227,6 @@ impl StreamingProtocolExecutor for BashStreamExecutor {
                 .context("failed writing stdin to bash process")?;
         }
 
-        // Stream stdout line-by-line.
-        let mut reader = BufReader::new(stdout);
-        let mut line = String::new();
-        let mut total_bytes: usize = 0;
-
-        loop {
-            line.clear();
-            let bytes_read = reader
-                .read_line(&mut line)
-                .await
-                .context("failed reading bash stdout")?;
-            if bytes_read == 0 {
-                break;
-            }
-
-            total_bytes = total_bytes.saturating_add(bytes_read);
-            if total_bytes > max_bytes {
-                bail!("bash stdout exceeded configured max output bytes ({max_bytes} bytes)");
-            }
-
-            let chunk = StreamChunk {
-                data: line.as_bytes().to_vec(),
-                content_type: None,
-            };
-            if sender.send(chunk).await.is_err() {
-                // Receiver dropped — stop streaming gracefully.
-                break;
-            }
-        }
-
-        // Drop the sender so the consumer sees the end of the stream.
-        drop(sender);
-
         // Use sandbox timeout if set, otherwise fall back to transport timeout.
         let timeout = data
             .sandbox
@@ -267,31 +234,84 @@ impl StreamingProtocolExecutor for BashStreamExecutor {
             .map(Duration::from_millis)
             .unwrap_or(ctx.transport.timeout);
 
-        let status = match tokio::time::timeout(timeout, child.wait()).await {
-            Ok(wait_result) => wait_result.context("failed waiting for bash process")?,
+        // Helper closure to kill the process group.
+        let kill_process = |pid: u32| {
+            if let Ok(pgid) = i32::try_from(pid) {
+                unsafe { libc::killpg(pgid, libc::SIGKILL) };
+            }
+        };
+
+        // Wrap the entire streaming operation (stdout reading + wait) in a
+        // single timeout so that a long-running process cannot stream forever.
+        let stream_result = tokio::time::timeout(timeout, async {
+            let mut reader = BufReader::new(stdout);
+            let mut buf = Vec::new();
+            let mut total_bytes: usize = 0;
+
+            loop {
+                buf.clear();
+                let bytes_read = reader
+                    .read_until(b'\n', &mut buf)
+                    .await
+                    .context("failed reading bash stdout")?;
+                if bytes_read == 0 {
+                    break;
+                }
+
+                total_bytes = total_bytes.saturating_add(bytes_read);
+                if total_bytes > max_bytes {
+                    // Kill the process before bailing.
+                    kill_process(pid);
+                    bail!("bash stdout exceeded configured max output bytes ({max_bytes} bytes)");
+                }
+
+                let line = String::from_utf8_lossy(&buf).into_owned();
+                let chunk = StreamChunk {
+                    data: line.into_bytes(),
+                    content_type: None,
+                };
+                if sender.send(chunk).await.is_err() {
+                    // Receiver dropped — kill the process and stop.
+                    kill_process(pid);
+                    break;
+                }
+            }
+
+            // Drop the sender so the consumer sees the end of the stream.
+            drop(sender);
+
+            // Wait for the child to finish.
+            let status = child
+                .wait()
+                .await
+                .context("failed waiting for bash process")?;
+            Ok::<_, anyhow::Error>(status)
+        })
+        .await;
+
+        // Abort the stderr task — we don't need it anymore.
+        stderr_task.abort();
+
+        match stream_result {
+            Ok(Ok(status)) => {
+                let exit_code = status
+                    .code()
+                    .map(|c| c.clamp(0, u16::MAX as i32) as u16)
+                    .unwrap_or(1);
+                Ok(StreamMeta {
+                    status: exit_code,
+                    url: "bash://script".into(),
+                })
+            }
+            Ok(Err(e)) => Err(e),
             Err(_) => {
                 // Timeout: kill the entire process group.
-                if let Ok(pgid) = i32::try_from(pid) {
-                    unsafe { libc::killpg(pgid, libc::SIGKILL) };
-                }
+                kill_process(pid);
                 let _ = child.kill().await;
                 let _ = child.wait().await;
                 bail!("bash script timed out after {timeout:?}");
             }
-        };
-
-        // Wait for stderr drain to finish (ignore errors — we don't stream stderr).
-        let _ = stderr_task.await;
-
-        let exit_code = status
-            .code()
-            .map(|c| c.clamp(0, u16::MAX as i32) as u16)
-            .unwrap_or(1);
-
-        Ok(StreamMeta {
-            status: exit_code,
-            url: "bash://script".into(),
-        })
+        }
     }
 }
 

--- a/crates/earl-protocol-bash/src/executor.rs
+++ b/crates/earl-protocol-bash/src/executor.rs
@@ -260,8 +260,9 @@ impl StreamingProtocolExecutor for BashStreamExecutor {
 
                 total_bytes = total_bytes.saturating_add(bytes_read);
                 if total_bytes > max_bytes {
-                    // Kill the process before bailing.
+                    // Kill the process and reap it before bailing.
                     kill_process(pid);
+                    let _ = child.wait().await;
                     bail!("bash stdout exceeded configured max output bytes ({max_bytes} bytes)");
                 }
 

--- a/crates/earl-protocol-bash/src/lib.rs
+++ b/crates/earl-protocol-bash/src/lib.rs
@@ -4,6 +4,7 @@ pub mod sandbox;
 pub mod schema;
 
 pub use executor::BashExecutor;
+pub use executor::BashStreamExecutor;
 pub use schema::{BashOperationTemplate, BashSandboxTemplate, BashScriptTemplate};
 
 /// Resolved sandbox settings for bash execution.

--- a/crates/earl-protocol-bash/src/schema.rs
+++ b/crates/earl-protocol-bash/src/schema.rs
@@ -9,6 +9,8 @@ use earl_core::schema::TransportTemplate;
 #[serde(deny_unknown_fields)]
 pub struct BashOperationTemplate {
     pub bash: BashScriptTemplate,
+    #[serde(default)]
+    pub stream: bool,
     pub transport: Option<TransportTemplate>,
 }
 
@@ -29,4 +31,23 @@ pub struct BashSandboxTemplate {
     pub writable_paths: Option<Vec<String>>,
     pub max_time_ms: Option<u64>,
     pub max_output_bytes: Option<u64>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bash_operation_defaults_stream_false() {
+        let json = r#"{"bash":{"script":"echo hello"}}"#;
+        let op: BashOperationTemplate = serde_json::from_str(json).unwrap();
+        assert!(!op.stream);
+    }
+
+    #[test]
+    fn bash_operation_accepts_stream_true() {
+        let json = r#"{"stream":true,"bash":{"script":"echo hello"}}"#;
+        let op: BashOperationTemplate = serde_json::from_str(json).unwrap();
+        assert!(op.stream);
+    }
 }

--- a/crates/earl-protocol-grpc/src/executor.rs
+++ b/crates/earl-protocol-grpc/src/executor.rs
@@ -15,12 +15,14 @@ use earl_core::{ExecutionContext, PreparedBody, RawExecutionResult};
 
 use crate::PreparedGrpcData;
 
-/// Execute a single gRPC request and return the result.
-pub async fn execute_grpc_once_with_host_validator<F, Fut>(
+/// Shared helper: validates the URL, resolves DNS, connects a tonic channel,
+/// and performs the dynamic gRPC call.  Returns the RPC URL and the raw
+/// `DynamicResponse` so callers can decide how to consume the result.
+async fn grpc_connect_and_call<F, Fut>(
     grpc_data: &PreparedGrpcData,
     ctx: &ExecutionContext,
     host_validator: &mut F,
-) -> Result<RawExecutionResult>
+) -> Result<(Url, DynamicResponse)>
 where
     F: FnMut(Url) -> Fut,
     Fut: Future<Output = Result<Vec<IpAddr>>>,
@@ -76,6 +78,22 @@ where
             .map_err(|err| anyhow!("gRPC reflection request failed: {err}"))?
     };
 
+    Ok((rpc_url, dynamic_response))
+}
+
+/// Execute a single gRPC request and return the result.
+pub async fn execute_grpc_once_with_host_validator<F, Fut>(
+    grpc_data: &PreparedGrpcData,
+    ctx: &ExecutionContext,
+    host_validator: &mut F,
+) -> Result<RawExecutionResult>
+where
+    F: FnMut(Url) -> Fut,
+    Fut: Future<Output = Result<Vec<IpAddr>>>,
+{
+    let (rpc_url, dynamic_response) =
+        grpc_connect_and_call(grpc_data, ctx, host_validator).await?;
+
     let (status, payload) = normalize_dynamic_response(dynamic_response);
     let payload_bytes = serde_json::to_vec(&payload).context("failed serializing gRPC payload")?;
     if payload_bytes.len() > ctx.transport.max_response_bytes {
@@ -115,6 +133,117 @@ where
         ctx: &ExecutionContext,
     ) -> Result<RawExecutionResult> {
         execute_grpc_once_with_host_validator(data, ctx, &mut self.host_validator).await
+    }
+}
+
+use earl_core::{StreamChunk, StreamMeta, StreamingProtocolExecutor};
+use tokio::sync::mpsc;
+
+/// Streaming gRPC protocol executor.
+///
+/// Sends each gRPC response message as an individual [`StreamChunk`] instead
+/// of buffering all messages into a single JSON array.  For unary responses
+/// the single message is sent as one chunk.
+pub struct GrpcStreamExecutor<F> {
+    pub host_validator: F,
+}
+
+impl<F, Fut> StreamingProtocolExecutor for GrpcStreamExecutor<F>
+where
+    F: FnMut(Url) -> Fut + Send,
+    Fut: Future<Output = Result<Vec<IpAddr>>> + Send,
+{
+    type PreparedData = PreparedGrpcData;
+
+    async fn execute_stream(
+        &mut self,
+        data: &PreparedGrpcData,
+        ctx: &ExecutionContext,
+        sender: mpsc::Sender<StreamChunk>,
+    ) -> Result<StreamMeta> {
+        let (rpc_url, dynamic_response) =
+            grpc_connect_and_call(data, ctx, &mut self.host_validator).await?;
+
+        let content_type = Some("application/json".to_string());
+
+        let status = match dynamic_response {
+            DynamicResponse::Unary(Ok(value)) => {
+                let bytes = serde_json::to_vec(&value)
+                    .context("failed serializing gRPC unary payload")?;
+                let _ = sender
+                    .send(StreamChunk {
+                        data: bytes,
+                        content_type: content_type.clone(),
+                    })
+                    .await;
+                0
+            }
+            DynamicResponse::Unary(Err(status)) => {
+                let code = grpc_code(status.code());
+                let payload = grpc_status_payload(&status);
+                let bytes = serde_json::to_vec(&payload)
+                    .context("failed serializing gRPC error payload")?;
+                let _ = sender
+                    .send(StreamChunk {
+                        data: bytes,
+                        content_type: content_type.clone(),
+                    })
+                    .await;
+                code
+            }
+            DynamicResponse::Streaming(Ok(values)) => {
+                let mut first_error_code = 0_u16;
+                for value in values {
+                    let (chunk_bytes, err_code) = match value {
+                        Ok(item) => {
+                            let bytes = serde_json::to_vec(&item)
+                                .context("failed serializing gRPC stream message")?;
+                            (bytes, 0)
+                        }
+                        Err(err) => {
+                            let code = grpc_code(err.code());
+                            let payload = grpc_status_payload(&err);
+                            let bytes = serde_json::to_vec(&payload)
+                                .context("failed serializing gRPC stream error")?;
+                            (bytes, code)
+                        }
+                    };
+                    if err_code != 0 && first_error_code == 0 {
+                        first_error_code = err_code;
+                    }
+                    if sender
+                        .send(StreamChunk {
+                            data: chunk_bytes,
+                            content_type: content_type.clone(),
+                        })
+                        .await
+                        .is_err()
+                    {
+                        // Receiver dropped — stop streaming gracefully.
+                        break;
+                    }
+                }
+                first_error_code
+            }
+            DynamicResponse::Streaming(Err(status)) => {
+                let code = grpc_code(status.code());
+                let payload = grpc_status_payload(&status);
+                let bytes = serde_json::to_vec(&payload)
+                    .context("failed serializing gRPC stream error payload")?;
+                let _ = sender
+                    .send(StreamChunk {
+                        data: bytes,
+                        content_type: content_type.clone(),
+                    })
+                    .await;
+                code
+            }
+        };
+
+        Ok(StreamMeta {
+            status,
+            url: rpc_url.to_string(),
+        })
     }
 }
 

--- a/crates/earl-protocol-grpc/src/executor.rs
+++ b/crates/earl-protocol-grpc/src/executor.rs
@@ -91,8 +91,7 @@ where
     F: FnMut(Url) -> Fut,
     Fut: Future<Output = Result<Vec<IpAddr>>>,
 {
-    let (rpc_url, dynamic_response) =
-        grpc_connect_and_call(grpc_data, ctx, host_validator).await?;
+    let (rpc_url, dynamic_response) = grpc_connect_and_call(grpc_data, ctx, host_validator).await?;
 
     let (status, payload) = normalize_dynamic_response(dynamic_response);
     let payload_bytes = serde_json::to_vec(&payload).context("failed serializing gRPC payload")?;
@@ -168,8 +167,8 @@ where
 
         let status = match dynamic_response {
             DynamicResponse::Unary(Ok(value)) => {
-                let bytes = serde_json::to_vec(&value)
-                    .context("failed serializing gRPC unary payload")?;
+                let bytes =
+                    serde_json::to_vec(&value).context("failed serializing gRPC unary payload")?;
                 let _ = sender
                     .send(StreamChunk {
                         data: bytes,

--- a/crates/earl-protocol-grpc/src/executor.rs
+++ b/crates/earl-protocol-grpc/src/executor.rs
@@ -164,11 +164,19 @@ where
             grpc_connect_and_call(data, ctx, &mut self.host_validator).await?;
 
         let content_type = Some("application/json".to_string());
+        let mut total_bytes = 0usize;
 
         let status = match dynamic_response {
             DynamicResponse::Unary(Ok(value)) => {
                 let bytes =
                     serde_json::to_vec(&value).context("failed serializing gRPC unary payload")?;
+                total_bytes = total_bytes.saturating_add(bytes.len());
+                if total_bytes > ctx.transport.max_response_bytes {
+                    bail!(
+                        "gRPC streaming response exceeded configured max_response_bytes ({} bytes)",
+                        ctx.transport.max_response_bytes
+                    );
+                }
                 let _ = sender
                     .send(StreamChunk {
                         data: bytes,
@@ -182,6 +190,13 @@ where
                 let payload = grpc_status_payload(&status);
                 let bytes = serde_json::to_vec(&payload)
                     .context("failed serializing gRPC error payload")?;
+                total_bytes = total_bytes.saturating_add(bytes.len());
+                if total_bytes > ctx.transport.max_response_bytes {
+                    bail!(
+                        "gRPC streaming response exceeded configured max_response_bytes ({} bytes)",
+                        ctx.transport.max_response_bytes
+                    );
+                }
                 let _ = sender
                     .send(StreamChunk {
                         data: bytes,
@@ -207,6 +222,13 @@ where
                             (bytes, code)
                         }
                     };
+                    total_bytes = total_bytes.saturating_add(chunk_bytes.len());
+                    if total_bytes > ctx.transport.max_response_bytes {
+                        bail!(
+                            "gRPC streaming response exceeded configured max_response_bytes ({} bytes)",
+                            ctx.transport.max_response_bytes
+                        );
+                    }
                     if err_code != 0 && first_error_code == 0 {
                         first_error_code = err_code;
                     }
@@ -229,6 +251,13 @@ where
                 let payload = grpc_status_payload(&status);
                 let bytes = serde_json::to_vec(&payload)
                     .context("failed serializing gRPC stream error payload")?;
+                total_bytes = total_bytes.saturating_add(bytes.len());
+                if total_bytes > ctx.transport.max_response_bytes {
+                    bail!(
+                        "gRPC streaming response exceeded configured max_response_bytes ({} bytes)",
+                        ctx.transport.max_response_bytes
+                    );
+                }
                 let _ = sender
                     .send(StreamChunk {
                         data: bytes,

--- a/crates/earl-protocol-grpc/src/lib.rs
+++ b/crates/earl-protocol-grpc/src/lib.rs
@@ -4,6 +4,7 @@ pub mod grpc;
 pub mod schema;
 
 pub use executor::GrpcExecutor;
+pub use executor::GrpcStreamExecutor;
 pub use schema::{GrpcOperationTemplate, GrpcTemplate};
 
 /// Prepared gRPC request data, ready for execution.

--- a/crates/earl-protocol-grpc/src/schema.rs
+++ b/crates/earl-protocol-grpc/src/schema.rs
@@ -12,6 +12,8 @@ pub struct GrpcOperationTemplate {
     pub headers: Option<BTreeMap<String, Value>>,
     pub auth: Option<AuthTemplate>,
     pub grpc: GrpcTemplate,
+    #[serde(default)]
+    pub stream: bool,
     pub transport: Option<TransportTemplate>,
 }
 
@@ -22,4 +24,23 @@ pub struct GrpcTemplate {
     pub method: String,
     pub body: Option<Value>,
     pub descriptor_set_file: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn grpc_operation_defaults_stream_false() {
+        let json = r#"{"url":"https://example.com","grpc":{"service":"test.Svc","method":"Call"}}"#;
+        let op: GrpcOperationTemplate = serde_json::from_str(json).unwrap();
+        assert!(!op.stream);
+    }
+
+    #[test]
+    fn grpc_operation_accepts_stream_true() {
+        let json = r#"{"url":"https://example.com","stream":true,"grpc":{"service":"test.Svc","method":"Call"}}"#;
+        let op: GrpcOperationTemplate = serde_json::from_str(json).unwrap();
+        assert!(op.stream);
+    }
 }

--- a/crates/earl-protocol-http/Cargo.toml
+++ b/crates/earl-protocol-http/Cargo.toml
@@ -17,4 +17,5 @@ reqwest = { version = "0.13.2", features = [
 ] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+tokio = { version = "1", features = ["sync"] }
 url = "2.5"

--- a/crates/earl-protocol-http/src/executor.rs
+++ b/crates/earl-protocol-http/src/executor.rs
@@ -219,7 +219,8 @@ async fn read_response_body_limited(
     Ok(out)
 }
 
-use earl_core::ProtocolExecutor;
+use earl_core::{ProtocolExecutor, StreamChunk, StreamMeta, StreamingProtocolExecutor};
+use tokio::sync::mpsc;
 
 /// HTTP/GraphQL protocol executor.
 ///
@@ -241,6 +242,120 @@ where
         ctx: &ExecutionContext,
     ) -> Result<RawExecutionResult> {
         execute_http_once_with_host_validator(data, ctx, &mut self.host_validator).await
+    }
+}
+
+/// Streaming HTTP executor — sends response chunks as they arrive.
+///
+/// Reuses the same connection setup (redirect following, SSRF validation,
+/// client building) as [`HttpExecutor`] but streams chunks through an
+/// `mpsc::Sender` instead of buffering the entire response body.
+pub struct HttpStreamExecutor<F> {
+    pub host_validator: F,
+}
+
+impl<F, Fut> StreamingProtocolExecutor for HttpStreamExecutor<F>
+where
+    F: FnMut(Url) -> Fut + Send,
+    Fut: Future<Output = Result<Vec<IpAddr>>> + Send,
+{
+    type PreparedData = PreparedHttpData;
+
+    async fn execute_stream(
+        &mut self,
+        data: &PreparedHttpData,
+        ctx: &ExecutionContext,
+        sender: mpsc::Sender<StreamChunk>,
+    ) -> anyhow::Result<StreamMeta> {
+        let mut method = data.method.clone();
+        let mut body = data.body.clone();
+        let mut url = data.url.clone();
+
+        for hop in 0..=ctx.transport.max_redirect_hops {
+            ensure_url_allowed(&url, &ctx.allow_rules)?;
+            let resolved_ips = (self.host_validator)(url.clone()).await?;
+            let client = build_http_client(ctx, &url, &resolved_ips)?;
+
+            let request = build_request(
+                &client,
+                &method,
+                &url,
+                &data.headers,
+                &data.cookies,
+                &data.query,
+                &body,
+            )?;
+            let response = request
+                .send()
+                .await
+                .with_context(|| format!("request execution failed for `{}`", url.as_str()))?;
+
+            if response.status().is_redirection() && ctx.transport.follow_redirects {
+                if hop >= ctx.transport.max_redirect_hops {
+                    bail!(
+                        "maximum redirect hops reached ({})",
+                        ctx.transport.max_redirect_hops
+                    );
+                }
+
+                let location = response
+                    .headers()
+                    .get(LOCATION)
+                    .ok_or_else(|| anyhow::anyhow!("redirect response missing Location header"))?
+                    .to_str()
+                    .context("redirect Location header is not valid UTF-8")?
+                    .to_string();
+
+                let new_url = url
+                    .join(&location)
+                    .with_context(|| format!("invalid redirect Location `{location}`"))?;
+
+                let status = response.status().as_u16();
+                if status == 303
+                    || ((status == 301 || status == 302) && method == reqwest::Method::POST)
+                {
+                    method = reqwest::Method::GET;
+                    body = PreparedBody::Empty;
+                }
+                url = new_url;
+                continue;
+            }
+
+            let status = response.status().as_u16();
+            let content_type = response
+                .headers()
+                .get(CONTENT_TYPE)
+                .and_then(|v| v.to_str().ok())
+                .map(|v| v.to_string());
+
+            // Stream chunks instead of buffering the entire response body.
+            let mut response = response;
+            let mut total_bytes = 0usize;
+            while let Some(chunk) = response.chunk().await? {
+                total_bytes = total_bytes.saturating_add(chunk.len());
+                if total_bytes > ctx.transport.max_response_bytes {
+                    bail!(
+                        "streaming response exceeded configured max_response_bytes ({} bytes)",
+                        ctx.transport.max_response_bytes
+                    );
+                }
+                let stream_chunk = StreamChunk {
+                    data: chunk.to_vec(),
+                    content_type: content_type.clone(),
+                };
+                if sender.send(stream_chunk).await.is_err() {
+                    // Receiver dropped — stop streaming gracefully.
+                    break;
+                }
+            }
+
+            return Ok(StreamMeta {
+                status,
+                url: url.to_string(),
+            });
+        }
+
+        bail!("redirect handling failed unexpectedly")
     }
 }
 

--- a/crates/earl-protocol-http/src/executor.rs
+++ b/crates/earl-protocol-http/src/executor.rs
@@ -344,10 +344,20 @@ where
             };
             // Buffer for incomplete UTF-8 sequences at chunk boundaries (SSE only).
             let mut utf8_buffer: Vec<u8> = Vec::new();
+            let max = ctx.transport.max_response_bytes;
 
             while let Some(chunk) = response.chunk().await? {
                 if let Some(parser) = &mut sse_parser {
                     utf8_buffer.extend_from_slice(&chunk);
+                    // Guard against unbounded buffer growth from invalid
+                    // UTF-8 or a server that never sends event boundaries.
+                    // An incomplete multi-byte sequence is at most 3 trailing
+                    // bytes; anything larger indicates bad data.
+                    if utf8_buffer.len() > max {
+                        bail!(
+                            "streaming response exceeded configured max_response_bytes ({max} bytes)"
+                        );
+                    }
                     // Find the last valid UTF-8 boundary — bytes beyond it
                     // are an incomplete multi-byte character.
                     let valid_up_to = match std::str::from_utf8(&utf8_buffer) {
@@ -362,21 +372,21 @@ where
                         .expect("validated UTF-8 boundary");
                     let events = parser.feed(text);
                     // Keep any incomplete trailing bytes for the next chunk.
-                    let remainder = utf8_buffer[valid_up_to..].to_vec();
-                    utf8_buffer.clear();
-                    utf8_buffer.extend_from_slice(&remainder);
+                    utf8_buffer.drain(..valid_up_to);
                     for event in events {
                         total_bytes = total_bytes.saturating_add(event.data.len());
-                        if total_bytes > ctx.transport.max_response_bytes {
+                        if total_bytes > max {
                             bail!(
-                                "streaming response exceeded configured max_response_bytes ({} bytes)",
-                                ctx.transport.max_response_bytes
+                                "streaming response exceeded configured max_response_bytes ({max} bytes)"
                             );
                         }
                         if sender
                             .send(StreamChunk {
                                 data: event.data.into_bytes(),
-                                content_type: content_type.clone(),
+                                // SSE event data is extracted content — not
+                                // text/event-stream.  Leave content_type as
+                                // None so decode="auto" can probe the data.
+                                content_type: None,
                             })
                             .await
                             .is_err()
@@ -416,27 +426,33 @@ where
                 {
                     for event in parser.feed(text) {
                         total_bytes = total_bytes.saturating_add(event.data.len());
-                        if total_bytes <= ctx.transport.max_response_bytes {
-                            let _ = sender
-                                .send(StreamChunk {
-                                    data: event.data.into_bytes(),
-                                    content_type: content_type.clone(),
-                                })
-                                .await;
+                        if total_bytes > max {
+                            bail!(
+                                "streaming response exceeded configured max_response_bytes ({max} bytes)"
+                            );
                         }
+                        let _ = sender
+                            .send(StreamChunk {
+                                data: event.data.into_bytes(),
+                                content_type: None,
+                            })
+                            .await;
                     }
                 }
 
                 if let Some(event) = parser.flush() {
                     total_bytes = total_bytes.saturating_add(event.data.len());
-                    if total_bytes <= ctx.transport.max_response_bytes {
-                        let _ = sender
-                            .send(StreamChunk {
-                                data: event.data.into_bytes(),
-                                content_type: content_type.clone(),
-                            })
-                            .await;
+                    if total_bytes > max {
+                        bail!(
+                            "streaming response exceeded configured max_response_bytes ({max} bytes)"
+                        );
                     }
+                    let _ = sender
+                        .send(StreamChunk {
+                            data: event.data.into_bytes(),
+                            content_type: None,
+                        })
+                        .await;
                 }
             }
 

--- a/crates/earl-protocol-http/src/executor.rs
+++ b/crates/earl-protocol-http/src/executor.rs
@@ -337,11 +337,34 @@ where
             // Stream chunks instead of buffering the entire response body.
             let mut response = response;
             let mut total_bytes = 0usize;
+            let mut sse_parser = if is_sse {
+                Some(crate::sse::SseParser::new())
+            } else {
+                None
+            };
+            // Buffer for incomplete UTF-8 sequences at chunk boundaries (SSE only).
+            let mut utf8_buffer: Vec<u8> = Vec::new();
+
             while let Some(chunk) = response.chunk().await? {
-                if is_sse {
-                    let text = std::str::from_utf8(&chunk)
-                        .context("SSE response contains invalid UTF-8")?;
-                    let events = crate::sse::parse_sse_events(text);
+                if let Some(parser) = &mut sse_parser {
+                    utf8_buffer.extend_from_slice(&chunk);
+                    // Find the last valid UTF-8 boundary — bytes beyond it
+                    // are an incomplete multi-byte character.
+                    let valid_up_to = match std::str::from_utf8(&utf8_buffer) {
+                        Ok(_) => utf8_buffer.len(),
+                        Err(e) => e.valid_up_to(),
+                    };
+                    if valid_up_to == 0 {
+                        // No complete UTF-8 characters yet — wait for more data.
+                        continue;
+                    }
+                    let text = std::str::from_utf8(&utf8_buffer[..valid_up_to])
+                        .expect("validated UTF-8 boundary");
+                    let events = parser.feed(text);
+                    // Keep any incomplete trailing bytes for the next chunk.
+                    let remainder = utf8_buffer[valid_up_to..].to_vec();
+                    utf8_buffer.clear();
+                    utf8_buffer.extend_from_slice(&remainder);
                     for event in events {
                         total_bytes = total_bytes.saturating_add(event.data.len());
                         if total_bytes > ctx.transport.max_response_bytes {
@@ -353,7 +376,7 @@ where
                         if sender
                             .send(StreamChunk {
                                 data: event.data.into_bytes(),
-                                content_type: Some("application/json".to_string()),
+                                content_type: content_type.clone(),
                             })
                             .await
                             .is_err()
@@ -382,6 +405,37 @@ where
                     {
                         // Receiver dropped — stop streaming gracefully.
                         break;
+                    }
+                }
+            }
+
+            // Feed remaining UTF-8 bytes and flush trailing SSE event.
+            if let Some(mut parser) = sse_parser {
+                if let Ok(text) = std::str::from_utf8(&utf8_buffer)
+                    && !text.is_empty()
+                {
+                    for event in parser.feed(text) {
+                        total_bytes = total_bytes.saturating_add(event.data.len());
+                        if total_bytes <= ctx.transport.max_response_bytes {
+                            let _ = sender
+                                .send(StreamChunk {
+                                    data: event.data.into_bytes(),
+                                    content_type: content_type.clone(),
+                                })
+                                .await;
+                        }
+                    }
+                }
+
+                if let Some(event) = parser.flush() {
+                    total_bytes = total_bytes.saturating_add(event.data.len());
+                    if total_bytes <= ctx.transport.max_response_bytes {
+                        let _ = sender
+                            .send(StreamChunk {
+                                data: event.data.into_bytes(),
+                                content_type: content_type.clone(),
+                            })
+                            .await;
                     }
                 }
             }

--- a/crates/earl-protocol-http/src/executor.rs
+++ b/crates/earl-protocol-http/src/executor.rs
@@ -328,24 +328,61 @@ where
                 .and_then(|v| v.to_str().ok())
                 .map(|v| v.to_string());
 
+            // Detect SSE responses so we can parse individual events.
+            let is_sse = content_type
+                .as_deref()
+                .map(|ct| ct.starts_with("text/event-stream"))
+                .unwrap_or(false);
+
             // Stream chunks instead of buffering the entire response body.
             let mut response = response;
             let mut total_bytes = 0usize;
             while let Some(chunk) = response.chunk().await? {
-                total_bytes = total_bytes.saturating_add(chunk.len());
-                if total_bytes > ctx.transport.max_response_bytes {
-                    bail!(
-                        "streaming response exceeded configured max_response_bytes ({} bytes)",
-                        ctx.transport.max_response_bytes
-                    );
-                }
-                let stream_chunk = StreamChunk {
-                    data: chunk.to_vec(),
-                    content_type: content_type.clone(),
-                };
-                if sender.send(stream_chunk).await.is_err() {
-                    // Receiver dropped — stop streaming gracefully.
-                    break;
+                if is_sse {
+                    let text = std::str::from_utf8(&chunk)
+                        .context("SSE response contains invalid UTF-8")?;
+                    let events = crate::sse::parse_sse_events(text);
+                    for event in events {
+                        total_bytes = total_bytes.saturating_add(event.data.len());
+                        if total_bytes > ctx.transport.max_response_bytes {
+                            bail!(
+                                "streaming response exceeded configured max_response_bytes ({} bytes)",
+                                ctx.transport.max_response_bytes
+                            );
+                        }
+                        if sender
+                            .send(StreamChunk {
+                                data: event.data.into_bytes(),
+                                content_type: Some("application/json".to_string()),
+                            })
+                            .await
+                            .is_err()
+                        {
+                            return Ok(StreamMeta {
+                                status,
+                                url: url.to_string(),
+                            });
+                        }
+                    }
+                } else {
+                    total_bytes = total_bytes.saturating_add(chunk.len());
+                    if total_bytes > ctx.transport.max_response_bytes {
+                        bail!(
+                            "streaming response exceeded configured max_response_bytes ({} bytes)",
+                            ctx.transport.max_response_bytes
+                        );
+                    }
+                    if sender
+                        .send(StreamChunk {
+                            data: chunk.to_vec(),
+                            content_type: content_type.clone(),
+                        })
+                        .await
+                        .is_err()
+                    {
+                        // Receiver dropped — stop streaming gracefully.
+                        break;
+                    }
                 }
             }
 

--- a/crates/earl-protocol-http/src/lib.rs
+++ b/crates/earl-protocol-http/src/lib.rs
@@ -2,7 +2,7 @@ pub mod builder;
 pub mod executor;
 pub mod schema;
 
-pub use executor::HttpExecutor;
+pub use executor::{HttpExecutor, HttpStreamExecutor};
 pub use schema::{GraphqlOperationTemplate, GraphqlTemplate, HttpOperationTemplate};
 
 /// Prepared HTTP/GraphQL request data, ready for execution.

--- a/crates/earl-protocol-http/src/lib.rs
+++ b/crates/earl-protocol-http/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod builder;
 pub mod executor;
 pub mod schema;
+pub mod sse;
 
 pub use executor::{HttpExecutor, HttpStreamExecutor};
 pub use schema::{GraphqlOperationTemplate, GraphqlTemplate, HttpOperationTemplate};

--- a/crates/earl-protocol-http/src/schema.rs
+++ b/crates/earl-protocol-http/src/schema.rs
@@ -73,7 +73,8 @@ mod tests {
 
     #[test]
     fn graphql_operation_accepts_stream_true() {
-        let json = r#"{"url":"https://example.com","stream":true,"graphql":{"query":"{ users { id } }"}}"#;
+        let json =
+            r#"{"url":"https://example.com","stream":true,"graphql":{"query":"{ users { id } }"}}"#;
         let op: GraphqlOperationTemplate = serde_json::from_str(json).unwrap();
         assert!(op.stream);
     }

--- a/crates/earl-protocol-http/src/schema.rs
+++ b/crates/earl-protocol-http/src/schema.rs
@@ -16,6 +16,8 @@ pub struct HttpOperationTemplate {
     pub cookies: Option<BTreeMap<String, Value>>,
     pub auth: Option<AuthTemplate>,
     pub body: Option<BodyTemplate>,
+    #[serde(default)]
+    pub stream: bool,
     pub transport: Option<TransportTemplate>,
 }
 
@@ -31,6 +33,8 @@ pub struct GraphqlOperationTemplate {
     pub cookies: Option<BTreeMap<String, Value>>,
     pub auth: Option<AuthTemplate>,
     pub graphql: GraphqlTemplate,
+    #[serde(default)]
+    pub stream: bool,
     pub transport: Option<TransportTemplate>,
 }
 
@@ -40,4 +44,37 @@ pub struct GraphqlTemplate {
     pub query: String,
     pub operation_name: Option<String>,
     pub variables: Option<Value>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn http_operation_defaults_stream_false() {
+        let json = r#"{"method":"GET","url":"https://example.com"}"#;
+        let op: HttpOperationTemplate = serde_json::from_str(json).unwrap();
+        assert!(!op.stream);
+    }
+
+    #[test]
+    fn http_operation_accepts_stream_true() {
+        let json = r#"{"method":"GET","url":"https://example.com","stream":true}"#;
+        let op: HttpOperationTemplate = serde_json::from_str(json).unwrap();
+        assert!(op.stream);
+    }
+
+    #[test]
+    fn graphql_operation_defaults_stream_false() {
+        let json = r#"{"url":"https://example.com","graphql":{"query":"{ users { id } }"}}"#;
+        let op: GraphqlOperationTemplate = serde_json::from_str(json).unwrap();
+        assert!(!op.stream);
+    }
+
+    #[test]
+    fn graphql_operation_accepts_stream_true() {
+        let json = r#"{"url":"https://example.com","stream":true,"graphql":{"query":"{ users { id } }"}}"#;
+        let op: GraphqlOperationTemplate = serde_json::from_str(json).unwrap();
+        assert!(op.stream);
+    }
 }

--- a/crates/earl-protocol-http/src/sse.rs
+++ b/crates/earl-protocol-http/src/sse.rs
@@ -6,28 +6,75 @@ pub struct SseEvent {
     pub id: Option<String>,
 }
 
-/// Parse raw SSE text into individual events.
+/// Stateful Server-Sent Events parser.
 ///
-/// Events are separated by blank lines (`\n\n`).
-///
-/// Within each event block:
-/// - Lines starting with `data:` contribute to the event data (joined with `\n`).
-/// - Lines starting with `event:` set the event type.
-/// - Lines starting with `id:` set the event id.
-/// - Lines starting with `:` are comments and are skipped.
-/// - Both `field: value` and `field:value` forms are accepted (optional space
-///   after the colon).
-pub fn parse_sse_events(input: &str) -> Vec<SseEvent> {
-    let mut events = Vec::new();
+/// Buffers incomplete events across calls to [`feed`] so that events split
+/// across HTTP chunk boundaries are handled correctly.
+pub struct SseParser {
+    /// Leftover text that hasn't yet formed a complete event block.
+    buffer: String,
+}
 
-    // Split on blank lines (the event boundary in the SSE spec).
-    // A blank line is produced by two consecutive newlines.
-    for block in input.split("\n\n") {
-        let block = block.trim_start_matches('\n');
-        if block.is_empty() {
-            continue;
+impl Default for SseParser {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SseParser {
+    pub fn new() -> Self {
+        Self {
+            buffer: String::new(),
+        }
+    }
+
+    /// Feed a chunk of text into the parser, returning any complete events.
+    ///
+    /// Incomplete events are buffered internally and will be emitted on
+    /// subsequent `feed()` calls once the closing blank line arrives.
+    pub fn feed(&mut self, input: &str) -> Vec<SseEvent> {
+        self.buffer.push_str(input);
+        let mut events = Vec::new();
+
+        // The SSE spec defines event boundaries as blank lines.
+        // We support both \n\n and \r\n\r\n.
+        loop {
+            // Find the next event boundary (blank line).
+            let boundary = self
+                .buffer
+                .find("\n\n")
+                .map(|pos| (pos, 2))
+                .or_else(|| self.buffer.find("\r\n\r\n").map(|pos| (pos, 4)));
+
+            let Some((pos, sep_len)) = boundary else {
+                break;
+            };
+
+            let block = &self.buffer[..pos];
+            if let Some(event) = Self::parse_block(block) {
+                events.push(event);
+            }
+            // Drain the consumed block + separator.
+            self.buffer.drain(..pos + sep_len);
         }
 
+        events
+    }
+
+    /// Flush any remaining buffered data as a final event.
+    ///
+    /// Call this when the stream ends to emit any trailing event that
+    /// wasn't followed by a blank line.
+    pub fn flush(&mut self) -> Option<SseEvent> {
+        let block = std::mem::take(&mut self.buffer);
+        let block = block.trim();
+        if block.is_empty() {
+            return None;
+        }
+        Self::parse_block(block)
+    }
+
+    fn parse_block(block: &str) -> Option<SseEvent> {
         let mut data_lines: Vec<&str> = Vec::new();
         let mut event_type: Option<String> = None;
         let mut id: Option<String> = None;
@@ -52,16 +99,16 @@ pub fn parse_sse_events(input: &str) -> Vec<SseEvent> {
         }
 
         // Only emit an event if there was at least one data line.
-        if !data_lines.is_empty() {
-            events.push(SseEvent {
-                event_type,
-                data: data_lines.join("\n"),
-                id,
-            });
+        if data_lines.is_empty() {
+            return None;
         }
-    }
 
-    events
+        Some(SseEvent {
+            event_type,
+            data: data_lines.join("\n"),
+            id,
+        })
+    }
 }
 
 #[cfg(test)]
@@ -71,7 +118,7 @@ mod tests {
     #[test]
     fn parses_simple_data_event() {
         let input = "data: hello world\n\n";
-        let events = parse_sse_events(input);
+        let events = SseParser::new().feed(input);
         assert_eq!(events.len(), 1);
         assert_eq!(events[0].data, "hello world");
     }
@@ -79,7 +126,7 @@ mod tests {
     #[test]
     fn parses_multiline_data_event() {
         let input = "data: line1\ndata: line2\n\n";
-        let events = parse_sse_events(input);
+        let events = SseParser::new().feed(input);
         assert_eq!(events.len(), 1);
         assert_eq!(events[0].data, "line1\nline2");
     }
@@ -87,7 +134,7 @@ mod tests {
     #[test]
     fn parses_event_with_type() {
         let input = "event: update\ndata: {\"key\":\"value\"}\n\n";
-        let events = parse_sse_events(input);
+        let events = SseParser::new().feed(input);
         assert_eq!(events.len(), 1);
         assert_eq!(events[0].event_type.as_deref(), Some("update"));
         assert_eq!(events[0].data, "{\"key\":\"value\"}");
@@ -96,7 +143,7 @@ mod tests {
     #[test]
     fn skips_comments() {
         let input = ": this is a comment\ndata: actual data\n\n";
-        let events = parse_sse_events(input);
+        let events = SseParser::new().feed(input);
         assert_eq!(events.len(), 1);
         assert_eq!(events[0].data, "actual data");
     }
@@ -104,14 +151,14 @@ mod tests {
     #[test]
     fn handles_multiple_events() {
         let input = "data: event1\n\ndata: event2\n\n";
-        let events = parse_sse_events(input);
+        let events = SseParser::new().feed(input);
         assert_eq!(events.len(), 2);
     }
 
     #[test]
     fn parses_event_with_id() {
         let input = "id: 42\ndata: payload\n\n";
-        let events = parse_sse_events(input);
+        let events = SseParser::new().feed(input);
         assert_eq!(events.len(), 1);
         assert_eq!(events[0].id.as_deref(), Some("42"));
         assert_eq!(events[0].data, "payload");
@@ -120,7 +167,7 @@ mod tests {
     #[test]
     fn handles_no_space_after_colon() {
         let input = "data:no-space\n\n";
-        let events = parse_sse_events(input);
+        let events = SseParser::new().feed(input);
         assert_eq!(events.len(), 1);
         assert_eq!(events[0].data, "no-space");
     }
@@ -128,13 +175,65 @@ mod tests {
     #[test]
     fn ignores_block_without_data() {
         let input = "event: ping\n\n";
-        let events = parse_sse_events(input);
+        let events = SseParser::new().feed(input);
         assert!(events.is_empty());
     }
 
     #[test]
     fn handles_empty_input() {
-        let events = parse_sse_events("");
+        let events = SseParser::new().feed("");
         assert!(events.is_empty());
+    }
+
+    #[test]
+    fn event_split_across_chunks() {
+        let mut parser = SseParser::new();
+
+        // First chunk contains the beginning of the event but no blank-line terminator.
+        let events = parser.feed("data: hel");
+        assert!(events.is_empty(), "no complete event yet");
+
+        // Second chunk completes the event with the rest of the data + blank line.
+        let events = parser.feed("lo world\n\n");
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].data, "hello world");
+    }
+
+    #[test]
+    fn handles_crlf_line_endings() {
+        let input = "event: update\r\ndata: payload\r\n\r\n";
+        let events = SseParser::new().feed(input);
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].event_type.as_deref(), Some("update"));
+        assert_eq!(events[0].data, "payload");
+    }
+
+    #[test]
+    fn flush_trailing_event() {
+        let mut parser = SseParser::new();
+
+        // Feed an event that is NOT terminated by a blank line.
+        let events = parser.feed("data: trailing");
+        assert!(events.is_empty(), "no blank line yet, so nothing emitted");
+
+        // Flush should emit the trailing event.
+        let event = parser.flush().expect("should flush trailing event");
+        assert_eq!(event.data, "trailing");
+    }
+
+    #[test]
+    fn multiple_feed_calls() {
+        let mut parser = SseParser::new();
+
+        // First feed: one complete event and start of another.
+        let events = parser.feed("data: first\n\ndata: sec");
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].data, "first");
+
+        // Second feed: finish the second event and deliver a third.
+        let events = parser.feed("ond\n\ndata: third\n\n");
+        assert_eq!(events.len(), 2);
+        assert_eq!(events[0].data, "second");
+        assert_eq!(events[1].data, "third");
     }
 }

--- a/crates/earl-protocol-http/src/sse.rs
+++ b/crates/earl-protocol-http/src/sse.rs
@@ -1,0 +1,140 @@
+/// A parsed Server-Sent Event.
+#[derive(Debug, Clone)]
+pub struct SseEvent {
+    pub event_type: Option<String>,
+    pub data: String,
+    pub id: Option<String>,
+}
+
+/// Parse raw SSE text into individual events.
+///
+/// Events are separated by blank lines (`\n\n`).
+///
+/// Within each event block:
+/// - Lines starting with `data:` contribute to the event data (joined with `\n`).
+/// - Lines starting with `event:` set the event type.
+/// - Lines starting with `id:` set the event id.
+/// - Lines starting with `:` are comments and are skipped.
+/// - Both `field: value` and `field:value` forms are accepted (optional space
+///   after the colon).
+pub fn parse_sse_events(input: &str) -> Vec<SseEvent> {
+    let mut events = Vec::new();
+
+    // Split on blank lines (the event boundary in the SSE spec).
+    // A blank line is produced by two consecutive newlines.
+    for block in input.split("\n\n") {
+        let block = block.trim_start_matches('\n');
+        if block.is_empty() {
+            continue;
+        }
+
+        let mut data_lines: Vec<&str> = Vec::new();
+        let mut event_type: Option<String> = None;
+        let mut id: Option<String> = None;
+
+        for line in block.lines() {
+            if line.starts_with(':') {
+                // Comment — skip.
+                continue;
+            }
+
+            if let Some(rest) = line.strip_prefix("data:") {
+                let value = rest.strip_prefix(' ').unwrap_or(rest);
+                data_lines.push(value);
+            } else if let Some(rest) = line.strip_prefix("event:") {
+                let value = rest.strip_prefix(' ').unwrap_or(rest);
+                event_type = Some(value.to_string());
+            } else if let Some(rest) = line.strip_prefix("id:") {
+                let value = rest.strip_prefix(' ').unwrap_or(rest);
+                id = Some(value.to_string());
+            }
+            // Unknown fields are ignored per the SSE spec.
+        }
+
+        // Only emit an event if there was at least one data line.
+        if !data_lines.is_empty() {
+            events.push(SseEvent {
+                event_type,
+                data: data_lines.join("\n"),
+                id,
+            });
+        }
+    }
+
+    events
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_simple_data_event() {
+        let input = "data: hello world\n\n";
+        let events = parse_sse_events(input);
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].data, "hello world");
+    }
+
+    #[test]
+    fn parses_multiline_data_event() {
+        let input = "data: line1\ndata: line2\n\n";
+        let events = parse_sse_events(input);
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].data, "line1\nline2");
+    }
+
+    #[test]
+    fn parses_event_with_type() {
+        let input = "event: update\ndata: {\"key\":\"value\"}\n\n";
+        let events = parse_sse_events(input);
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].event_type.as_deref(), Some("update"));
+        assert_eq!(events[0].data, "{\"key\":\"value\"}");
+    }
+
+    #[test]
+    fn skips_comments() {
+        let input = ": this is a comment\ndata: actual data\n\n";
+        let events = parse_sse_events(input);
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].data, "actual data");
+    }
+
+    #[test]
+    fn handles_multiple_events() {
+        let input = "data: event1\n\ndata: event2\n\n";
+        let events = parse_sse_events(input);
+        assert_eq!(events.len(), 2);
+    }
+
+    #[test]
+    fn parses_event_with_id() {
+        let input = "id: 42\ndata: payload\n\n";
+        let events = parse_sse_events(input);
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].id.as_deref(), Some("42"));
+        assert_eq!(events[0].data, "payload");
+    }
+
+    #[test]
+    fn handles_no_space_after_colon() {
+        let input = "data:no-space\n\n";
+        let events = parse_sse_events(input);
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].data, "no-space");
+    }
+
+    #[test]
+    fn ignores_block_without_data() {
+        let input = "event: ping\n\n";
+        let events = parse_sse_events(input);
+        assert!(events.is_empty());
+    }
+
+    #[test]
+    fn handles_empty_input() {
+        let events = parse_sse_events("");
+        assert!(events.is_empty());
+    }
+}

--- a/src/app.rs
+++ b/src/app.rs
@@ -116,11 +116,8 @@ async fn run_call(
             let redacted = prepared.redactor.redact_json(&rendered);
             println!("{}", serde_json::to_string_pretty(&redacted)?);
         } else {
-            let output = render_human_output(
-                &prepared.result_template,
-                &prepared.args,
-                &execution.result,
-            )?;
+            let output =
+                render_human_output(&prepared.result_template, &prepared.args, &execution.result)?;
             println!("{}", prepared.redactor.redact(&output));
         }
     }

--- a/src/app.rs
+++ b/src/app.rs
@@ -106,9 +106,32 @@ async fn run_call(
         let redactor = prepared.redactor.clone();
 
         let (rx, handle) = start_streaming_request(prepared);
-        render_streaming_output(rx, &result_template, &args, &redactor, json_mode).await?;
-        // Wait for the producer to finish and propagate any errors
-        handle.await??;
+        let render_result =
+            render_streaming_output(rx, &result_template, &args, &redactor, json_mode).await;
+
+        if render_result.is_err() {
+            // Abort the producer so it doesn't leak.
+            handle.abort();
+            render_result?;
+        }
+
+        // Wait for the producer to finish and propagate any errors.
+        match handle.await {
+            Ok(Ok(meta)) => {
+                tracing::debug!(
+                    status = meta.status,
+                    url = %meta.url,
+                    "streaming request completed"
+                );
+            }
+            Ok(Err(e)) => {
+                return Err(e).context("streaming producer failed");
+            }
+            Err(e) => {
+                // JoinError — task panicked or was cancelled.
+                return Err(anyhow::anyhow!("streaming producer task failed: {e}"));
+            }
+        }
     } else {
         let execution = execute_prepared_request(&prepared).await?;
         if json_mode {

--- a/src/app.rs
+++ b/src/app.rs
@@ -97,16 +97,32 @@ async fn run_call(
         &sandbox_config,
     )
     .await?;
-    let execution = execute_prepared_request(&prepared).await?;
+    if prepared.stream {
+        use crate::output::stream::render_streaming_output;
+        use crate::protocol::executor::start_streaming_request;
 
-    if json_mode {
-        let rendered = render_json_output(&execution);
-        let redacted = prepared.redactor.redact_json(&rendered);
-        println!("{}", serde_json::to_string_pretty(&redacted)?);
+        let result_template = prepared.result_template.clone();
+        let args = prepared.args.clone();
+        let redactor = prepared.redactor.clone();
+
+        let (rx, handle) = start_streaming_request(prepared);
+        render_streaming_output(rx, &result_template, &args, &redactor, json_mode).await?;
+        // Wait for the producer to finish and propagate any errors
+        handle.await??;
     } else {
-        let output =
-            render_human_output(&prepared.result_template, &prepared.args, &execution.result)?;
-        println!("{}", prepared.redactor.redact(&output));
+        let execution = execute_prepared_request(&prepared).await?;
+        if json_mode {
+            let rendered = render_json_output(&execution);
+            let redacted = prepared.redactor.redact_json(&rendered);
+            println!("{}", serde_json::to_string_pretty(&redacted)?);
+        } else {
+            let output = render_human_output(
+                &prepared.result_template,
+                &prepared.args,
+                &execution.result,
+            )?;
+            println!("{}", prepared.redactor.redact(&output));
+        }
     }
 
     Ok(())

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -1082,6 +1082,7 @@ mod tests {
                     cookies: None,
                     auth: None,
                     body: None,
+                    stream: false,
                     transport: None,
                 }),
                 result: ResultTemplate {

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -1,2 +1,3 @@
 pub mod human;
 pub mod json;
+pub mod stream;

--- a/src/output/stream.rs
+++ b/src/output/stream.rs
@@ -3,8 +3,8 @@ use serde_json::{Map, Value};
 use tokio::sync::mpsc;
 
 use earl_core::decode::DecodedBody;
-use earl_core::{Redactor, StreamChunk, decode_response};
 use earl_core::schema::ResultTemplate;
+use earl_core::{Redactor, StreamChunk, decode_response};
 
 use crate::output::human::render_human_output;
 use crate::protocol::extract::extract_result;

--- a/src/output/stream.rs
+++ b/src/output/stream.rs
@@ -1,0 +1,45 @@
+use anyhow::Result;
+use serde_json::{Map, Value};
+use tokio::sync::mpsc;
+
+use earl_core::decode::DecodedBody;
+use earl_core::{Redactor, StreamChunk, decode_response};
+use earl_core::schema::ResultTemplate;
+
+use crate::output::human::render_human_output;
+use crate::protocol::extract::extract_result;
+
+/// Consume streaming chunks and render each one to stdout.
+///
+/// Each [`StreamChunk`] is decoded, extracted, and printed independently,
+/// giving the user real-time output as data arrives from the server.
+pub async fn render_streaming_output(
+    mut rx: mpsc::Receiver<StreamChunk>,
+    result_template: &ResultTemplate,
+    args: &Map<String, Value>,
+    redactor: &Redactor,
+    json_mode: bool,
+) -> Result<()> {
+    while let Some(chunk) = rx.recv().await {
+        let decoded_body: DecodedBody = decode_response(
+            result_template.decode,
+            chunk.content_type.as_deref(),
+            &chunk.data,
+        )?;
+        let extracted = extract_result(result_template.extract.as_ref(), &decoded_body)?;
+
+        if json_mode {
+            let obj = Value::Object(Map::from_iter([
+                ("result".to_string(), extracted.clone()),
+                ("decoded".to_string(), decoded_body.to_json_value()),
+            ]));
+            let redacted = redactor.redact_json(&obj);
+            println!("{}", serde_json::to_string(&redacted)?);
+        } else {
+            let output = render_human_output(result_template, args, &extracted)?;
+            println!("{}", redactor.redact(&output));
+        }
+    }
+
+    Ok(())
+}

--- a/src/output/stream.rs
+++ b/src/output/stream.rs
@@ -2,7 +2,6 @@ use anyhow::Result;
 use serde_json::{Map, Value};
 use tokio::sync::mpsc;
 
-use earl_core::decode::DecodedBody;
 use earl_core::schema::ResultTemplate;
 use earl_core::{Redactor, StreamChunk, decode_response};
 
@@ -20,25 +19,42 @@ pub async fn render_streaming_output(
     redactor: &Redactor,
     json_mode: bool,
 ) -> Result<()> {
+    use std::io::Write;
+
     while let Some(chunk) = rx.recv().await {
-        let decoded_body: DecodedBody = decode_response(
+        let decoded_body = match decode_response(
             result_template.decode,
             chunk.content_type.as_deref(),
             &chunk.data,
-        )?;
-        let extracted = extract_result(result_template.extract.as_ref(), &decoded_body)?;
+        ) {
+            Ok(d) => d,
+            Err(e) => {
+                tracing::warn!("skipping stream chunk: failed to decode: {e}");
+                continue;
+            }
+        };
+        let extracted = match extract_result(result_template.extract.as_ref(), &decoded_body) {
+            Ok(v) => v,
+            Err(e) => {
+                tracing::warn!("skipping stream chunk: failed to extract: {e}");
+                continue;
+            }
+        };
 
+        let stdout = std::io::stdout();
+        let mut out = stdout.lock();
         if json_mode {
             let obj = Value::Object(Map::from_iter([
                 ("result".to_string(), extracted.clone()),
                 ("decoded".to_string(), decoded_body.to_json_value()),
             ]));
             let redacted = redactor.redact_json(&obj);
-            println!("{}", serde_json::to_string(&redacted)?);
+            writeln!(out, "{}", serde_json::to_string(&redacted)?)?;
         } else {
             let output = render_human_output(result_template, args, &extracted)?;
-            println!("{}", redactor.redact(&output));
+            writeln!(out, "{}", redactor.redact(&output))?;
         }
+        out.flush()?;
     }
 
     Ok(())

--- a/src/protocol/builder.rs
+++ b/src/protocol/builder.rs
@@ -41,6 +41,7 @@ impl earl_core::TemplateRenderer for JinjaRenderer {
 pub struct PreparedRequest {
     pub key: String,
     pub mode: CommandMode,
+    pub stream: bool,
     pub allow_rules: Vec<crate::template::schema::AllowRule>,
     pub transport: ResolvedTransport,
     pub result_template: crate::template::schema::ResultTemplate,
@@ -165,6 +166,7 @@ where
             Ok(PreparedRequest {
                 key: entry.key.clone(),
                 mode: entry.mode,
+                stream: entry.template.operation.is_streaming(),
                 allow_rules: allow_rules.to_vec(),
                 transport,
                 result_template: entry.template.result.clone(),
@@ -199,6 +201,7 @@ where
             Ok(PreparedRequest {
                 key: entry.key.clone(),
                 mode: entry.mode,
+                stream: entry.template.operation.is_streaming(),
                 allow_rules: allow_rules.to_vec(),
                 transport,
                 result_template: entry.template.result.clone(),
@@ -246,6 +249,7 @@ where
             Ok(PreparedRequest {
                 key: entry.key.clone(),
                 mode: entry.mode,
+                stream: entry.template.operation.is_streaming(),
                 allow_rules: allow_rules.to_vec(),
                 transport,
                 result_template: entry.template.result.clone(),
@@ -272,6 +276,7 @@ where
             Ok(PreparedRequest {
                 key: entry.key.clone(),
                 mode: entry.mode,
+                stream: entry.template.operation.is_streaming(),
                 allow_rules: Vec::new(),
                 transport,
                 result_template: entry.template.result.clone(),
@@ -319,6 +324,7 @@ where
             Ok(PreparedRequest {
                 key: entry.key.clone(),
                 mode: entry.mode,
+                stream: entry.template.operation.is_streaming(),
                 allow_rules: Vec::new(),
                 transport,
                 result_template: entry.template.result.clone(),

--- a/src/protocol/executor.rs
+++ b/src/protocol/executor.rs
@@ -3,12 +3,16 @@ use std::net::IpAddr;
 use std::time::Duration;
 
 use anyhow::{Context, Result};
+use tokio::sync::mpsc;
 use url::Url;
 
 use super::extract::extract_result;
 #[allow(unused_imports)]
 use earl_core::ProtocolExecutor;
+#[allow(unused_imports)]
+use earl_core::StreamingProtocolExecutor;
 use earl_core::decode_response;
+use earl_core::{StreamChunk, StreamMeta};
 
 use crate::security::dns::resolve_and_validate_host;
 
@@ -115,6 +119,80 @@ where
     }
 
     Err(last_err.unwrap_or_else(|| anyhow::anyhow!("request failed without details")))
+}
+
+/// Start a streaming execution of the given prepared request.
+///
+/// Returns a receiver for [`StreamChunk`]s and a [`tokio::task::JoinHandle`]
+/// that resolves to [`StreamMeta`] when the stream finishes.
+///
+/// Unlike [`execute_prepared_request`], this function takes ownership of the
+/// `PreparedRequest` (needed to move data into the spawned task) and does
+/// **not** perform retries — retrying a partially consumed stream would be
+/// nonsensical.
+///
+/// SSRF host validation is still applied before any data flows.
+pub fn start_streaming_request(
+    prepared: PreparedRequest,
+) -> (
+    mpsc::Receiver<StreamChunk>,
+    tokio::task::JoinHandle<Result<StreamMeta>>,
+) {
+    let (tx, rx) = mpsc::channel(64);
+
+    let handle = tokio::spawn(async move {
+        let mut host_validator = |url: Url| async move {
+            let host = url
+                .host_str()
+                .ok_or_else(|| anyhow::anyhow!("request URL missing host"))?;
+            resolve_and_validate_host(host).await
+        };
+
+        let context = to_context(&prepared);
+
+        #[allow(unreachable_patterns)]
+        match prepared.protocol_data {
+            #[cfg(feature = "http")]
+            PreparedProtocolData::Http(ref http_data) => {
+                earl_protocol_http::HttpStreamExecutor {
+                    host_validator: &mut host_validator,
+                }
+                .execute_stream(http_data, &context, tx)
+                .await
+            }
+            #[cfg(feature = "graphql")]
+            PreparedProtocolData::Graphql(ref http_data) => {
+                earl_protocol_http::HttpStreamExecutor {
+                    host_validator: &mut host_validator,
+                }
+                .execute_stream(http_data, &context, tx)
+                .await
+            }
+            #[cfg(feature = "grpc")]
+            PreparedProtocolData::Grpc(ref grpc_data) => {
+                earl_protocol_grpc::GrpcStreamExecutor {
+                    host_validator: &mut host_validator,
+                }
+                .execute_stream(grpc_data, &context, tx)
+                .await
+            }
+            #[cfg(feature = "bash")]
+            PreparedProtocolData::Bash(ref bash_data) => {
+                earl_protocol_bash::BashStreamExecutor
+                    .execute_stream(bash_data, &context, tx)
+                    .await
+            }
+            #[cfg(feature = "sql")]
+            PreparedProtocolData::Sql(_) => {
+                Err(anyhow::anyhow!("streaming not supported for SQL protocol"))
+            }
+            _ => Err(anyhow::anyhow!(
+                "unsupported protocol (feature not enabled)"
+            )),
+        }
+    });
+
+    (rx, handle)
 }
 
 fn backoff(base: Duration, attempt: usize) -> Duration {

--- a/src/template/import.rs
+++ b/src/template/import.rs
@@ -327,6 +327,7 @@ mod tests {
                     cookies: None,
                     auth: None,
                     body: None,
+                    stream: false,
                     transport: None,
                 }),
                 result: ResultTemplate {
@@ -362,6 +363,7 @@ mod tests {
                     cookies: None,
                     auth: None,
                     body: None,
+                    stream: false,
                     transport: None,
                 }),
                 result: ResultTemplate {

--- a/src/template/schema.rs
+++ b/src/template/schema.rs
@@ -146,6 +146,23 @@ impl OperationTemplate {
             _ => None,
         }
     }
+
+    #[allow(unreachable_patterns)]
+    pub fn is_streaming(&self) -> bool {
+        match self {
+            #[cfg(feature = "http")]
+            OperationTemplate::Http(op) => op.stream,
+            #[cfg(feature = "graphql")]
+            OperationTemplate::Graphql(op) => op.stream,
+            #[cfg(feature = "grpc")]
+            OperationTemplate::Grpc(op) => op.stream,
+            #[cfg(feature = "bash")]
+            OperationTemplate::Bash(op) => op.stream,
+            #[cfg(feature = "sql")]
+            OperationTemplate::Sql(_) => false,
+            _ => false,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq)]

--- a/tests/bash_executor.rs
+++ b/tests/bash_executor.rs
@@ -43,6 +43,7 @@ fn prepared_bash_request(script: &str, result_template: ResultTemplate) -> Prepa
     PreparedRequest {
         key: "test.bash".to_string(),
         mode: CommandMode::Read,
+        stream: false,
         allow_rules: vec![],
         transport: default_transport(),
         result_template,

--- a/tests/bash_streaming.rs
+++ b/tests/bash_streaming.rs
@@ -194,3 +194,39 @@ async fn bash_streaming_env_vars_passed() {
         "expected env var value in: {combined}"
     );
 }
+
+#[tokio::test]
+async fn bash_streaming_stops_when_receiver_drops() {
+    // Start a long-running script that would run for a while.
+    let script = PreparedBashScript {
+        script: "for i in $(seq 1 1000); do echo line$i; sleep 0.01; done".to_string(),
+        env: vec![],
+        cwd: None,
+        stdin: None,
+        sandbox: default_sandbox(),
+    };
+
+    let (tx, mut rx) = mpsc::channel::<StreamChunk>(4);
+    let context = default_context();
+
+    let mut executor = BashStreamExecutor;
+    let handle = tokio::spawn(async move { executor.execute_stream(&script, &context, tx).await });
+
+    // Read a few chunks then drop the receiver.
+    let mut received = 0;
+    while let Some(_chunk) = rx.recv().await {
+        received += 1;
+        if received >= 3 {
+            break;
+        }
+    }
+    drop(rx);
+
+    // The executor should finish without error (or finish within a reasonable time).
+    let result = tokio::time::timeout(Duration::from_secs(5), handle).await;
+    assert!(
+        result.is_ok(),
+        "executor should finish quickly after receiver is dropped"
+    );
+    // The result can be Ok or Err depending on timing — the important thing is it stops.
+}

--- a/tests/bash_streaming.rs
+++ b/tests/bash_streaming.rs
@@ -130,10 +130,7 @@ async fn bash_streaming_respects_output_limit() {
 
     assert!(result.is_err(), "expected output limit error");
     let err = format!("{:#}", result.unwrap_err());
-    assert!(
-        err.contains("exceeded"),
-        "unexpected error message: {err}"
-    );
+    assert!(err.contains("exceeded"), "unexpected error message: {err}");
 }
 
 #[tokio::test]

--- a/tests/bash_streaming.rs
+++ b/tests/bash_streaming.rs
@@ -1,0 +1,199 @@
+#![cfg(feature = "bash")]
+
+use std::time::Duration;
+
+use earl_core::schema::{CommandMode, ResultTemplate};
+use earl_core::transport::ResolvedTransport;
+use earl_core::{ExecutionContext, Redactor, StreamChunk, StreamingProtocolExecutor};
+use earl_protocol_bash::{BashStreamExecutor, PreparedBashScript, ResolvedBashSandbox};
+use serde_json::Map;
+use tokio::sync::mpsc;
+
+fn default_transport() -> ResolvedTransport {
+    ResolvedTransport {
+        timeout: Duration::from_secs(10),
+        follow_redirects: false,
+        max_redirect_hops: 0,
+        retry_max_attempts: 1,
+        retry_backoff: Duration::from_millis(1),
+        retry_on_status: vec![],
+        compression: true,
+        tls_min_version: None,
+        proxy_url: None,
+        max_response_bytes: 8 * 1024 * 1024,
+    }
+}
+
+fn default_sandbox() -> ResolvedBashSandbox {
+    ResolvedBashSandbox {
+        network: false,
+        writable_paths: vec![],
+        max_time_ms: None,
+        max_output_bytes: None,
+    }
+}
+
+fn default_context() -> ExecutionContext {
+    ExecutionContext {
+        key: "test".to_string(),
+        mode: CommandMode::Read,
+        allow_rules: vec![],
+        transport: default_transport(),
+        result_template: ResultTemplate::default(),
+        args: Map::new(),
+        redactor: Redactor::new(vec![]),
+    }
+}
+
+#[tokio::test]
+async fn bash_streaming_sends_output_as_chunks() {
+    let script = PreparedBashScript {
+        script: "echo line1; echo line2; echo line3".to_string(),
+        env: vec![],
+        cwd: None,
+        stdin: None,
+        sandbox: default_sandbox(),
+    };
+
+    let (tx, mut rx) = mpsc::channel::<StreamChunk>(16);
+    let context = default_context();
+
+    let mut executor = BashStreamExecutor;
+    let meta = executor
+        .execute_stream(&script, &context, tx)
+        .await
+        .unwrap();
+
+    assert_eq!(meta.status, 0);
+    assert_eq!(meta.url, "bash://script");
+
+    let mut chunks = vec![];
+    while let Some(chunk) = rx.recv().await {
+        chunks.push(String::from_utf8(chunk.data).unwrap());
+    }
+    let combined: String = chunks.concat();
+    assert!(combined.contains("line1"), "missing line1 in: {combined}");
+    assert!(combined.contains("line2"), "missing line2 in: {combined}");
+    assert!(combined.contains("line3"), "missing line3 in: {combined}");
+}
+
+#[tokio::test]
+async fn bash_streaming_captures_exit_code() {
+    let script = PreparedBashScript {
+        script: "echo done; exit 42".to_string(),
+        env: vec![],
+        cwd: None,
+        stdin: None,
+        sandbox: default_sandbox(),
+    };
+
+    let (tx, mut rx) = mpsc::channel::<StreamChunk>(16);
+    let context = default_context();
+
+    let mut executor = BashStreamExecutor;
+    let meta = executor
+        .execute_stream(&script, &context, tx)
+        .await
+        .unwrap();
+
+    assert_eq!(meta.status, 42);
+
+    // Drain the channel so we confirm output was still sent.
+    let mut chunks = vec![];
+    while let Some(chunk) = rx.recv().await {
+        chunks.push(String::from_utf8(chunk.data).unwrap());
+    }
+    let combined: String = chunks.concat();
+    assert!(combined.contains("done"), "missing 'done' in: {combined}");
+}
+
+#[tokio::test]
+async fn bash_streaming_respects_output_limit() {
+    let script = PreparedBashScript {
+        script: "for i in $(seq 1 200); do echo 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'; done".to_string(),
+        env: vec![],
+        cwd: None,
+        stdin: None,
+        sandbox: ResolvedBashSandbox {
+            network: false,
+            writable_paths: vec![],
+            max_time_ms: None,
+            max_output_bytes: Some(1024),
+        },
+    };
+
+    let (tx, _rx) = mpsc::channel::<StreamChunk>(16);
+    let context = default_context();
+
+    let mut executor = BashStreamExecutor;
+    let result = executor.execute_stream(&script, &context, tx).await;
+
+    assert!(result.is_err(), "expected output limit error");
+    let err = format!("{:#}", result.unwrap_err());
+    assert!(
+        err.contains("exceeded"),
+        "unexpected error message: {err}"
+    );
+}
+
+#[tokio::test]
+async fn bash_streaming_each_line_is_separate_chunk() {
+    let script = PreparedBashScript {
+        script: "echo alpha; echo beta; echo gamma".to_string(),
+        env: vec![],
+        cwd: None,
+        stdin: None,
+        sandbox: default_sandbox(),
+    };
+
+    let (tx, mut rx) = mpsc::channel::<StreamChunk>(16);
+    let context = default_context();
+
+    let mut executor = BashStreamExecutor;
+    let meta = executor
+        .execute_stream(&script, &context, tx)
+        .await
+        .unwrap();
+
+    assert_eq!(meta.status, 0);
+
+    let mut lines = vec![];
+    while let Some(chunk) = rx.recv().await {
+        let text = String::from_utf8(chunk.data).unwrap();
+        lines.push(text.trim_end().to_string());
+    }
+
+    assert_eq!(lines, vec!["alpha", "beta", "gamma"]);
+}
+
+#[tokio::test]
+async fn bash_streaming_env_vars_passed() {
+    let script = PreparedBashScript {
+        script: "echo $MY_VAR".to_string(),
+        env: vec![("MY_VAR".to_string(), "streamed_value".to_string())],
+        cwd: None,
+        stdin: None,
+        sandbox: default_sandbox(),
+    };
+
+    let (tx, mut rx) = mpsc::channel::<StreamChunk>(16);
+    let context = default_context();
+
+    let mut executor = BashStreamExecutor;
+    let meta = executor
+        .execute_stream(&script, &context, tx)
+        .await
+        .unwrap();
+
+    assert_eq!(meta.status, 0);
+
+    let mut chunks = vec![];
+    while let Some(chunk) = rx.recv().await {
+        chunks.push(String::from_utf8(chunk.data).unwrap());
+    }
+    let combined: String = chunks.concat();
+    assert!(
+        combined.contains("streamed_value"),
+        "expected env var value in: {combined}"
+    );
+}

--- a/tests/http_builder.rs
+++ b/tests/http_builder.rs
@@ -58,6 +58,7 @@ fn base_entry(
                 cookies: Some(BTreeMap::new()),
                 auth,
                 body,
+                stream: false,
                 transport: None,
             }),
             result: ResultTemplate {
@@ -493,6 +494,7 @@ async fn builds_graphql_payload_and_headers() {
             operation_name: Some("User".to_string()),
             variables: Some(json!({ "id": "{{ args.user_id }}" })),
         },
+        stream: false,
         transport: None,
     });
 
@@ -576,6 +578,7 @@ async fn builds_grpc_payload_and_headers() {
             })),
             descriptor_set_file: None,
         },
+        stream: false,
         transport: None,
     });
 

--- a/tests/http_executor.rs
+++ b/tests/http_executor.rs
@@ -133,6 +133,7 @@ fn prepared_request(
     PreparedRequest {
         key: "test.command".to_string(),
         mode: earl::template::schema::CommandMode::Read,
+        stream: false,
         allow_rules: vec![AllowRule {
             scheme: "http".to_string(),
             host,
@@ -167,6 +168,7 @@ fn prepared_grpc_request(
     PreparedRequest {
         key: "test.grpc".to_string(),
         mode: earl::template::schema::CommandMode::Read,
+        stream: false,
         allow_rules: vec![AllowRule {
             scheme: "http".to_string(),
             host,

--- a/tests/sql_executor.rs
+++ b/tests/sql_executor.rs
@@ -39,6 +39,7 @@ fn prepared_sql_request(
     PreparedRequest {
         key: "test.sql".to_string(),
         mode: CommandMode::Read,
+        stream: false,
         allow_rules: vec![],
         transport: default_transport(),
         result_template: ResultTemplate {

--- a/tests/streaming_decode_extract.rs
+++ b/tests/streaming_decode_extract.rs
@@ -7,15 +7,15 @@
 
 use earl::protocol::extract::extract_result;
 use earl::template::schema::{ResultDecode, ResultExtract};
-use earl_core::decode::{DecodedBody, decode_response};
 use earl_core::StreamChunk;
+use earl_core::decode::{DecodedBody, decode_response};
 use serde_json::json;
 
 // ── JSON chunks ───────────────────────────────────────────
 
 #[test]
 fn streaming_json_chunks_are_independently_decodable() {
-    let chunks = vec![
+    let chunks = [
         StreamChunk {
             data: br#"{"msg":"hello"}"#.to_vec(),
             content_type: Some("application/json".to_string()),
@@ -42,7 +42,7 @@ fn streaming_json_chunks_are_independently_decodable() {
 
 #[test]
 fn streaming_json_chunks_with_extract_json_pointer() {
-    let chunks = vec![
+    let chunks = [
         StreamChunk {
             data: br#"{"data":{"id":1}}"#.to_vec(),
             content_type: Some("application/json".to_string()),
@@ -80,7 +80,7 @@ fn streaming_json_chunks_with_extract_json_pointer() {
 
 #[test]
 fn streaming_text_chunks_with_regex_extract() {
-    let chunks = vec![
+    let chunks = [
         StreamChunk {
             data: b"event_id=abc-001 status=ok".to_vec(),
             content_type: Some("text/plain".to_string()),
@@ -97,9 +97,12 @@ fn streaming_text_chunks_with_regex_extract() {
 
     let mut event_ids = vec![];
     for chunk in &chunks {
-        let decoded =
-            decode_response(ResultDecode::Text, chunk.content_type.as_deref(), &chunk.data)
-                .unwrap();
+        let decoded = decode_response(
+            ResultDecode::Text,
+            chunk.content_type.as_deref(),
+            &chunk.data,
+        )
+        .unwrap();
         let value = extract_result(Some(&extract), &decoded).unwrap();
         event_ids.push(value);
     }
@@ -116,8 +119,12 @@ fn streaming_auto_decode_infers_json_from_content_type() {
         content_type: Some("application/json".to_string()),
     };
 
-    let decoded =
-        decode_response(ResultDecode::Auto, chunk.content_type.as_deref(), &chunk.data).unwrap();
+    let decoded = decode_response(
+        ResultDecode::Auto,
+        chunk.content_type.as_deref(),
+        &chunk.data,
+    )
+    .unwrap();
     match decoded {
         DecodedBody::Json(v) => assert_eq!(v, json!({"ok": true})),
         other => panic!("expected Json, got {other:?}"),
@@ -131,8 +138,12 @@ fn streaming_auto_decode_infers_text_from_content_type() {
         content_type: Some("text/plain".to_string()),
     };
 
-    let decoded =
-        decode_response(ResultDecode::Auto, chunk.content_type.as_deref(), &chunk.data).unwrap();
+    let decoded = decode_response(
+        ResultDecode::Auto,
+        chunk.content_type.as_deref(),
+        &chunk.data,
+    )
+    .unwrap();
     match decoded {
         DecodedBody::Text(v) => assert_eq!(v, "plain text line"),
         other => panic!("expected Text, got {other:?}"),
@@ -146,8 +157,12 @@ fn streaming_auto_decode_falls_back_to_json_for_valid_json_without_content_type(
         content_type: None,
     };
 
-    let decoded =
-        decode_response(ResultDecode::Auto, chunk.content_type.as_deref(), &chunk.data).unwrap();
+    let decoded = decode_response(
+        ResultDecode::Auto,
+        chunk.content_type.as_deref(),
+        &chunk.data,
+    )
+    .unwrap();
     match decoded {
         DecodedBody::Json(v) => assert_eq!(v, json!({"key": "value"})),
         other => panic!("expected Json, got {other:?}"),
@@ -163,8 +178,12 @@ fn streaming_chunk_with_no_extract_returns_full_decoded_value() {
         content_type: Some("application/json".to_string()),
     };
 
-    let decoded =
-        decode_response(ResultDecode::Json, chunk.content_type.as_deref(), &chunk.data).unwrap();
+    let decoded = decode_response(
+        ResultDecode::Json,
+        chunk.content_type.as_deref(),
+        &chunk.data,
+    )
+    .unwrap();
     let value = extract_result(None, &decoded).unwrap();
 
     assert_eq!(value, json!({"a": 1, "b": "two"}));
@@ -174,7 +193,7 @@ fn streaming_chunk_with_no_extract_returns_full_decoded_value() {
 
 #[test]
 fn streaming_html_chunks_with_css_selector_extract() {
-    let chunks = vec![
+    let chunks = [
         StreamChunk {
             data: b"<html><body><span class=\"val\">100</span></body></html>".to_vec(),
             content_type: Some("text/html".to_string()),
@@ -191,9 +210,12 @@ fn streaming_html_chunks_with_css_selector_extract() {
 
     let mut values = vec![];
     for chunk in &chunks {
-        let decoded =
-            decode_response(ResultDecode::Html, chunk.content_type.as_deref(), &chunk.data)
-                .unwrap();
+        let decoded = decode_response(
+            ResultDecode::Html,
+            chunk.content_type.as_deref(),
+            &chunk.data,
+        )
+        .unwrap();
         let value = extract_result(Some(&extract), &decoded).unwrap();
         values.push(value);
     }
@@ -205,7 +227,7 @@ fn streaming_html_chunks_with_css_selector_extract() {
 
 #[test]
 fn streaming_xml_chunks_with_xpath_extract() {
-    let chunks = vec![
+    let chunks = [
         StreamChunk {
             data: b"<root><item>alpha</item></root>".to_vec(),
             content_type: Some("application/xml".to_string()),
@@ -222,9 +244,12 @@ fn streaming_xml_chunks_with_xpath_extract() {
 
     let mut values = vec![];
     for chunk in &chunks {
-        let decoded =
-            decode_response(ResultDecode::Xml, chunk.content_type.as_deref(), &chunk.data)
-                .unwrap();
+        let decoded = decode_response(
+            ResultDecode::Xml,
+            chunk.content_type.as_deref(),
+            &chunk.data,
+        )
+        .unwrap();
         let value = extract_result(Some(&extract), &decoded).unwrap();
         values.push(value);
     }
@@ -241,8 +266,12 @@ fn streaming_binary_chunks_decode_without_error() {
         content_type: Some("application/octet-stream".to_string()),
     };
 
-    let decoded =
-        decode_response(ResultDecode::Binary, chunk.content_type.as_deref(), &chunk.data).unwrap();
+    let decoded = decode_response(
+        ResultDecode::Binary,
+        chunk.content_type.as_deref(),
+        &chunk.data,
+    )
+    .unwrap();
     let value = extract_result(None, &decoded).unwrap();
 
     // Binary data is base64 encoded when converted to JSON.
@@ -259,7 +288,11 @@ fn streaming_chunk_with_malformed_json_returns_error() {
         content_type: Some("application/json".to_string()),
     };
 
-    let result = decode_response(ResultDecode::Json, chunk.content_type.as_deref(), &chunk.data);
+    let result = decode_response(
+        ResultDecode::Json,
+        chunk.content_type.as_deref(),
+        &chunk.data,
+    );
     assert!(
         result.is_err(),
         "malformed JSON in a chunk should produce an error"

--- a/tests/streaming_decode_extract.rs
+++ b/tests/streaming_decode_extract.rs
@@ -1,0 +1,267 @@
+//! Integration tests for the streaming decode/extract pipeline.
+//!
+//! These tests verify that individual [`StreamChunk`] values can be decoded and
+//! extracted independently — the core property that makes streaming output work.
+//! The bash executor streaming tests live in `bash_streaming.rs`; here we focus
+//! on the decode → extract path that is shared by all protocols.
+
+use earl::protocol::extract::extract_result;
+use earl::template::schema::{ResultDecode, ResultExtract};
+use earl_core::decode::{DecodedBody, decode_response};
+use earl_core::StreamChunk;
+use serde_json::json;
+
+// ── JSON chunks ───────────────────────────────────────────
+
+#[test]
+fn streaming_json_chunks_are_independently_decodable() {
+    let chunks = vec![
+        StreamChunk {
+            data: br#"{"msg":"hello"}"#.to_vec(),
+            content_type: Some("application/json".to_string()),
+        },
+        StreamChunk {
+            data: br#"{"msg":"world"}"#.to_vec(),
+            content_type: Some("application/json".to_string()),
+        },
+    ];
+
+    for (i, chunk) in chunks.iter().enumerate() {
+        let decoded = decode_response(
+            ResultDecode::Json,
+            chunk.content_type.as_deref(),
+            &chunk.data,
+        );
+        assert!(
+            decoded.is_ok(),
+            "chunk {i} should be independently decodable: {:?}",
+            decoded.err()
+        );
+    }
+}
+
+#[test]
+fn streaming_json_chunks_with_extract_json_pointer() {
+    let chunks = vec![
+        StreamChunk {
+            data: br#"{"data":{"id":1}}"#.to_vec(),
+            content_type: Some("application/json".to_string()),
+        },
+        StreamChunk {
+            data: br#"{"data":{"id":2}}"#.to_vec(),
+            content_type: Some("application/json".to_string()),
+        },
+        StreamChunk {
+            data: br#"{"data":{"id":3}}"#.to_vec(),
+            content_type: Some("application/json".to_string()),
+        },
+    ];
+
+    let extract = ResultExtract::JsonPointer {
+        json_pointer: "/data/id".to_string(),
+    };
+
+    let mut extracted_ids = vec![];
+    for chunk in &chunks {
+        let decoded = decode_response(
+            ResultDecode::Json,
+            chunk.content_type.as_deref(),
+            &chunk.data,
+        )
+        .unwrap();
+        let value = extract_result(Some(&extract), &decoded).unwrap();
+        extracted_ids.push(value);
+    }
+
+    assert_eq!(extracted_ids, vec![json!(1), json!(2), json!(3)]);
+}
+
+// ── Text / line-oriented chunks ──────────────────────────
+
+#[test]
+fn streaming_text_chunks_with_regex_extract() {
+    let chunks = vec![
+        StreamChunk {
+            data: b"event_id=abc-001 status=ok".to_vec(),
+            content_type: Some("text/plain".to_string()),
+        },
+        StreamChunk {
+            data: b"event_id=def-002 status=error".to_vec(),
+            content_type: Some("text/plain".to_string()),
+        },
+    ];
+
+    let extract = ResultExtract::Regex {
+        regex: r"event_id=([a-z0-9-]+)".to_string(),
+    };
+
+    let mut event_ids = vec![];
+    for chunk in &chunks {
+        let decoded =
+            decode_response(ResultDecode::Text, chunk.content_type.as_deref(), &chunk.data)
+                .unwrap();
+        let value = extract_result(Some(&extract), &decoded).unwrap();
+        event_ids.push(value);
+    }
+
+    assert_eq!(event_ids, vec![json!("abc-001"), json!("def-002")]);
+}
+
+// ── Auto decode ──────────────────────────────────────────
+
+#[test]
+fn streaming_auto_decode_infers_json_from_content_type() {
+    let chunk = StreamChunk {
+        data: br#"{"ok":true}"#.to_vec(),
+        content_type: Some("application/json".to_string()),
+    };
+
+    let decoded =
+        decode_response(ResultDecode::Auto, chunk.content_type.as_deref(), &chunk.data).unwrap();
+    match decoded {
+        DecodedBody::Json(v) => assert_eq!(v, json!({"ok": true})),
+        other => panic!("expected Json, got {other:?}"),
+    }
+}
+
+#[test]
+fn streaming_auto_decode_infers_text_from_content_type() {
+    let chunk = StreamChunk {
+        data: b"plain text line".to_vec(),
+        content_type: Some("text/plain".to_string()),
+    };
+
+    let decoded =
+        decode_response(ResultDecode::Auto, chunk.content_type.as_deref(), &chunk.data).unwrap();
+    match decoded {
+        DecodedBody::Text(v) => assert_eq!(v, "plain text line"),
+        other => panic!("expected Text, got {other:?}"),
+    }
+}
+
+#[test]
+fn streaming_auto_decode_falls_back_to_json_for_valid_json_without_content_type() {
+    let chunk = StreamChunk {
+        data: br#"{"key":"value"}"#.to_vec(),
+        content_type: None,
+    };
+
+    let decoded =
+        decode_response(ResultDecode::Auto, chunk.content_type.as_deref(), &chunk.data).unwrap();
+    match decoded {
+        DecodedBody::Json(v) => assert_eq!(v, json!({"key": "value"})),
+        other => panic!("expected Json, got {other:?}"),
+    }
+}
+
+// ── No-extract passthrough ───────────────────────────────
+
+#[test]
+fn streaming_chunk_with_no_extract_returns_full_decoded_value() {
+    let chunk = StreamChunk {
+        data: br#"{"a":1,"b":"two"}"#.to_vec(),
+        content_type: Some("application/json".to_string()),
+    };
+
+    let decoded =
+        decode_response(ResultDecode::Json, chunk.content_type.as_deref(), &chunk.data).unwrap();
+    let value = extract_result(None, &decoded).unwrap();
+
+    assert_eq!(value, json!({"a": 1, "b": "two"}));
+}
+
+// ── HTML / CSS selector chunks ───────────────────────────
+
+#[test]
+fn streaming_html_chunks_with_css_selector_extract() {
+    let chunks = vec![
+        StreamChunk {
+            data: b"<html><body><span class=\"val\">100</span></body></html>".to_vec(),
+            content_type: Some("text/html".to_string()),
+        },
+        StreamChunk {
+            data: b"<html><body><span class=\"val\">200</span></body></html>".to_vec(),
+            content_type: Some("text/html".to_string()),
+        },
+    ];
+
+    let extract = ResultExtract::CssSelector {
+        css_selector: "span.val".to_string(),
+    };
+
+    let mut values = vec![];
+    for chunk in &chunks {
+        let decoded =
+            decode_response(ResultDecode::Html, chunk.content_type.as_deref(), &chunk.data)
+                .unwrap();
+        let value = extract_result(Some(&extract), &decoded).unwrap();
+        values.push(value);
+    }
+
+    assert_eq!(values, vec![json!(["100"]), json!(["200"])]);
+}
+
+// ── XML / XPath chunks ──────────────────────────────────
+
+#[test]
+fn streaming_xml_chunks_with_xpath_extract() {
+    let chunks = vec![
+        StreamChunk {
+            data: b"<root><item>alpha</item></root>".to_vec(),
+            content_type: Some("application/xml".to_string()),
+        },
+        StreamChunk {
+            data: b"<root><item>beta</item></root>".to_vec(),
+            content_type: Some("application/xml".to_string()),
+        },
+    ];
+
+    let extract = ResultExtract::XPath {
+        xpath: "//item/text()".to_string(),
+    };
+
+    let mut values = vec![];
+    for chunk in &chunks {
+        let decoded =
+            decode_response(ResultDecode::Xml, chunk.content_type.as_deref(), &chunk.data)
+                .unwrap();
+        let value = extract_result(Some(&extract), &decoded).unwrap();
+        values.push(value);
+    }
+
+    assert_eq!(values, vec![json!(["alpha"]), json!(["beta"])]);
+}
+
+// ── Binary chunks ────────────────────────────────────────
+
+#[test]
+fn streaming_binary_chunks_decode_without_error() {
+    let chunk = StreamChunk {
+        data: vec![0x00, 0xFF, 0xAB, 0xCD],
+        content_type: Some("application/octet-stream".to_string()),
+    };
+
+    let decoded =
+        decode_response(ResultDecode::Binary, chunk.content_type.as_deref(), &chunk.data).unwrap();
+    let value = extract_result(None, &decoded).unwrap();
+
+    // Binary data is base64 encoded when converted to JSON.
+    assert!(value.is_string(), "binary should be base64-encoded string");
+    assert!(!value.as_str().unwrap().is_empty());
+}
+
+// ── Error case: malformed JSON in a chunk ────────────────
+
+#[test]
+fn streaming_chunk_with_malformed_json_returns_error() {
+    let chunk = StreamChunk {
+        data: b"not valid json {{{".to_vec(),
+        content_type: Some("application/json".to_string()),
+    };
+
+    let result = decode_response(ResultDecode::Json, chunk.content_type.as_deref(), &chunk.data);
+    assert!(
+        result.is_err(),
+        "malformed JSON in a chunk should produce an error"
+    );
+}

--- a/tests/streaming_output.rs
+++ b/tests/streaming_output.rs
@@ -1,0 +1,159 @@
+//! Tests for the streaming output pipeline and backwards compatibility.
+
+use std::path::Path;
+
+use earl::output::stream::render_streaming_output;
+use earl::template::parser::parse_template_hcl;
+use earl::template::schema::{ResultDecode, ResultTemplate};
+use earl_core::{Redactor, StreamChunk};
+use serde_json::Map;
+use tokio::sync::mpsc;
+
+// ── render_streaming_output tests ───────────────────────────
+
+#[tokio::test]
+async fn render_streaming_output_processes_json_chunks() {
+    let (tx, rx) = mpsc::channel::<StreamChunk>(16);
+
+    tokio::spawn(async move {
+        tx.send(StreamChunk {
+            data: br#"{"msg":"hello"}"#.to_vec(),
+            content_type: Some("application/json".to_string()),
+        })
+        .await
+        .unwrap();
+        tx.send(StreamChunk {
+            data: br#"{"msg":"world"}"#.to_vec(),
+            content_type: Some("application/json".to_string()),
+        })
+        .await
+        .unwrap();
+    });
+
+    let result_template = ResultTemplate::default();
+    let args = Map::new();
+    let redactor = Redactor::new(vec![]);
+
+    let result = render_streaming_output(rx, &result_template, &args, &redactor, true).await;
+    assert!(result.is_ok(), "should process JSON chunks without error");
+}
+
+#[tokio::test]
+async fn render_streaming_output_skips_malformed_json_chunks() {
+    let (tx, rx) = mpsc::channel::<StreamChunk>(16);
+
+    tokio::spawn(async move {
+        tx.send(StreamChunk {
+            data: b"not valid json".to_vec(),
+            content_type: Some("application/json".to_string()),
+        })
+        .await
+        .unwrap();
+        tx.send(StreamChunk {
+            data: br#"{"ok":true}"#.to_vec(),
+            content_type: Some("application/json".to_string()),
+        })
+        .await
+        .unwrap();
+    });
+
+    let result_template = ResultTemplate {
+        decode: ResultDecode::Json,
+        extract: None,
+        output: "{{ result }}".to_string(),
+        result_alias: None,
+    };
+    let args = Map::new();
+    let redactor = Redactor::new(vec![]);
+
+    let result = render_streaming_output(rx, &result_template, &args, &redactor, true).await;
+    assert!(result.is_ok(), "should skip bad chunks and continue");
+}
+
+#[tokio::test]
+async fn render_streaming_output_handles_empty_channel() {
+    let (_tx, rx) = mpsc::channel::<StreamChunk>(1);
+    drop(_tx);
+
+    let result_template = ResultTemplate::default();
+    let args = Map::new();
+    let redactor = Redactor::new(vec![]);
+
+    let result = render_streaming_output(rx, &result_template, &args, &redactor, false).await;
+    assert!(result.is_ok(), "empty channel should return Ok");
+}
+
+// ── Backwards compatibility tests ───────────────────────────
+
+#[test]
+#[cfg(feature = "http")]
+fn non_streaming_template_defaults_to_false() {
+    let hcl_src = r#"
+version = 1
+provider = "demo"
+
+command "fetch" {
+  title = "Fetch"
+  summary = "Fetch data"
+  description = "Non-streaming."
+
+  annotations {
+    mode = "read"
+    secrets = []
+  }
+
+  operation {
+    protocol = "http"
+    method = "GET"
+    url = "https://api.example.com/data"
+  }
+
+  result {
+    output = "{{ result }}"
+  }
+}
+"#;
+    let template_file = parse_template_hcl(hcl_src, Path::new(".")).unwrap();
+    let cmd = template_file.commands.get("fetch").unwrap();
+    assert!(
+        !cmd.operation.is_streaming(),
+        "should default to false when stream field is absent"
+    );
+}
+
+#[test]
+#[cfg(feature = "http")]
+fn template_with_stream_false_returns_false() {
+    let hcl_src = r#"
+version = 1
+provider = "demo"
+
+command "fetch" {
+  title = "Fetch"
+  summary = "Fetch data"
+  description = "Explicitly non-streaming."
+
+  annotations {
+    mode = "read"
+    secrets = []
+  }
+
+  operation {
+    protocol = "http"
+    method = "GET"
+    url = "https://api.example.com/data"
+    stream = false
+  }
+
+  result {
+    output = "{{ result }}"
+  }
+}
+"#;
+    let template_file = parse_template_hcl(hcl_src, Path::new(".")).unwrap();
+    let cmd = template_file.commands.get("fetch").unwrap();
+    assert!(
+        !cmd.operation.is_streaming(),
+        "should return false when stream = false is explicit"
+    );
+}

--- a/tests/streaming_template_validation.rs
+++ b/tests/streaming_template_validation.rs
@@ -89,11 +89,7 @@ command "fetch" {
     fs::write(local_dir.join("no_stream.hcl"), hcl).unwrap();
 
     let files = validate_all_from_dirs(&global_dir, &local_dir).unwrap();
-    assert_eq!(
-        files.len(),
-        1,
-        "stream=false HTTP template should be valid"
-    );
+    assert_eq!(files.len(), 1, "stream=false HTTP template should be valid");
 }
 
 #[test]

--- a/tests/streaming_template_validation.rs
+++ b/tests/streaming_template_validation.rs
@@ -1,0 +1,263 @@
+//! Integration tests verifying that templates with `stream = true` are accepted
+//! by the template validator, and that the `is_streaming()` helper returns the
+//! correct value for each protocol variant.
+
+use std::fs;
+use std::path::Path;
+
+use earl::template::loader::validate_all_from_dirs;
+use earl::template::parser::parse_template_hcl;
+use tempfile::tempdir;
+
+#[test]
+#[cfg(feature = "http")]
+fn http_template_with_stream_true_is_valid() {
+    let dir = tempdir().unwrap();
+    let local_dir = dir.path().join("local");
+    let global_dir = dir.path().join("global");
+    fs::create_dir_all(&local_dir).unwrap();
+    fs::create_dir_all(&global_dir).unwrap();
+
+    let hcl = r#"
+version = 1
+provider = "demo"
+
+command "events" {
+  title = "Events"
+  summary = "Stream events from server"
+  description = "Opens a streaming connection and prints events as they arrive."
+
+  annotations {
+    mode = "read"
+    secrets = []
+  }
+
+  operation {
+    protocol = "http"
+    method = "GET"
+    url = "https://api.example.com/events"
+    stream = true
+  }
+
+  result {
+    decode = "json"
+    output = "{{ result }}"
+  }
+}
+"#;
+    fs::write(local_dir.join("stream_http.hcl"), hcl).unwrap();
+
+    let files = validate_all_from_dirs(&global_dir, &local_dir).unwrap();
+    assert_eq!(files.len(), 1, "stream=true HTTP template should be valid");
+}
+
+#[test]
+#[cfg(feature = "http")]
+fn http_template_with_stream_false_is_valid() {
+    let dir = tempdir().unwrap();
+    let local_dir = dir.path().join("local");
+    let global_dir = dir.path().join("global");
+    fs::create_dir_all(&local_dir).unwrap();
+    fs::create_dir_all(&global_dir).unwrap();
+
+    let hcl = r#"
+version = 1
+provider = "demo"
+
+command "fetch" {
+  title = "Fetch"
+  summary = "Fetch a resource"
+  description = "Standard non-streaming HTTP fetch."
+
+  annotations {
+    mode = "read"
+    secrets = []
+  }
+
+  operation {
+    protocol = "http"
+    method = "GET"
+    url = "https://api.example.com/data"
+    stream = false
+  }
+
+  result {
+    output = "{{ result }}"
+  }
+}
+"#;
+    fs::write(local_dir.join("no_stream.hcl"), hcl).unwrap();
+
+    let files = validate_all_from_dirs(&global_dir, &local_dir).unwrap();
+    assert_eq!(
+        files.len(),
+        1,
+        "stream=false HTTP template should be valid"
+    );
+}
+
+#[test]
+#[cfg(feature = "bash")]
+fn bash_template_with_stream_true_is_valid() {
+    let dir = tempdir().unwrap();
+    let local_dir = dir.path().join("local");
+    let global_dir = dir.path().join("global");
+    fs::create_dir_all(&local_dir).unwrap();
+    fs::create_dir_all(&global_dir).unwrap();
+
+    let hcl = r#"
+version = 1
+provider = "demo"
+
+command "tail" {
+  title = "Tail"
+  summary = "Tail a log file"
+  description = "Streams output from a bash script line by line."
+
+  annotations {
+    mode = "read"
+    secrets = []
+  }
+
+  operation {
+    protocol = "bash"
+    stream = true
+
+    bash {
+      script = "echo streaming"
+    }
+  }
+
+  result {
+    output = "{{ result }}"
+  }
+}
+"#;
+    fs::write(local_dir.join("stream_bash.hcl"), hcl).unwrap();
+
+    let files = validate_all_from_dirs(&global_dir, &local_dir).unwrap();
+    assert_eq!(files.len(), 1, "stream=true bash template should be valid");
+}
+
+#[test]
+#[cfg(feature = "grpc")]
+fn grpc_template_with_stream_true_is_valid() {
+    let dir = tempdir().unwrap();
+    let local_dir = dir.path().join("local");
+    let global_dir = dir.path().join("global");
+    fs::create_dir_all(&local_dir).unwrap();
+    fs::create_dir_all(&global_dir).unwrap();
+
+    let hcl = r#"
+version = 1
+provider = "demo"
+
+command "watch" {
+  title = "Watch"
+  summary = "Watch gRPC server stream"
+  description = "Opens a server-streaming gRPC call."
+
+  annotations {
+    mode = "read"
+    secrets = []
+  }
+
+  operation {
+    protocol = "grpc"
+    url = "http://localhost:50051"
+    stream = true
+
+    grpc {
+      service = "example.Watcher"
+      method = "Watch"
+      body = {}
+    }
+  }
+
+  result {
+    output = "{{ result }}"
+  }
+}
+"#;
+    fs::write(local_dir.join("stream_grpc.hcl"), hcl).unwrap();
+
+    let files = validate_all_from_dirs(&global_dir, &local_dir).unwrap();
+    assert_eq!(files.len(), 1, "stream=true gRPC template should be valid");
+}
+
+// ── is_streaming() helper tests ─────────────────────────
+
+#[test]
+#[cfg(feature = "http")]
+fn is_streaming_returns_true_for_stream_http_template() {
+    let hcl_src = r#"
+version = 1
+provider = "demo"
+
+command "events" {
+  title = "Events"
+  summary = "Stream events"
+  description = "Streams events."
+
+  annotations {
+    mode = "read"
+    secrets = []
+  }
+
+  operation {
+    protocol = "http"
+    method = "GET"
+    url = "https://api.example.com/events"
+    stream = true
+  }
+
+  result {
+    output = "{{ result }}"
+  }
+}
+"#;
+    let template_file = parse_template_hcl(hcl_src, Path::new(".")).unwrap();
+
+    let cmd = template_file.commands.get("events").unwrap();
+    assert!(
+        cmd.operation.is_streaming(),
+        "is_streaming() should return true when stream = true"
+    );
+}
+
+#[test]
+#[cfg(feature = "http")]
+fn is_streaming_returns_false_for_non_stream_http_template() {
+    let hcl_src = r#"
+version = 1
+provider = "demo"
+
+command "fetch" {
+  title = "Fetch"
+  summary = "Normal fetch"
+  description = "Non-streaming."
+
+  annotations {
+    mode = "read"
+    secrets = []
+  }
+
+  operation {
+    protocol = "http"
+    method = "GET"
+    url = "https://api.example.com/data"
+  }
+
+  result {
+    output = "{{ result }}"
+  }
+}
+"#;
+    let template_file = parse_template_hcl(hcl_src, Path::new(".")).unwrap();
+
+    let cmd = template_file.commands.get("fetch").unwrap();
+    assert!(
+        !cmd.operation.is_streaming(),
+        "is_streaming() should return false by default"
+    );
+}


### PR DESCRIPTION
## Summary

- Add progressive streaming output for HTTP (SSE/chunked), gRPC (server-streaming), and Bash (live stdout/stderr)
- Template authors opt in with `stream = true` on the operation block
- Each chunk is independently decoded, extracted, and rendered through the output template as it arrives
- In `--json` mode, each chunk is emitted as NDJSON (one JSON object per line)

## Architecture

- New `StreamingProtocolExecutor` trait alongside existing `ProtocolExecutor` — buffered path is untouched
- Streaming executors send chunks through `tokio::sync::mpsc` channels
- SSE parser for `text/event-stream` responses splits events into individual chunks
- `max_response_bytes` enforced as a running total across chunks
- Retry logic intentionally skipped for streaming (nonsensical mid-stream)

## Example

```hcl
command "watch_events" {
  title = "Watch SSE events"
  operation {
    protocol = "http"
    method   = "GET"
    url      = "https://api.example.com/events"
    stream   = true
  }
  result {
    decode = "json"
    output = "Event: {{ result.type }} - {{ result.message }}"
  }
}
```

## Test plan

- [x] Unit tests for `StreamChunk`, `StreamMeta`, `StreamingProtocolExecutor` mock (earl-core)
- [x] Schema tests for `stream` field on HTTP, GraphQL, gRPC, Bash templates
- [x] Bash streaming integration tests (5 tests: chunks, exit codes, output limits, line separation, env vars)
- [x] SSE parser tests (9 tests: simple/multiline events, types, comments, IDs, edge cases)
- [x] Streaming decode/extract pipeline tests (11 tests: JSON, text, HTML, XML, binary, regex, JSONPath, CSS selectors, auto-detect)
- [x] Template validation tests (6 tests: stream=true accepted for HTTP, Bash, gRPC)
- [x] Full regression suite passes (196 tests, 0 failures, 0 clippy warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)