### PR TITLE
refactor: replace granc_core with inline gRPC client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1385,9 +1385,19 @@ version = "0.4.0"
 dependencies = [
  "anyhow",
  "earl-core",
- "granc_core",
+ "futures-util",
+ "http",
+ "http-body",
+ "prost",
+ "prost-reflect",
+ "prost-types",
  "serde",
  "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tonic",
+ "tonic-reflection",
  "url",
 ]
 
@@ -1880,26 +1890,6 @@ checksum = "f5df2ba84018d80c213569363bdcd0c64e6933c67fe4c1d60ecf822971a3c35e"
 dependencies = [
  "color_quant",
  "weezl",
-]
-
-[[package]]
-name = "granc_core"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12684196af508c702e011ed6d6c3272c089b562fdd7a3e4d481d91859f7cfb89"
-dependencies = [
- "futures-util",
- "http",
- "http-body",
- "prost",
- "prost-reflect",
- "prost-types",
- "serde_json",
- "thiserror 2.0.18",
- "tokio",
- "tokio-stream",
- "tonic",
- "tonic-reflection",
 ]
 
 [[package]]

--- a/crates/earl-protocol-grpc/Cargo.toml
+++ b/crates/earl-protocol-grpc/Cargo.toml
@@ -11,7 +11,17 @@ documentation.workspace = true
 [dependencies]
 anyhow = "1.0"
 earl-core = { version = "0.4.0", path = "../earl-core" }
-granc_core = "0.6.1"
+futures-util = "0.3"
+http = "1"
+http-body = "1"
+prost = "0.14"
+prost-reflect = { version = "0.16", features = ["serde"] }
+prost-types = "0.14"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+thiserror = "2.0"
+tokio = { version = "1", features = ["sync"] }
+tokio-stream = "0.1"
+tonic = { version = "0.14", features = ["transport"] }
+tonic-reflection = "0.14"
 url = "2.5"

--- a/crates/earl-protocol-grpc/src/executor.rs
+++ b/crates/earl-protocol-grpc/src/executor.rs
@@ -2,10 +2,13 @@ use std::future::Future;
 use std::net::IpAddr;
 
 use anyhow::{Context, Result, anyhow, bail};
-use granc_core::client::{DynamicRequest, DynamicResponse, GrancClient};
-use granc_core::tonic;
+use prost_reflect::DescriptorPool;
 use serde_json::{Value, json};
 use url::Url;
+
+use crate::grpc::client::{
+    DynamicRequest, DynamicResponse, dynamic_call, dynamic_call_with_reflection,
+};
 
 use earl_core::allowlist::ensure_url_allowed;
 use earl_core::{ExecutionContext, PreparedBody, RawExecutionResult};
@@ -49,7 +52,7 @@ where
         .timeout(ctx.transport.timeout)
         .connect_timeout(ctx.transport.timeout);
 
-    let channel: tonic::transport::Channel = endpoint
+    let channel = endpoint
         .connect()
         .await
         .with_context(|| format!("failed connecting to gRPC endpoint `{}`", grpc_data.url))?;
@@ -62,17 +65,13 @@ where
     };
 
     let dynamic_response = if let Some(descriptor_set) = &grpc_data.descriptor_set {
-        let mut client = GrancClient::from(channel)
-            .with_file_descriptor(descriptor_set.clone())
+        let pool = DescriptorPool::decode(descriptor_set.as_slice())
             .context("invalid gRPC descriptor set bytes")?;
-        client
-            .dynamic(dynamic_request)
+        dynamic_call(channel, &pool, dynamic_request)
             .await
             .map_err(|err| anyhow!("gRPC request failed: {err}"))?
     } else {
-        let mut client = GrancClient::from(channel);
-        client
-            .dynamic(dynamic_request)
+        dynamic_call_with_reflection(channel, dynamic_request)
             .await
             .map_err(|err| anyhow!("gRPC reflection request failed: {err}"))?
     };

--- a/crates/earl-protocol-grpc/src/grpc/client.rs
+++ b/crates/earl-protocol-grpc/src/grpc/client.rs
@@ -1,0 +1,173 @@
+use anyhow::{Context, Result, bail};
+use futures_util::StreamExt;
+use prost_reflect::{DescriptorPool, MethodDescriptor};
+use std::str::FromStr;
+use tonic::metadata::{MetadataKey, MetadataValue};
+use tonic::transport::Channel;
+
+use super::codec::JsonCodec;
+use super::reflection;
+
+/// A request object for a dynamic gRPC call.
+#[derive(Debug, Clone)]
+pub struct DynamicRequest {
+    pub body: serde_json::Value,
+    pub headers: Vec<(String, String)>,
+    pub service: String,
+    pub method: String,
+}
+
+/// The result of a dynamic gRPC call.
+#[derive(Debug, Clone)]
+pub enum DynamicResponse {
+    Unary(Result<serde_json::Value, tonic::Status>),
+    Streaming(Result<Vec<Result<serde_json::Value, tonic::Status>>, tonic::Status>),
+}
+
+/// Execute a dynamic gRPC call using a pre-loaded `DescriptorPool`.
+pub async fn dynamic_call(
+    channel: Channel,
+    pool: &DescriptorPool,
+    request: DynamicRequest,
+) -> Result<DynamicResponse> {
+    let method = pool
+        .get_service_by_name(&request.service)
+        .with_context(|| format!("service '{}' not found in descriptor pool", request.service))?
+        .methods()
+        .find(|m| m.name() == request.method)
+        .with_context(|| format!("method '{}' not found in service", request.method))?;
+
+    let mut grpc = tonic::client::Grpc::new(channel);
+    grpc.ready().await.context("gRPC client not ready")?;
+
+    match (method.is_client_streaming(), method.is_server_streaming()) {
+        (false, false) => {
+            let result = do_unary(&mut grpc, method, request.body, request.headers).await?;
+            Ok(DynamicResponse::Unary(result))
+        }
+        (false, true) => {
+            let result =
+                do_server_streaming(&mut grpc, method, request.body, request.headers).await?;
+            Ok(result)
+        }
+        (true, false) => {
+            let items = json_array(request.body)?;
+            let result = do_client_streaming(&mut grpc, method, items, request.headers).await?;
+            Ok(DynamicResponse::Unary(result))
+        }
+        (true, true) => {
+            let items = json_array(request.body)?;
+            let result = do_bidi_streaming(&mut grpc, method, items, request.headers).await?;
+            Ok(result)
+        }
+    }
+}
+
+/// Execute a dynamic gRPC call using server reflection for schema discovery.
+pub async fn dynamic_call_with_reflection(
+    channel: Channel,
+    request: DynamicRequest,
+) -> Result<DynamicResponse> {
+    let fd_set = reflection::resolve_file_descriptor_set(channel.clone(), &request.service)
+        .await
+        .context("reflection resolution failed")?;
+
+    let pool = DescriptorPool::from_file_descriptor_set(fd_set)
+        .context("failed to build descriptor pool from reflection response")?;
+
+    dynamic_call(channel, &pool, request).await
+}
+
+async fn do_unary(
+    grpc: &mut tonic::client::Grpc<Channel>,
+    method: MethodDescriptor,
+    payload: serde_json::Value,
+    headers: Vec<(String, String)>,
+) -> Result<Result<serde_json::Value, tonic::Status>> {
+    let codec = JsonCodec::new(method.input(), method.output());
+    let path = http_path(&method);
+    let request = build_request(payload, headers)?;
+
+    match grpc.unary(request, path, codec).await {
+        Ok(response) => Ok(Ok(response.into_inner())),
+        Err(status) => Ok(Err(status)),
+    }
+}
+
+async fn do_server_streaming(
+    grpc: &mut tonic::client::Grpc<Channel>,
+    method: MethodDescriptor,
+    payload: serde_json::Value,
+    headers: Vec<(String, String)>,
+) -> Result<DynamicResponse> {
+    let codec = JsonCodec::new(method.input(), method.output());
+    let path = http_path(&method);
+    let request = build_request(payload, headers)?;
+
+    match grpc.server_streaming(request, path, codec).await {
+        Ok(response) => {
+            let items: Vec<_> = response.into_inner().collect().await;
+            Ok(DynamicResponse::Streaming(Ok(items)))
+        }
+        Err(status) => Ok(DynamicResponse::Streaming(Err(status))),
+    }
+}
+
+async fn do_client_streaming(
+    grpc: &mut tonic::client::Grpc<Channel>,
+    method: MethodDescriptor,
+    items: Vec<serde_json::Value>,
+    headers: Vec<(String, String)>,
+) -> Result<Result<serde_json::Value, tonic::Status>> {
+    let codec = JsonCodec::new(method.input(), method.output());
+    let path = http_path(&method);
+    let request = build_request(tokio_stream::iter(items), headers)?;
+
+    match grpc.client_streaming(request, path, codec).await {
+        Ok(response) => Ok(Ok(response.into_inner())),
+        Err(status) => Ok(Err(status)),
+    }
+}
+
+async fn do_bidi_streaming(
+    grpc: &mut tonic::client::Grpc<Channel>,
+    method: MethodDescriptor,
+    items: Vec<serde_json::Value>,
+    headers: Vec<(String, String)>,
+) -> Result<DynamicResponse> {
+    let codec = JsonCodec::new(method.input(), method.output());
+    let path = http_path(&method);
+    let request = build_request(tokio_stream::iter(items), headers)?;
+
+    match grpc.streaming(request, path, codec).await {
+        Ok(response) => {
+            let items: Vec<_> = response.into_inner().collect().await;
+            Ok(DynamicResponse::Streaming(Ok(items)))
+        }
+        Err(status) => Ok(DynamicResponse::Streaming(Err(status))),
+    }
+}
+
+fn http_path(method: &MethodDescriptor) -> http::uri::PathAndQuery {
+    let path = format!("/{}/{}", method.parent_service().full_name(), method.name());
+    http::uri::PathAndQuery::from_str(&path).expect("valid gRPC path")
+}
+
+fn build_request<T>(payload: T, headers: Vec<(String, String)>) -> Result<tonic::Request<T>> {
+    let mut request = tonic::Request::new(payload);
+    for (k, v) in headers {
+        let key = MetadataKey::from_str(&k)
+            .with_context(|| format!("invalid gRPC metadata key '{k}'"))?;
+        let val = MetadataValue::from_str(&v)
+            .with_context(|| format!("invalid gRPC metadata value for key '{k}'"))?;
+        request.metadata_mut().insert(key, val);
+    }
+    Ok(request)
+}
+
+fn json_array(value: serde_json::Value) -> Result<Vec<serde_json::Value>> {
+    match value {
+        serde_json::Value::Array(items) => Ok(items),
+        _ => bail!("client streaming requires a JSON array body"),
+    }
+}

--- a/crates/earl-protocol-grpc/src/grpc/codec.rs
+++ b/crates/earl-protocol-grpc/src/grpc/codec.rs
@@ -1,0 +1,71 @@
+use prost::Message;
+use prost_reflect::{DynamicMessage, MessageDescriptor};
+use tonic::{
+    Status,
+    codec::{Codec, DecodeBuf, Decoder, EncodeBuf, Encoder},
+};
+
+/// A codec that bridges `serde_json::Value` and Protobuf binary format.
+pub struct JsonCodec {
+    req_desc: MessageDescriptor,
+    res_desc: MessageDescriptor,
+}
+
+impl JsonCodec {
+    pub fn new(req_desc: MessageDescriptor, res_desc: MessageDescriptor) -> Self {
+        Self { req_desc, res_desc }
+    }
+}
+
+impl Codec for JsonCodec {
+    type Encode = serde_json::Value;
+    type Decode = serde_json::Value;
+
+    type Encoder = JsonEncoder;
+    type Decoder = JsonDecoder;
+
+    fn encoder(&mut self) -> Self::Encoder {
+        JsonEncoder(self.req_desc.clone())
+    }
+
+    fn decoder(&mut self) -> Self::Decoder {
+        JsonDecoder(self.res_desc.clone())
+    }
+}
+
+pub struct JsonEncoder(MessageDescriptor);
+
+impl Encoder for JsonEncoder {
+    type Item = serde_json::Value;
+    type Error = Status;
+
+    fn encode(&mut self, item: Self::Item, dst: &mut EncodeBuf<'_>) -> Result<(), Self::Error> {
+        let msg = DynamicMessage::deserialize(self.0.clone(), item).map_err(|e| {
+            Status::invalid_argument(format!(
+                "JSON structure does not match Protobuf schema: {}",
+                e
+            ))
+        })?;
+
+        msg.encode_raw(dst);
+        Ok(())
+    }
+}
+
+pub struct JsonDecoder(MessageDescriptor);
+
+impl Decoder for JsonDecoder {
+    type Item = serde_json::Value;
+    type Error = Status;
+
+    fn decode(&mut self, src: &mut DecodeBuf<'_>) -> Result<Option<Self::Item>, Self::Error> {
+        let mut msg = DynamicMessage::new(self.0.clone());
+        msg.merge(src)
+            .map_err(|e| Status::internal(format!("Failed to decode Protobuf bytes: {}", e)))?;
+
+        let value = serde_json::to_value(&msg)
+            .map_err(|e| Status::internal(format!("Failed to map response to JSON: {}", e)))?;
+
+        Ok(Some(value))
+    }
+}

--- a/crates/earl-protocol-grpc/src/grpc/mod.rs
+++ b/crates/earl-protocol-grpc/src/grpc/mod.rs
@@ -1,0 +1,3 @@
+pub mod client;
+mod codec;
+pub mod reflection;

--- a/crates/earl-protocol-grpc/src/grpc/reflection.rs
+++ b/crates/earl-protocol-grpc/src/grpc/reflection.rs
@@ -1,0 +1,160 @@
+use prost::Message;
+use prost_types::{FileDescriptorProto, FileDescriptorSet};
+use std::collections::{HashMap, HashSet};
+use tokio::sync::mpsc;
+use tokio_stream::wrappers::ReceiverStream;
+use tonic::Streaming;
+use tonic::transport::Channel;
+use tonic_reflection::pb::v1::{
+    ServerReflectionRequest, ServerReflectionResponse,
+    server_reflection_client::ServerReflectionClient, server_reflection_request::MessageRequest,
+    server_reflection_response::MessageResponse,
+};
+
+#[derive(Debug, thiserror::Error)]
+pub enum ReflectionError {
+    #[error("Failed to start reflection stream, reflection might not be supported: '{0}'")]
+    StreamInitFailed(#[source] tonic::Status),
+
+    #[error("Reflection stream returned an error status: '{0}'")]
+    StreamFailure(#[source] tonic::Status),
+
+    #[error("Reflection stream closed unexpectedly")]
+    StreamClosed,
+
+    #[error("Failed to send request to reflection stream")]
+    SendFailed,
+
+    #[error("Server returned reflection error code {code}: {message}")]
+    ServerError { code: i32, message: String },
+
+    #[error("Failed to decode FileDescriptorProto: {0}")]
+    DecodeError(#[from] prost::DecodeError),
+}
+
+const EMPTY_HOST: &str = "";
+
+/// Resolve the complete `FileDescriptorSet` for a symbol via server reflection.
+///
+/// Opens a bidi stream to the reflection service, fetches the file defining `symbol`,
+/// and recursively fetches all transitive dependencies.
+pub async fn resolve_file_descriptor_set(
+    channel: Channel,
+    symbol: &str,
+) -> Result<FileDescriptorSet, ReflectionError> {
+    let mut client = ServerReflectionClient::new(channel);
+
+    let (tx, rx) = mpsc::channel(100);
+
+    let mut response_stream = client
+        .server_reflection_info(ReceiverStream::new(rx))
+        .await
+        .map_err(ReflectionError::StreamInitFailed)?
+        .into_inner();
+
+    let req = ServerReflectionRequest {
+        host: EMPTY_HOST.to_string(),
+        message_request: Some(MessageRequest::FileContainingSymbol(symbol.to_string())),
+    };
+
+    tx.send(req)
+        .await
+        .map_err(|_| ReflectionError::SendFailed)?;
+
+    let file_map = collect_descriptors(&mut response_stream, tx).await?;
+
+    Ok(FileDescriptorSet {
+        file: file_map.into_values().collect(),
+    })
+}
+
+async fn collect_descriptors(
+    response_stream: &mut Streaming<ServerReflectionResponse>,
+    request_channel: mpsc::Sender<ServerReflectionRequest>,
+) -> Result<HashMap<String, FileDescriptorProto>, ReflectionError> {
+    let mut inflight = 1;
+    let mut collected_files = HashMap::new();
+    let mut requested = HashSet::new();
+
+    while inflight > 0 {
+        let response = response_stream
+            .message()
+            .await
+            .map_err(ReflectionError::StreamFailure)?
+            .ok_or(ReflectionError::StreamClosed)?;
+
+        inflight -= 1;
+
+        match response.message_response {
+            Some(MessageResponse::FileDescriptorResponse(res)) => {
+                let sent_count = process_descriptor_batch(
+                    res.file_descriptor_proto,
+                    &mut collected_files,
+                    &mut requested,
+                    &request_channel,
+                )
+                .await?;
+
+                inflight += sent_count;
+            }
+            Some(MessageResponse::ErrorResponse(e)) => {
+                return Err(ReflectionError::ServerError {
+                    message: e.error_message,
+                    code: e.error_code,
+                });
+            }
+            _ => {
+                return Err(ReflectionError::StreamClosed);
+            }
+        }
+    }
+
+    Ok(collected_files)
+}
+
+async fn process_descriptor_batch(
+    raw_protos: Vec<Vec<u8>>,
+    collected_files: &mut HashMap<String, FileDescriptorProto>,
+    requested: &mut HashSet<String>,
+    tx: &mpsc::Sender<ServerReflectionRequest>,
+) -> Result<usize, ReflectionError> {
+    let mut sent_count = 0;
+
+    for raw in raw_protos {
+        let fd = FileDescriptorProto::decode(raw.as_ref())?;
+
+        if let Some(name) = &fd.name
+            && !collected_files.contains_key(name)
+        {
+            sent_count += queue_dependencies(&fd, collected_files, requested, tx).await?;
+            collected_files.insert(name.clone(), fd);
+        }
+    }
+
+    Ok(sent_count)
+}
+
+async fn queue_dependencies(
+    fd: &FileDescriptorProto,
+    collected_files: &HashMap<String, FileDescriptorProto>,
+    requested: &mut HashSet<String>,
+    tx: &mpsc::Sender<ServerReflectionRequest>,
+) -> Result<usize, ReflectionError> {
+    let mut count = 0;
+
+    for dep in &fd.dependency {
+        if !collected_files.contains_key(dep) && requested.insert(dep.clone()) {
+            let req = ServerReflectionRequest {
+                host: EMPTY_HOST.to_string(),
+                message_request: Some(MessageRequest::FileByFilename(dep.clone())),
+            };
+
+            tx.send(req)
+                .await
+                .map_err(|_| ReflectionError::SendFailed)?;
+            count += 1;
+        }
+    }
+
+    Ok(count)
+}

--- a/crates/earl-protocol-grpc/src/lib.rs
+++ b/crates/earl-protocol-grpc/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod builder;
 pub mod executor;
+pub mod grpc;
 pub mod schema;
 
 pub use executor::GrpcExecutor;


### PR DESCRIPTION
## Summary

- Remove `granc_core` external dependency from `earl-protocol-grpc`
- Inline the dynamic gRPC client as three new modules under `src/grpc/`: codec (JSON↔protobuf), reflection (server schema discovery), and client (request dispatching for all streaming patterns)
- Update `executor.rs` to use the new inline client — same behavior, no API changes

## Test plan

- [x] `cargo build --features grpc` — clean
- [x] `cargo clippy --features grpc` — no warnings
- [x] `cargo test --features grpc` — all 183 tests pass
- [x] `cargo tree -p earl-protocol-grpc | grep -c granc` returns 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)