### PR TITLE
test: validate all example templates in CI

### DIFF
--- a/tests/template_validation.rs
+++ b/tests/template_validation.rs
@@ -1,4 +1,4 @@
-use std::fs;
+use std::{fs, path::Path};
 
 use earl::template::loader::validate_all_from_dirs;
 use tempfile::tempdir;
@@ -853,5 +853,21 @@ command "fetch" {
     assert!(
         rendered.contains("is not declared in annotations.secrets"),
         "unexpected error: {rendered}"
+    );
+}
+
+#[test]
+#[cfg(feature = "http")]
+fn validates_all_example_templates() {
+    let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let examples_dir = manifest_dir.join("examples");
+    let empty_dir = tempdir().unwrap();
+
+    let files = validate_all_from_dirs(empty_dir.path(), &examples_dir)
+        .expect("example templates should all be valid");
+
+    assert!(
+        !files.is_empty(),
+        "no .hcl files found in examples/ directory"
     );
 }


### PR DESCRIPTION
## Summary

- Adds `validates_all_example_templates` test that runs `validate_all_from_dirs` against the `examples/` directory
- Ensures all pre-built company templates stay valid as the codebase evolves — no more silent regressions

## Test plan

- [x] Test passes locally against the 25 example templates
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)