### PR TITLE
ci: allow git describe in Claude release notes step

### DIFF
--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -25,7 +25,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: --allowedTools "Bash(git log:*),Read,Write(//tmp/release-notes.md)"
+          claude_args: --allowedTools "Bash(git log:*),Bash(git describe:*),Read,Write(//tmp/release-notes.md)"
           prompt: |
             Write an exciting, polished GitHub release body for Earl ${{ inputs.tag }} and save it to `/tmp/release-notes.md`.
 


### PR DESCRIPTION
## Summary

- Adds `Bash(git describe:*)` to `--allowedTools` in the release-notes workflow
- Required for the `git log $(git describe --tags --abbrev=0 HEAD^)..HEAD` subshell in the prompt