### PR TITLE
docs: document pre-built template library

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,10 +53,13 @@ Or do it manually:
 curl -fsSL https://raw.githubusercontent.com/brwse/earl/main/scripts/install.sh | bash
 # Or: cargo install earl
 
-# Import a template
-earl templates import ./examples/bash/system.hcl
+# Import a pre-built template (25 providers available: stripe, slack, github, notion, openai, ...)
+earl templates import https://raw.githubusercontent.com/brwse/earl/main/examples/stripe.hcl
+earl secrets set stripe.api_key
+earl call stripe.list_customers
 
-# Call a command defined in the template
+# Or start with the no-auth system example
+earl templates import ./examples/bash/system.hcl
 earl call system.disk_usage --path /tmp
 ```
 

--- a/site/content/docs/quick-start.mdx
+++ b/site/content/docs/quick-start.mdx
@@ -133,7 +133,7 @@ Earl executes `ls -la /tmp` inside a sandboxed Bash environment and prints the r
 ### Import the GitHub template
 
 ```bash
-earl templates import https://raw.githubusercontent.com/brwse/earl/main/templates/github.hcl
+earl templates import https://raw.githubusercontent.com/brwse/earl/main/examples/github.hcl
 ```
 
 Earl prints the required secrets for this template. The GitHub template uses `github.token` for authentication.
@@ -182,6 +182,7 @@ Earl resolves the `github.token` secret from your keychain, builds the HTTP requ
 
 ## What's Next
 
+- **Pre-built templates** — Import ready-made templates for Stripe, Slack, Notion, OpenAI, and 21 more providers. See [Templates → Pre-built Templates](/docs/templates#pre-built-templates).
 - **Browse commands** — Run `earl templates search "what you want to do"` for semantic search across all loaded templates.
 - **Web playground** — Run `earl web` to launch a local web UI for browsing and testing commands.
 - **MCP integration** — Run `earl mcp` to expose your templates as MCP tools for AI agents. See [MCP Integration](/docs/mcp).

--- a/site/content/docs/templates.mdx
+++ b/site/content/docs/templates.mdx
@@ -431,6 +431,31 @@ command "recent_orders" {
 </Tab>
 </Tabs>
 
+## Pre-built Templates
+
+Earl ships with a library of ready-made templates for 25 popular APIs. Import any of them with a single command:
+
+```bash
+earl templates import https://raw.githubusercontent.com/brwse/earl/main/examples/stripe.hcl
+earl secrets set stripe.api_key
+earl call stripe.list_customers
+```
+
+| Category | Providers |
+| -------- | --------- |
+| Developer Tools | `github`, `gitlab`, `jira`, `linear`, `pagerduty` |
+| Communication | `slack`, `discord`, `twilio`, `sendgrid` |
+| Cloud | `cloudflare`, `vercel`, `render` |
+| Payments | `stripe`, `shopify` |
+| CRM | `hubspot`, `mailchimp` |
+| Analytics | `datadog`, `sentry` |
+| AI / ML | `openai`, `anthropic` |
+| Productivity | `notion`, `airtable` |
+| Auth | `auth0` |
+| Storage & Email | `supabase`, `resend` |
+
+All templates live under [`examples/`](https://github.com/brwse/earl/tree/main/examples) in the repository. Each provider file declares the required secrets — Earl prints them after import.
+
 ## Importing Templates
 
 Import templates from a local file path or a direct HTTP(S) URL.

--- a/skills/getting-started-with-earl/SKILL.md
+++ b/skills/getting-started-with-earl/SKILL.md
@@ -53,15 +53,22 @@ If `earl doctor` succeeds, move on silently. If it fails, diagnose the specific 
 
 ## Phase 2: Quick Demo
 
-Import a ready-made template and run it so the user sees Earl work before making any decisions:
+Import a ready-made template and run it so the user sees Earl work before making any decisions.
+
+**If the user already mentions a specific service** (e.g. GitHub, Stripe, Slack, Notion), import that pre-built template directly — Earl ships with 25 ready-made providers:
+
+```bash
+# Available: github, stripe, slack, notion, openai, anthropic, discord, gitlab,
+# jira, linear, pagerduty, twilio, sendgrid, cloudflare, vercel, render,
+# shopify, hubspot, mailchimp, datadog, sentry, airtable, auth0, supabase, resend
+earl templates import https://raw.githubusercontent.com/brwse/earl/main/examples/<provider>.hcl
+earl secrets set <provider>.<credential>   # Earl prints the required secret names after import
+```
+
+**Otherwise**, use the no-auth system example to demonstrate the flow without any setup:
 
 ```bash
 earl templates import https://raw.githubusercontent.com/brwse/earl/main/examples/bash/system.hcl
-```
-
-Run it:
-
-```bash
 earl call system.list_files --path .
 ```
 
@@ -74,6 +81,8 @@ earl templates list
 ```
 
 ## Phase 3: Discover Intent
+
+**Check for pre-built templates first.** If the user names a known service (GitHub, Stripe, Slack, Notion, OpenAI, Datadog, etc.), offer to import the pre-built template rather than building from scratch. Only proceed to custom template authoring if no pre-built template matches.
 
 Ask the user ONE question:
 


### PR DESCRIPTION
## Summary

- Adds "Pre-built Templates" section to `templates.mdx` with a table of all 25 providers and an import example
- Fixes broken GitHub template URL in `quick-start.mdx` (`templates/github.hcl` → `examples/github.hcl`)
- Adds pre-built templates bullet to "What's Next" in `quick-start.mdx`
- Updates README quick start to showcase a company template import (`stripe.hcl`)
- Updates the getting-started skill to suggest pre-built templates in Phase 2 and Phase 3 before falling back to custom authoring

## Test plan

- [ ] Verify all internal doc links resolve correctly
- [ ] Confirm the GitHub template URL in quick-start now resolves (was 404)
- [ ] Check the skill flow works end-to-end with a pre-built provider

🤖 Generated with [Claude Code](https://claude.com/claude-code)