### PR TITLE
ci: add id-token: write permission to release-notes workflow

### DIFF
--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -14,6 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

- Adds missing `id-token: write` permission to the `release-notes.yml` workflow, matching what the original step in `release.yml` had.

## Test Plan
- [x] Manually trigger `release-notes.yml` and confirm it runs without permission errors