### PR TITLE
ci: use absolute workspace path in Write allowedTools

### DIFF
--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -25,7 +25,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: --allowedTools "Bash(git log:*),Bash(git describe:*),Read,Write(release-notes.md)"
+          claude_args: --allowedTools "Bash(git log:*),Bash(git describe:*),Read,Write(/home/runner/work/earl/earl/release-notes.md)"
           prompt: |
             Write an exciting, polished GitHub release body for Earl ${{ inputs.tag }} and save it to `release-notes.md`.
 


### PR DESCRIPTION
Pins the `Write` allowed path to the exact runner workspace path.