### PR TITLE
ci: fix Write path to use single slash

### DIFF
--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -25,7 +25,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: --allowedTools "Bash(git log:*),Bash(git describe:*),Read,Write(//tmp/release-notes.md)"
+          claude_args: --allowedTools "Bash(git log:*),Bash(git describe:*),Read,Write(/tmp/release-notes.md)"
           prompt: |
             Write an exciting, polished GitHub release body for Earl ${{ inputs.tag }} and save it to `/tmp/release-notes.md`.
 


### PR DESCRIPTION
Removes the erroneous double slash from `Write(//tmp/release-notes.md)` — the correct syntax is `Write(/tmp/release-notes.md)`.