### PR TITLE
feat: enhance GitHub release notes with Claude

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -234,7 +234,13 @@ jobs:
     environment: release
     permissions:
       contents: write
+      id-token: write
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
       - name: Download release assets
         uses: actions/download-artifact@v4
         with:
@@ -250,6 +256,28 @@ jobs:
           prerelease: ${{ needs.meta.outputs.is_prerelease == 'true' }}
           files: dist/*
           fail_on_unmatched_files: true
+
+      - name: Enhance release notes with Claude
+        uses: anthropics/claude-code-action@v1
+        env:
+          GH_TOKEN: ${{ github.token }}
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: |
+            Write an exciting, polished GitHub release body for Earl ${{ needs.meta.outputs.tag }} and publish it.
+
+            Earl is a Rust CLI tool for calling APIs using HCL template files. It supports HTTP, GraphQL, gRPC, Bash, and SQL protocols — letting developers define reusable, parameterised API calls as code.
+
+            Steps:
+            1. Run `git log $(git describe --tags --abbrev=0 HEAD^)..HEAD --oneline` to see all commits in this release.
+            2. Read `README.md` and any relevant source files under `src/` and `docs/` to understand the features and syntax.
+            3. Write the release body to `/tmp/release-notes.md`. It should:
+               - Open with an enthusiastic one-paragraph summary of what's new or why this release is exciting.
+               - Have clearly labelled sections (e.g. **✨ New Features**, **🐛 Bug Fixes**, **⚡ Improvements**) — only include sections that actually have content.
+               - For any significant new feature, include a short, concrete HCL example snippet showing it in action.
+               - End with a quick installation/upgrade snippet (`cargo install earl` or the shell one-liner from the README).
+               - Be written in an upbeat, developer-friendly tone — celebrate the work!
+            4. Publish it: `gh release edit ${{ needs.meta.outputs.tag }} --repo ${{ github.repository }} --notes-file /tmp/release-notes.md`
 
   attest-provenance:
     name: Attest Build Provenance


### PR DESCRIPTION
## Summary

- Merges the `enhance-release` job into `create-release` as a final step, keeping release creation atomic
- Adds a `Checkout` step (full history via `fetch-depth: 0`) so Claude can run `git log` against the previous tag
- Uses `claude-code-action` to read the codebase and rewrite the release body into an enthusiastic, feature-rich summary with HCL examples and an install snippet
- Passes `GH_TOKEN` so the agent can call `gh release edit` directly
- Adds `id-token: write` permission required by the action

## Test plan

- [ ] Verify workflow parses cleanly (`act --list` or a dry-run push to a test tag)
- [ ] Confirm `CLAUDE_CODE_OAUTH_TOKEN` is present in the `release` environment
- [ ] Trigger a release and check that the published body is populated with Claude-generated content

🤖 Generated with [Claude Code](https://claude.com/claude-code)