### PR TITLE
ci: publish release notes in a dedicated shell step

### DIFF
--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -43,9 +43,7 @@ jobs:
             Do NOT publish it yourself — a subsequent step will do that.
 
       - name: Publish release notes
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          gh release edit ${{ inputs.tag }} \
-            --repo ${{ github.repository }} \
-            --notes-file /tmp/release-notes.md
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ inputs.tag }}
+          body_path: /tmp/release-notes.md

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Release tag (e.g. v0.4.1)'
+        description: "Release tag (e.g. v0.4.1)"
         required: true
         type: string
 
@@ -21,14 +21,13 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Enhance release notes with Claude
+      - name: Write release notes with Claude
         uses: anthropics/claude-code-action@v1
-        env:
-          GH_TOKEN: ${{ github.token }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_args: --allowedTools "Bash(git log:*),Read,Write(//tmp/release-notes.md)"
           prompt: |
-            Write an exciting, polished GitHub release body for Earl ${{ inputs.tag }} and publish it.
+            Write an exciting, polished GitHub release body for Earl ${{ inputs.tag }} and save it to `/tmp/release-notes.md`.
 
             Earl is a Rust CLI tool for calling APIs using HCL template files. It supports HTTP, GraphQL, gRPC, Bash, and SQL protocols — letting developers define reusable, parameterised API calls as code.
 
@@ -41,4 +40,12 @@ jobs:
                - For any significant new feature, include a short, concrete HCL example snippet showing it in action.
                - End with a quick installation/upgrade snippet (`cargo install earl` or the shell one-liner from the README).
                - Be written in an upbeat, developer-friendly tone — celebrate the work!
-            4. Publish it: `gh release edit ${{ inputs.tag }} --repo ${{ github.repository }} --notes-file /tmp/release-notes.md`
+            Do NOT publish it yourself — a subsequent step will do that.
+
+      - name: Publish release notes
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release edit ${{ inputs.tag }} \
+            --repo ${{ github.repository }} \
+            --notes-file /tmp/release-notes.md


### PR DESCRIPTION
## Summary

- Claude was ignoring the prompt instruction to use `--notes-file` and instead calling `gh release edit --notes` with a huge inline escaped string, which silently failed to update the release
- Split the Claude step into two: Claude writes `/tmp/release-notes.md`, a dedicated shell step publishes it with `--notes-file`
- Removed `GH_TOKEN` from the Claude step env (it doesn't need it for writing the file)

## Test Plan
- [ ] Manually trigger `release-notes.yml` and verify the release body is updated on GitHub