### PR TITLE
feat(bash): add memory and CPU resource limits to sandbox

### DIFF
--- a/crates/earl-protocol-bash/src/builder.rs
+++ b/crates/earl-protocol-bash/src/builder.rs
@@ -71,6 +71,8 @@ pub fn build_bash_request(
             writable_paths,
             max_time_ms,
             max_output_bytes,
+            max_memory_bytes: None, // filled in next task
+            max_cpu_time_ms: None,  // filled in next task
         },
     })
 }

--- a/crates/earl-protocol-bash/src/builder.rs
+++ b/crates/earl-protocol-bash/src/builder.rs
@@ -11,6 +11,8 @@ pub struct GlobalBashLimits {
     pub allow_network: bool,
     pub max_time_ms: Option<u64>,
     pub max_output_bytes: Option<u64>,
+    pub max_memory_bytes: Option<u64>,
+    pub max_cpu_time_ms: Option<u64>,
 }
 
 /// Build a complete `PreparedBashScript` from a Bash operation template.
@@ -61,6 +63,17 @@ pub fn build_bash_request(
     )
     .map(|v| v as usize);
 
+    let max_memory_bytes = most_restrictive_option(
+        template_sandbox.as_ref().and_then(|s| s.max_memory_bytes),
+        global_limits.max_memory_bytes,
+    )
+    .map(|v| v as usize);
+
+    let max_cpu_time_ms = most_restrictive_option(
+        template_sandbox.as_ref().and_then(|s| s.max_cpu_time_ms),
+        global_limits.max_cpu_time_ms,
+    );
+
     Ok(PreparedBashScript {
         script,
         env,
@@ -71,8 +84,8 @@ pub fn build_bash_request(
             writable_paths,
             max_time_ms,
             max_output_bytes,
-            max_memory_bytes: None, // filled in next task
-            max_cpu_time_ms: None,  // filled in next task
+            max_memory_bytes,
+            max_cpu_time_ms,
         },
     })
 }

--- a/crates/earl-protocol-bash/src/executor.rs
+++ b/crates/earl-protocol-bash/src/executor.rs
@@ -48,7 +48,9 @@ pub async fn execute_bash_once(
                     rlim_cur: bytes as libc::rlim_t,
                     rlim_max: bytes as libc::rlim_t,
                 };
-                let _ = libc::setrlimit(libc::RLIMIT_AS, &rlim);
+                if libc::setrlimit(libc::RLIMIT_AS, &rlim) != 0 {
+                    return Err(std::io::Error::last_os_error());
+                }
             }
             if let Some(secs) = max_cpu_secs {
                 // Note: RLIMIT_CPU grace period sends SIGXCPU then SIGKILL ~1s later.
@@ -56,7 +58,9 @@ pub async fn execute_bash_once(
                     rlim_cur: secs as libc::rlim_t,
                     rlim_max: secs as libc::rlim_t,
                 };
-                let _ = libc::setrlimit(libc::RLIMIT_CPU, &rlim);
+                if libc::setrlimit(libc::RLIMIT_CPU, &rlim) != 0 {
+                    return Err(std::io::Error::last_os_error());
+                }
             }
             Ok(())
         });
@@ -214,7 +218,9 @@ impl StreamingProtocolExecutor for BashStreamExecutor {
                         rlim_cur: bytes as libc::rlim_t,
                         rlim_max: bytes as libc::rlim_t,
                     };
-                    let _ = libc::setrlimit(libc::RLIMIT_AS, &rlim);
+                    if libc::setrlimit(libc::RLIMIT_AS, &rlim) != 0 {
+                        return Err(std::io::Error::last_os_error());
+                    }
                 }
                 if let Some(secs) = max_cpu_secs {
                     // Note: RLIMIT_CPU grace period sends SIGXCPU then SIGKILL ~1s later.
@@ -222,7 +228,9 @@ impl StreamingProtocolExecutor for BashStreamExecutor {
                         rlim_cur: secs as libc::rlim_t,
                         rlim_max: secs as libc::rlim_t,
                     };
-                    let _ = libc::setrlimit(libc::RLIMIT_CPU, &rlim);
+                    if libc::setrlimit(libc::RLIMIT_CPU, &rlim) != 0 {
+                        return Err(std::io::Error::last_os_error());
+                    }
                 }
                 Ok(())
             });

--- a/crates/earl-protocol-bash/src/executor.rs
+++ b/crates/earl-protocol-bash/src/executor.rs
@@ -34,11 +34,30 @@ pub async fn execute_bash_once(
         command.stdin(Stdio::null());
     }
 
+    let max_memory = data.sandbox.max_memory_bytes;
+    let max_cpu_secs = data.sandbox.max_cpu_time_ms.map(|ms| (ms + 999) / 1000);
+
     // SAFETY: setsid() creates a new session / process group so that we can
     // kill the entire group on timeout without leaking children.
+    // setrlimit() calls are safe in a post-fork, pre-exec context.
     unsafe {
-        command.pre_exec(|| {
+        command.pre_exec(move || {
             libc::setsid();
+            if let Some(bytes) = max_memory {
+                let rlim = libc::rlimit {
+                    rlim_cur: bytes as libc::rlim_t,
+                    rlim_max: bytes as libc::rlim_t,
+                };
+                let _ = libc::setrlimit(libc::RLIMIT_AS, &rlim);
+            }
+            if let Some(secs) = max_cpu_secs {
+                // Note: RLIMIT_CPU grace period sends SIGXCPU then SIGKILL ~1s later.
+                let rlim = libc::rlimit {
+                    rlim_cur: secs as libc::rlim_t,
+                    rlim_max: secs as libc::rlim_t,
+                };
+                let _ = libc::setrlimit(libc::RLIMIT_CPU, &rlim);
+            }
             Ok(())
         });
     }
@@ -181,11 +200,30 @@ impl StreamingProtocolExecutor for BashStreamExecutor {
             command.stdin(Stdio::null());
         }
 
+        let max_memory = data.sandbox.max_memory_bytes;
+        let max_cpu_secs = data.sandbox.max_cpu_time_ms.map(|ms| (ms + 999) / 1000);
+
         // SAFETY: setsid() creates a new session / process group so that we
         // can kill the entire group on timeout without leaking children.
+        // setrlimit() calls are safe in a post-fork, pre-exec context.
         unsafe {
-            command.pre_exec(|| {
+            command.pre_exec(move || {
                 libc::setsid();
+                if let Some(bytes) = max_memory {
+                    let rlim = libc::rlimit {
+                        rlim_cur: bytes as libc::rlim_t,
+                        rlim_max: bytes as libc::rlim_t,
+                    };
+                    let _ = libc::setrlimit(libc::RLIMIT_AS, &rlim);
+                }
+                if let Some(secs) = max_cpu_secs {
+                    // Note: RLIMIT_CPU grace period sends SIGXCPU then SIGKILL ~1s later.
+                    let rlim = libc::rlimit {
+                        rlim_cur: secs as libc::rlim_t,
+                        rlim_max: secs as libc::rlim_t,
+                    };
+                    let _ = libc::setrlimit(libc::RLIMIT_CPU, &rlim);
+                }
                 Ok(())
             });
         }

--- a/crates/earl-protocol-bash/src/executor.rs
+++ b/crates/earl-protocol-bash/src/executor.rs
@@ -35,7 +35,7 @@ pub async fn execute_bash_once(
     }
 
     let max_memory = data.sandbox.max_memory_bytes;
-    let max_cpu_secs = data.sandbox.max_cpu_time_ms.map(|ms| (ms + 999) / 1000);
+    let max_cpu_secs = data.sandbox.max_cpu_time_ms.map(|ms| ms.div_ceil(1000));
 
     // SAFETY: setsid() creates a new session / process group so that we can
     // kill the entire group on timeout without leaking children.
@@ -205,7 +205,7 @@ impl StreamingProtocolExecutor for BashStreamExecutor {
         }
 
         let max_memory = data.sandbox.max_memory_bytes;
-        let max_cpu_secs = data.sandbox.max_cpu_time_ms.map(|ms| (ms + 999) / 1000);
+        let max_cpu_secs = data.sandbox.max_cpu_time_ms.map(|ms| ms.div_ceil(1000));
 
         // SAFETY: setsid() creates a new session / process group so that we
         // can kill the entire group on timeout without leaking children.

--- a/crates/earl-protocol-bash/src/lib.rs
+++ b/crates/earl-protocol-bash/src/lib.rs
@@ -14,6 +14,8 @@ pub struct ResolvedBashSandbox {
     pub writable_paths: Vec<String>,
     pub max_time_ms: Option<u64>,
     pub max_output_bytes: Option<usize>,
+    pub max_memory_bytes: Option<usize>,
+    pub max_cpu_time_ms: Option<u64>,
 }
 
 /// Prepared bash script data, ready for execution.

--- a/crates/earl-protocol-bash/src/schema.rs
+++ b/crates/earl-protocol-bash/src/schema.rs
@@ -34,6 +34,8 @@ pub struct BashSandboxTemplate {
     pub writable_paths: Option<Vec<String>>,
     pub max_time_ms: Option<u64>,
     pub max_output_bytes: Option<u64>,
+    pub max_memory_bytes: Option<u64>,
+    pub max_cpu_time_ms: Option<u64>,
 }
 
 #[cfg(test)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -130,6 +130,10 @@ pub struct SandboxConfig {
     pub bash_max_output_bytes: Option<u64>,
     #[serde(default)]
     pub bash_allow_network: bool,
+    #[serde(default)]
+    pub bash_max_memory_bytes: Option<u64>,
+    #[serde(default)]
+    pub bash_max_cpu_time_ms: Option<u64>,
     #[serde(default = "default_true")]
     pub sql_force_read_only: bool,
     #[serde(default)]
@@ -144,6 +148,8 @@ impl Default for SandboxConfig {
             bash_max_time_ms: None,
             bash_max_output_bytes: None,
             bash_allow_network: false,
+            bash_max_memory_bytes: None,
+            bash_max_cpu_time_ms: None,
             sql_force_read_only: true,
             sql_max_rows: None,
             sql_connection_allowlist: Vec::new(),

--- a/src/protocol/builder.rs
+++ b/src/protocol/builder.rs
@@ -264,6 +264,8 @@ where
                 allow_network: sandbox_config.bash_allow_network,
                 max_time_ms: sandbox_config.bash_max_time_ms,
                 max_output_bytes: sandbox_config.bash_max_output_bytes,
+                max_memory_bytes: sandbox_config.bash_max_memory_bytes,
+                max_cpu_time_ms: sandbox_config.bash_max_cpu_time_ms,
             };
 
             let data = earl_protocol_bash::builder::build_bash_request(

--- a/tests/bash_executor.rs
+++ b/tests/bash_executor.rs
@@ -244,6 +244,8 @@ async fn bash_json_output() {
 }
 
 /// Test that sandbox max_memory_bytes is enforced.
+/// macOS does not enforce RLIMIT_AS, so this test only runs on Linux.
+#[cfg(target_os = "linux")]
 #[tokio::test]
 async fn bash_sandbox_memory_limit_enforced() {
     let result_template = ResultTemplate {

--- a/tests/bash_executor.rs
+++ b/tests/bash_executor.rs
@@ -242,3 +242,66 @@ async fn bash_json_output() {
     assert_eq!(out.status, 0);
     assert_eq!(out.result, serde_json::json!("hi"));
 }
+
+/// Test that sandbox max_memory_bytes is enforced.
+#[tokio::test]
+async fn bash_sandbox_memory_limit_enforced() {
+    let result_template = ResultTemplate {
+        decode: ResultDecode::Text,
+        extract: None,
+        output: "{{ result }}".to_string(),
+        result_alias: None,
+    };
+
+    // Allocate 300MB; limit is 100MB.
+    let mut prepared = prepared_bash_request(
+        "python3 -c \"x = bytearray(300 * 1024 * 1024)\"",
+        result_template,
+    );
+    if let PreparedProtocolData::Bash(ref mut bash) = prepared.protocol_data {
+        bash.sandbox.max_memory_bytes = Some(100 * 1024 * 1024); // 100 MB
+    }
+
+    let out = execute_prepared_request_with_host_validator(&prepared, |_url| async {
+        Ok(loopback_resolver())
+    })
+    .await
+    .unwrap();
+
+    assert_ne!(out.status, 0, "expected non-zero exit due to memory limit");
+}
+
+/// Test that sandbox max_cpu_time_ms is enforced.
+#[tokio::test]
+async fn bash_sandbox_cpu_limit_enforced() {
+    let result_template = ResultTemplate {
+        decode: ResultDecode::Text,
+        extract: None,
+        output: "{{ result }}".to_string(),
+        result_alias: None,
+    };
+
+    // Tight CPU-bound loop; 1 CPU-second limit.
+    let mut prepared = prepared_bash_request(
+        "python3 -c \"while True: pass\"",
+        result_template,
+    );
+    if let PreparedProtocolData::Bash(ref mut bash) = prepared.protocol_data {
+        bash.sandbox.max_cpu_time_ms = Some(1_000); // 1 CPU-second
+        bash.sandbox.max_time_ms = Some(5_000);     // 5s wall-clock guard
+    }
+
+    let start = std::time::Instant::now();
+    let out = execute_prepared_request_with_host_validator(&prepared, |_url| async {
+        Ok(loopback_resolver())
+    })
+    .await
+    .unwrap();
+
+    let elapsed = start.elapsed();
+    assert_ne!(out.status, 0, "expected non-zero exit due to CPU limit");
+    assert!(
+        elapsed < std::time::Duration::from_secs(4),
+        "CPU limit should have fired before wall-clock guard"
+    );
+}

--- a/tests/bash_executor.rs
+++ b/tests/bash_executor.rs
@@ -284,13 +284,10 @@ async fn bash_sandbox_cpu_limit_enforced() {
     };
 
     // Tight CPU-bound loop; 1 CPU-second limit.
-    let mut prepared = prepared_bash_request(
-        "python3 -c \"while True: pass\"",
-        result_template,
-    );
+    let mut prepared = prepared_bash_request("python3 -c \"while True: pass\"", result_template);
     if let PreparedProtocolData::Bash(ref mut bash) = prepared.protocol_data {
         bash.sandbox.max_cpu_time_ms = Some(1_000); // 1 CPU-second
-        bash.sandbox.max_time_ms = Some(5_000);     // 5s wall-clock guard
+        bash.sandbox.max_time_ms = Some(5_000); // 5s wall-clock guard
     }
 
     let start = std::time::Instant::now();

--- a/tests/bash_executor.rs
+++ b/tests/bash_executor.rs
@@ -36,6 +36,8 @@ fn default_sandbox() -> ResolvedBashSandbox {
         writable_paths: vec![],
         max_time_ms: None,
         max_output_bytes: None,
+        max_memory_bytes: None,
+        max_cpu_time_ms: None,
     }
 }
 

--- a/tests/bash_streaming.rs
+++ b/tests/bash_streaming.rs
@@ -30,6 +30,8 @@ fn default_sandbox() -> ResolvedBashSandbox {
         writable_paths: vec![],
         max_time_ms: None,
         max_output_bytes: None,
+        max_memory_bytes: None,
+        max_cpu_time_ms: None,
     }
 }
 
@@ -119,6 +121,8 @@ async fn bash_streaming_respects_output_limit() {
             writable_paths: vec![],
             max_time_ms: None,
             max_output_bytes: Some(1024),
+            max_memory_bytes: None,
+            max_cpu_time_ms: None,
         },
     };
 


### PR DESCRIPTION
## Summary

- Adds `max_memory_bytes` (RLIMIT_AS) and `max_cpu_time_ms` (RLIMIT_CPU) to the bash sandbox, enforced via `setrlimit` in the `pre_exec` hook
- New fields thread through the same most-restrictive-wins pipeline as the existing `max_time_ms` and `max_output_bytes` — configurable per-template (HCL `sandbox {}` block) and globally (`config.toml`)
- `setrlimit` failures propagate as errors so callers know when a requested limit could not be applied

## Test Plan

- [x] `bash_sandbox_memory_limit_enforced` — 300 MB allocation against a 100 MB limit exits non-zero (Linux only; RLIMIT_AS not enforced on macOS)
- [x] `bash_sandbox_cpu_limit_enforced` — infinite Python busy-loop against a 1 CPU-second limit exits non-zero within 4 seconds (cross-platform)
- [x] All 8 existing bash executor tests pass with no regressions
- [x] All 6 streaming tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)