### PR TITLE
feat: replace template generate with create-template agent skill

### DIFF
--- a/skills/create-template/SKILL.md
+++ b/skills/create-template/SKILL.md
@@ -92,6 +92,16 @@ params = ["{{ args.limit }}"]   # correct
 params = [{{ args.limit }}]     # WRONG — invalid HCL
 ```
 
+### Environments (optional)
+
+If the user needs to target multiple backends (e.g., production vs staging) or swap credentials per stage, use named environments. See [references/environments.md](references/environments.md) for full syntax.
+
+Key points:
+- Define an `environments` block at the provider level with named variable sets
+- Access variables as `vars.<key>` in operations and results
+- Select at runtime with `earl call --env <name> provider.command`
+- If an environment override switches protocols, set `allow_environment_protocol_switching = true` in annotations
+
 ## Step 6: Validate
 
 After writing the file, run:

--- a/skills/create-template/SKILL.md
+++ b/skills/create-template/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: create-template
+description: Creates a new Earl HCL template (or adds a command to an existing one). Use when someone asks to create, add, generate, or build an Earl template for any protocol (HTTP, GraphQL, gRPC, Bash, SQL).
+---
+
+# Create Earl Template
+
+Earl templates are HCL files that define commands for calling APIs, databases, and shell scripts. This skill walks through creating or extending one.
+
+## Step 1: Discover Intent
+
+If the request already names a provider, command, and protocol, skip this step.
+
+Otherwise ask ONE question:
+
+> "What do you want to build? Include the service/provider name and what the command should do — for example: 'a GitHub command that lists open issues for a repo' or 'a Postgres command that queries recent orders'."
+
+## Step 2: Infer Protocol
+
+Map the user's description to a protocol:
+
+| User mentions                                                  | Protocol  | Reference file                                          |
+| -------------------------------------------------------------- | --------- | ------------------------------------------------------- |
+| REST, HTTP, API, endpoint, webhook, JSON API                   | `http`    | [references/http.md](references/http.md)                |
+| GraphQL, query/mutation (in API context)                       | `graphql` | [references/graphql.md](references/graphql.md)          |
+| gRPC, protobuf, service mesh                                   | `grpc`    | [references/grpc.md](references/grpc.md)                |
+| shell, bash, CLI, script, command line                         | `bash`    | [references/bash.md](references/bash.md)                |
+| SQL, database, postgres, mysql, sqlite, query (in DB context)  | `sql`     | [references/sql.md](references/sql.md)                  |
+
+Only ask a follow-up if the protocol is genuinely ambiguous.
+
+## Step 3: Read the Reference File
+
+Read the reference file for the chosen protocol (path shown in table above). It contains the HCL skeleton, key fields, and common patterns you must follow.
+
+For auth/secrets patterns also read [references/secrets-and-auth.md](references/secrets-and-auth.md).
+
+## Step 4: Determine Target File
+
+- **Local templates:** `./templates/<provider>.hcl` — available in the current project only
+- **Global templates:** `~/.config/earl/templates/<provider>.hcl` — available everywhere
+
+Default to local unless the user asks for global.
+
+If the file already exists, read it first and add the new command block — do not overwrite existing commands.
+
+## Step 5: Write the Template
+
+Apply ALL of the following constraints:
+
+### Schema fields (all commands must have)
+
+- `version = 1` at file top
+- `provider = "<name>"` at file top
+- `command "<name>" { ... }` block with:
+  - `title` — short human-readable name
+  - `summary` — one sentence
+  - `description` — markdown; see Description Rules below
+  - `annotations { mode = "read" | "write" }` — `write` for any mutating operation
+  - `param` blocks for each input (`type`, `required`, `default` if optional)
+  - `operation { ... }` — protocol-specific shape (see reference file)
+  - `result { decode = "..." output = "..." }`
+
+### Description rules
+
+Every description must include:
+
+1. A plain explanation of what the command does (1-2 sentences)
+2. A `## Guidance for AI agents` section with:
+   - When to use this command
+   - A concrete `earl call` usage example: `earl call <provider>.<command> --param value`
+
+### Mode selection
+
+- `read` — fetching, querying, listing (no side effects)
+- `write` — creating, updating, deleting, sending, inserting
+
+### Auth / secrets (least-privilege)
+
+- Only request secrets that the command actually needs
+- For secret references in `auth` blocks use the dotted key (e.g. `github.token`)
+- For secret references in template expressions use underscores (e.g. `{{ secrets.github_token }}`)
+- Declare required secrets in `annotations { secrets = ["..."] }`
+- See [references/secrets-and-auth.md](references/secrets-and-auth.md) for patterns
+
+### HCL/Jinja critical rule
+
+HCL is parsed BEFORE Jinja rendering. All `{{ }}` expressions must be inside valid HCL string values. For SQL params this means:
+
+```hcl
+params = ["{{ args.limit }}"]   # correct
+params = [{{ args.limit }}]     # WRONG — invalid HCL
+```
+
+## Step 6: Validate
+
+After writing the file, run:
+
+```bash
+earl templates validate
+```
+
+If validation fails, read the error, fix the template, and run again. Common errors:
+
+| Error message                         | Likely cause                                                  |
+| ------------------------------------- | ------------------------------------------------------------- |
+| "unexpected token"                    | HCL syntax error — check braces, quotes, block structure      |
+| "undefined variable"                  | `{{ args.x }}` param name doesn't match a `param` block name  |
+| "missing required field"              | Protocol-specific required field omitted (see reference file) |
+| "expected discriminator field `kind`" | `body` or `auth` block missing `kind = "..."` field           |
+
+## Step 7: Report
+
+After successful validation, output:
+
+1. The file path written
+2. The `earl call` command to run it
+3. Any secrets the user needs to set: `earl secrets set <key>`
+4. Any assumptions made about the API or behavior

--- a/skills/create-template/references/bash.md
+++ b/skills/create-template/references/bash.md
@@ -11,7 +11,15 @@ provider = "tools"
 command "disk_usage" {
   title       = "Disk Usage"
   summary     = "Check disk usage for a path"
-  description = "Reports disk usage using du"
+  description = <<-EOT
+    Reports disk usage for a given path using the du command.
+
+    ## Guidance for AI agents
+
+    Use this command to check how much disk space a directory is using.
+
+    Example: `earl call tools.disk_usage --path /var/log`
+  EOT
 
   annotations {
     mode = "read"

--- a/skills/create-template/references/bash.md
+++ b/skills/create-template/references/bash.md
@@ -1,0 +1,101 @@
+# Bash Templates
+
+Use Bash when running shell commands, CLI tools, or local scripts.
+
+## Template Skeleton
+
+```hcl
+version = 1
+provider = "tools"
+
+command "disk_usage" {
+  title       = "Disk Usage"
+  summary     = "Check disk usage for a path"
+  description = "Reports disk usage using du"
+
+  annotations {
+    mode = "read"
+  }
+
+  param "path" {
+    type        = "string"
+    required    = true
+    description = "Path to check"
+  }
+
+  operation {
+    protocol = "bash"
+
+    bash {
+      script = "du -sh {{ args.path }}"
+
+      sandbox {
+        network      = false
+        max_time_ms  = 30000
+      }
+    }
+  }
+
+  result {
+    decode = "text"
+    output = "{{ result }}"
+  }
+}
+```
+
+## Key Fields
+
+| Field                           | Required | Description                                        |
+| ------------------------------- | -------- | -------------------------------------------------- |
+| `bash.script`                   | Yes      | Shell command to execute (supports `{{ args.* }}`) |
+| `bash.sandbox.network`          | No       | Allow network access (default: false)              |
+| `bash.sandbox.max_time_ms`      | No       | Timeout in milliseconds (default: from config)     |
+| `bash.sandbox.max_output_bytes` | No       | Max output size (default: from config)             |
+
+**Note:** Bash uses a nested `bash` block inside `operation`.
+
+## Sandbox
+
+Bash commands run in a sandbox by default:
+
+- **No network access** unless `network = true`
+- **Configurable timeout** via `max_time_ms`
+- **Output limits** via `max_output_bytes`
+
+Global sandbox defaults can be set in `~/.config/earl/config.toml`:
+
+```toml
+[sandbox]
+bash_max_time_ms = 60000
+bash_max_output_bytes = 1048576
+bash_allow_network = false
+```
+
+## Multi-line Scripts
+
+Use HCL heredoc syntax for longer scripts:
+
+```hcl
+bash {
+  script = <<-EOT
+    echo "Checking system info..."
+    uname -a
+    df -h
+    free -m 2>/dev/null || vm_stat
+  EOT
+}
+```
+
+## Auth
+
+Bash templates typically do not use auth blocks. If you need credentials in a script, reference secrets directly:
+
+```hcl
+bash {
+  script = "curl -H 'Authorization: Bearer {{ secrets.myapi_token }}' https://api.example.com/data"
+}
+```
+
+Set the secret: `earl secrets set myapi.token`
+
+Note that `secrets.*` uses underscores in template expressions (e.g., `secrets.myapi_token`), while the secret key uses dots (e.g., `myapi.token`).

--- a/skills/create-template/references/environments.md
+++ b/skills/create-template/references/environments.md
@@ -1,0 +1,125 @@
+# Environments
+
+Named environments let a single template work with multiple backends (production, staging, dev) by defining variable sets that are selected at runtime with `--env <name>`.
+
+Environments are optional — templates work without them.
+
+## Provider-Level Environments Block
+
+Define at the root of the template file:
+
+```hcl
+version = 1
+provider = "myapi"
+
+environments {
+  default = "production"
+  secrets = ["myapi.staging_token", "myapi.prod_token"]
+
+  production {
+    base_url  = "https://api.example.com"
+    api_token = "{{ secrets.myapi_prod_token }}"
+  }
+
+  staging {
+    base_url  = "https://staging.example.com"
+    api_token = "{{ secrets.myapi_staging_token }}"
+  }
+}
+```
+
+| Field | Required | Description |
+| ----- | -------- | ----------- |
+| `default` | No | Environment name to use when no `--env` flag is given |
+| `secrets` | No | Secret keys that `vars` values may reference via `{{ secrets.* }}` |
+| `<name> { ... }` | No | Named environment blocks; key-value pairs become `vars.<key>` |
+
+Environment names must match `[a-zA-Z0-9_-]` and be 1-64 characters.
+
+## Using `vars.*` in Templates
+
+Variables from the active environment are accessible as `vars.<key>`:
+
+```hcl
+operation {
+  protocol = "http"
+  method   = "GET"
+  url      = "{{ vars.base_url }}/items"
+
+  auth {
+    kind   = "bearer"
+    secret = "myapi.token"
+  }
+}
+```
+
+**Important:** `vars` values are rendered with only `secrets` context — you cannot reference `args.*` inside environment variable definitions. Use `args` in the operation/result templates instead.
+
+## Per-Command Environment Overrides
+
+Override the entire operation (and optionally result) for a specific environment:
+
+```hcl
+command "sync_data" {
+  annotations {
+    mode                                 = "write"
+    allow_environment_protocol_switching = true
+  }
+
+  operation {
+    protocol = "http"
+    method   = "POST"
+    url      = "{{ vars.base_url }}/sync"
+  }
+
+  environment "local" {
+    operation {
+      protocol = "bash"
+      bash {
+        script = "echo synced locally"
+      }
+    }
+    result {
+      decode = "text"
+      output = "Local sync: {{ result }}"
+    }
+  }
+
+  result {
+    decode = "text"
+    output = "{{ result }}"
+  }
+}
+```
+
+The `result` block inside `environment` is optional — if omitted, the command's default result is used.
+
+## Protocol Switching Guard
+
+If an environment override changes the protocol (e.g., HTTP to Bash), you **must** set:
+
+```hcl
+annotations {
+  allow_environment_protocol_switching = true
+}
+```
+
+Without this, validation fails. This prevents accidental sandbox bypass.
+
+## Environment Resolution Order
+
+The active environment is selected in this priority (highest first):
+
+1. `--env <name>` CLI flag
+2. `[environments] default` in `~/.config/earl/config.toml`
+3. `default` field in the template's `environments` block
+4. No active environment — `vars` is an empty map
+
+## When to Use Environments
+
+- **Different API endpoints** per stage (production, staging, dev)
+- **Different credentials** per stage
+- **Mock/local overrides** for testing (e.g., bash instead of HTTP)
+- **Regional configurations** (US, EU endpoints)
+
+If the template only ever hits one endpoint, you don't need environments.

--- a/skills/create-template/references/graphql.md
+++ b/skills/create-template/references/graphql.md
@@ -11,7 +11,15 @@ provider = "myapi_graphql"
 command "get_user" {
   title       = "Get User"
   summary     = "Fetch user profile from GraphQL API"
-  description = "Queries the authenticated user's profile"
+  description = <<-EOT
+    Queries the authenticated user's profile from the GraphQL API.
+
+    ## Guidance for AI agents
+
+    Use this command to look up a user's profile by username.
+
+    Example: `earl call myapi_graphql.get_user --username "alice"`
+  EOT
 
   annotations {
     mode    = "read"

--- a/skills/create-template/references/graphql.md
+++ b/skills/create-template/references/graphql.md
@@ -1,0 +1,117 @@
+# GraphQL Templates
+
+Use GraphQL when calling a GraphQL API endpoint.
+
+## Template Skeleton
+
+```hcl
+version = 1
+provider = "myapi_graphql"
+
+command "get_user" {
+  title       = "Get User"
+  summary     = "Fetch user profile from GraphQL API"
+  description = "Queries the authenticated user's profile"
+
+  annotations {
+    mode    = "read"
+    secrets = ["myapi.token"]
+  }
+
+  param "username" {
+    type        = "string"
+    required    = true
+    description = "Username to look up"
+  }
+
+  operation {
+    protocol = "graphql"
+    url      = "https://api.example.com/graphql"
+
+    graphql {
+      query = <<-EOT
+        query GetUser($username: String!) {
+          user(login: $username) {
+            name
+            email
+            createdAt
+          }
+        }
+      EOT
+
+      variables = {
+        username = "{{ args.username }}"
+      }
+    }
+
+    auth {
+      kind   = "bearer"
+      secret = "myapi.token"
+    }
+  }
+
+  result {
+    decode  = "json"
+    extract = { json_pointer = "/data/user" }
+    output  = "User: {{ result.name }} ({{ result.email }})"
+  }
+}
+```
+
+## Key Fields
+
+| Field               | Required | Description                                          |
+| ------------------- | -------- | ---------------------------------------------------- |
+| `url`               | Yes      | GraphQL endpoint URL                                 |
+| `graphql.query`     | Yes      | The GraphQL query or mutation string                 |
+| `graphql.variables` | No       | Variables as key-value map (supports `{{ args.* }}`) |
+| `auth`              | No       | Authentication block (same as HTTP)                  |
+
+**Note:** GraphQL uses a nested `graphql` block inside `operation`, unlike HTTP which is flat.
+
+## Mutations
+
+For write operations, use `annotations { mode = "write" }`:
+
+```hcl
+command "create_item" {
+  annotations {
+    mode = "write"
+  }
+
+  operation {
+    protocol = "graphql"
+    url      = "https://api.example.com/graphql"
+
+    graphql {
+      query = <<-EOT
+        mutation CreateItem($title: String!) {
+          createItem(input: { title: $title }) {
+            id
+            title
+          }
+        }
+      EOT
+
+      variables = {
+        title = "{{ args.title }}"
+      }
+    }
+  }
+}
+```
+
+## Auth
+
+GraphQL APIs typically use bearer tokens:
+
+```hcl
+auth {
+  kind   = "bearer"
+  secret = "myapi.token"
+}
+```
+
+Set the secret: `earl secrets set myapi.token`
+
+For advanced auth, see [secrets-and-auth.md](secrets-and-auth.md).

--- a/skills/create-template/references/grpc.md
+++ b/skills/create-template/references/grpc.md
@@ -1,0 +1,90 @@
+# gRPC Templates
+
+Use gRPC when calling gRPC services (protobuf-based RPC).
+
+## Template Skeleton (with reflection)
+
+```hcl
+version = 1
+provider = "myservice"
+
+command "health_check" {
+  title       = "Health Check"
+  summary     = "Check gRPC service health"
+  description = "Calls the standard gRPC health check endpoint"
+
+  annotations {
+    mode = "read"
+  }
+
+  param "service" {
+    type        = "string"
+    required    = false
+    description = "Service name to check (empty for server health)"
+    default     = ""
+  }
+
+  operation {
+    protocol   = "grpc"
+    url        = "http://grpc.example.com:50051"
+    timeout_ms = 5000
+
+    grpc {
+      service = "grpc.health.v1.Health"
+      method  = "Check"
+
+      body = {
+        service = "{{ args.service }}"
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Status: {{ result.status }}"
+  }
+}
+```
+
+## Key Fields
+
+| Field                      | Required | Description                                 |
+| -------------------------- | -------- | ------------------------------------------- |
+| `url`                      | Yes      | gRPC server address (include port)          |
+| `timeout_ms`               | No       | Request timeout in milliseconds             |
+| `grpc.service`             | Yes      | Fully qualified service name                |
+| `grpc.method`              | Yes      | RPC method name                             |
+| `grpc.body`                | No       | Request message as key-value map            |
+| `grpc.descriptor_set_file` | No       | Path to offline descriptor set (`.fds.bin`) |
+
+**Note:** gRPC uses a nested `grpc` block inside `operation`.
+
+## Reflection vs Descriptor Set
+
+**Reflection (default):** Earl discovers the service schema at runtime via gRPC reflection. The server must support reflection (v1). No extra files needed.
+
+**Descriptor set:** For servers without reflection, provide a pre-compiled descriptor set:
+
+```hcl
+grpc {
+  service             = "mypackage.MyService"
+  method              = "MyMethod"
+  descriptor_set_file = "myservice.fds.bin"
+
+  body = {
+    field = "{{ args.value }}"
+  }
+}
+```
+
+Generate the descriptor set from proto files:
+
+```bash
+protoc --descriptor_set_out=myservice.fds.bin --include_imports myservice.proto
+```
+
+## Known Issues
+
+**TLS with SSRF protection:** Earl's TOCTOU protection pins the gRPC endpoint to its resolved IP address, which can break TLS certificate validation (the cert expects the hostname, not the IP). For TLS endpoints, consider using `descriptor_set_file` to avoid reflection-related issues, or use HTTP-based testing.
+
+**Reflection version:** Earl uses gRPC reflection v1. Some servers only support v1alpha. If reflection fails, try using a descriptor set instead.

--- a/skills/create-template/references/grpc.md
+++ b/skills/create-template/references/grpc.md
@@ -11,7 +11,15 @@ provider = "myservice"
 command "health_check" {
   title       = "Health Check"
   summary     = "Check gRPC service health"
-  description = "Calls the standard gRPC health check endpoint"
+  description = <<-EOT
+    Calls the standard gRPC health check endpoint to verify service availability.
+
+    ## Guidance for AI agents
+
+    Use this command to check whether the gRPC service is running and healthy. Leave service empty to check server-wide health.
+
+    Example: `earl call myservice.health_check --service ""`
+  EOT
 
   annotations {
     mode = "read"

--- a/skills/create-template/references/http.md
+++ b/skills/create-template/references/http.md
@@ -11,7 +11,15 @@ provider = "myapi"
 command "get_items" {
   title       = "Get Items"
   summary     = "Fetch items from the API"
-  description = "Retrieves a list of items with optional filtering"
+  description = <<-EOT
+    Retrieves a list of items with optional filtering.
+
+    ## Guidance for AI agents
+
+    Use this command to search or list items from the API. Provide a search query and an optional result limit.
+
+    Example: `earl call myapi.get_items --query "widgets" --limit 5`
+  EOT
 
   annotations {
     mode = "read"

--- a/skills/create-template/references/http.md
+++ b/skills/create-template/references/http.md
@@ -1,0 +1,153 @@
+# HTTP Templates
+
+Use HTTP when calling REST APIs, webhooks, or any HTTP endpoint.
+
+## Template Skeleton
+
+```hcl
+version = 1
+provider = "myapi"
+
+command "get_items" {
+  title       = "Get Items"
+  summary     = "Fetch items from the API"
+  description = "Retrieves a list of items with optional filtering"
+
+  annotations {
+    mode = "read"
+    secrets = ["myapi.token"]
+  }
+
+  param "query" {
+    type        = "string"
+    required    = true
+    description = "Search query"
+  }
+
+  param "limit" {
+    type        = "integer"
+    required    = false
+    description = "Max results to return"
+    default     = 10
+  }
+
+  operation {
+    protocol = "http"
+    method   = "GET"
+    url      = "https://api.example.com/items"
+
+    query = {
+      q     = "{{ args.query }}"
+      limit = "{{ args.limit }}"
+    }
+
+    headers = {
+      Accept = "application/json"
+    }
+
+    auth {
+      kind   = "bearer"
+      secret = "myapi.token"
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Found {{ result | length }} items"
+  }
+}
+```
+
+## Key Fields
+
+| Field     | Required | Description                                    |
+| --------- | -------- | ---------------------------------------------- |
+| `method`  | Yes      | HTTP method: GET, POST, PUT, PATCH, DELETE     |
+| `url`     | Yes      | Full URL (supports `{{ args.* }}` expressions) |
+| `query`   | No       | Query parameters as key-value map              |
+| `headers` | No       | HTTP headers as key-value map                  |
+| `body`    | No       | Request body (see body kinds below)            |
+| `auth`    | No       | Authentication block                           |
+
+**Note:** HTTP operation fields are flat (directly in the `operation` block), unlike other protocols which use nested sub-blocks.
+
+## Body Kinds
+
+For POST/PUT/PATCH, add a `body` block inside `operation`:
+
+```hcl
+# JSON body
+body {
+  kind  = "json"
+  value = {
+    title = "{{ args.title }}"
+    body  = "{{ args.body }}"
+  }
+}
+
+# Form body
+body {
+  kind  = "form"
+  value = {
+    username = "{{ args.username }}"
+    password = "{{ args.password }}"
+  }
+}
+
+# Raw text body
+body {
+  kind  = "raw"
+  value = "{{ args.content }}"
+}
+```
+
+## Auth Patterns
+
+```hcl
+# Bearer token (most common for REST APIs)
+auth {
+  kind   = "bearer"
+  secret = "myapi.token"
+}
+
+# Basic auth
+auth {
+  kind   = "basic"
+  secret = "myapi.credentials"
+}
+
+# API key in header (use headers instead of auth block)
+headers = {
+  X-API-Key = "{{ secrets.myapi_key }}"
+}
+```
+
+Set the secret: `earl secrets set myapi.token`
+
+For advanced auth (OAuth, profiles), see [secrets-and-auth.md](secrets-and-auth.md).
+
+## Common Patterns
+
+**URL parameters:**
+
+```hcl
+url = "https://api.example.com/users/{{ args.user_id }}/repos"
+```
+
+**Result extraction with JSON pointer:**
+
+```hcl
+result {
+  decode  = "json"
+  extract = { json_pointer = "/items" }
+  output  = "Found {{ result | length }} items"
+}
+```
+
+**Write-mode command (requires user confirmation):**
+
+```hcl
+annotations {
+  mode = "write"
+}
+```

--- a/skills/create-template/references/secrets-and-auth.md
+++ b/skills/create-template/references/secrets-and-auth.md
@@ -1,0 +1,116 @@
+# Secrets and Authentication
+
+Earl stores secrets in the OS keychain (Apple Keychain, Windows Credential Manager, Linux Secret Service) and supports multiple authentication patterns.
+
+## Managing Secrets
+
+```bash
+# Set a secret (interactive prompt)
+earl secrets set myapi.token
+
+# Set a secret from stdin (for piping)
+echo "sk-abc123" | earl secrets set myapi.token --stdin
+
+# View a secret
+earl secrets get myapi.token
+
+# List all secrets
+earl secrets list
+
+# Delete a secret
+earl secrets delete myapi.token
+```
+
+## Auth Block Kinds
+
+Use an `auth` block inside `operation` to attach credentials to requests:
+
+```hcl
+# Bearer token
+auth {
+  kind   = "bearer"
+  secret = "myapi.token"
+}
+
+# Basic auth (username:password stored as single secret)
+auth {
+  kind   = "basic"
+  secret = "myapi.credentials"
+}
+
+# OAuth2 profile (uses config.toml profile)
+auth {
+  kind    = "oauth2"
+  profile = "myservice"
+}
+```
+
+## Referencing Secrets in Templates
+
+In `auth` blocks, use the `secret` field with the dotted key name:
+
+```hcl
+auth {
+  kind   = "bearer"
+  secret = "github.token"
+}
+```
+
+In template expressions (e.g., headers or bash scripts), use `secrets.*` with underscores:
+
+```hcl
+headers = {
+  X-API-Key = "{{ secrets.myapi_key }}"
+}
+```
+
+Note: dots in secret keys become underscores in template expressions (`myapi.key` becomes `secrets.myapi_key`).
+
+## OAuth2 Profiles
+
+For OAuth2 flows, configure a profile in `~/.config/earl/config.toml`:
+
+```toml
+[auth.profiles.myservice]
+flow = "device_code"
+client_id = "your-client-id"
+token_url = "https://auth.example.com/token"
+device_authorization_url = "https://auth.example.com/device"
+scopes = ["read", "write"]
+```
+
+Supported flows: `device_code`, `auth_code_pkce`, `client_credentials`.
+
+Log in:
+
+```bash
+earl auth login myservice
+```
+
+Check status:
+
+```bash
+earl auth status myservice
+```
+
+Then reference it in templates:
+
+```hcl
+auth {
+  kind    = "oauth2"
+  profile = "myservice"
+}
+```
+
+## Annotations
+
+Declare which secrets a command needs in `annotations`:
+
+```hcl
+annotations {
+  mode    = "read"
+  secrets = ["myapi.token"]
+}
+```
+
+This tells Earl (and MCP consumers) which secrets are required before the command can run.

--- a/skills/create-template/references/sql.md
+++ b/skills/create-template/references/sql.md
@@ -1,0 +1,119 @@
+# SQL Templates
+
+Use SQL when querying databases (PostgreSQL, MySQL, SQLite, etc.).
+
+## Template Skeleton
+
+```hcl
+version = 1
+provider = "analytics"
+
+command "recent_orders" {
+  title       = "Recent Orders"
+  summary     = "Fetch recent orders from the database"
+  description = "Queries the orders table with a configurable limit"
+
+  annotations {
+    mode    = "read"
+    secrets = ["analytics.db_url"]
+  }
+
+  param "limit" {
+    type        = "integer"
+    required    = false
+    description = "Max rows to return"
+    default     = 10
+  }
+
+  operation {
+    protocol = "sql"
+
+    sql {
+      connection_secret = "analytics.db_url"
+      query             = "SELECT id, customer, total, created_at FROM orders ORDER BY created_at DESC LIMIT ?"
+      params            = ["{{ args.limit }}"]
+
+      sandbox {
+        read_only = true
+        max_rows  = 100
+      }
+    }
+  }
+
+  result {
+    decode = "json"
+    output = "Found {{ result | length }} orders"
+  }
+}
+```
+
+## Key Fields
+
+| Field                   | Required | Description                                         |
+| ----------------------- | -------- | --------------------------------------------------- |
+| `sql.connection_secret` | Yes      | Secret key containing the database connection URL   |
+| `sql.query`             | Yes      | SQL query with `?` placeholders for parameters      |
+| `sql.params`            | No       | Array of parameter values (supports `{{ args.* }}`) |
+| `sql.sandbox.read_only` | No       | Force read-only mode (default: true)                |
+| `sql.sandbox.max_rows`  | No       | Maximum rows returned                               |
+
+**Note:** SQL uses a nested `sql` block inside `operation`.
+
+## Critical: HCL/Jinja Interaction
+
+HCL parsing happens BEFORE Jinja template rendering. This means all `{{ }}` expressions must be valid HCL tokens.
+
+**Correct — string-wrapped params:**
+
+```hcl
+params = ["{{ args.limit }}"]
+```
+
+**Wrong — bare expression (invalid HCL):**
+
+```hcl
+params = [{{ args.limit }}]
+```
+
+The string-wrapped version works because Earl's `render_string_value` auto-parses pure Jinja expressions as JSON, so `"{{ args.limit }}"` correctly becomes a number when `args.limit` is an integer.
+
+## Connection URL Format
+
+The connection secret should contain a standard database URL:
+
+- **PostgreSQL:** `postgres://user:pass@host:5432/dbname`
+- **MySQL:** `mysql://user:pass@host:3306/dbname`
+- **SQLite:** `sqlite:///path/to/database.db`
+
+Set it: `earl secrets set analytics.db_url --stdin` (then paste the URL)
+
+## Sandbox
+
+SQL queries run with safety defaults:
+
+- **Read-only by default** (`read_only = true`) — prevents accidental writes
+- **Row limits** — cap output size with `max_rows`
+
+To allow writes (INSERT, UPDATE, DELETE), set `read_only = false` and use `annotations { mode = "write" }`:
+
+```hcl
+command "insert_order" {
+  annotations {
+    mode = "write"
+  }
+
+  operation {
+    protocol = "sql"
+    sql {
+      connection_secret = "analytics.db_url"
+      query  = "INSERT INTO orders (customer, total) VALUES (?, ?)"
+      params = ["{{ args.customer }}", "{{ args.total }}"]
+      sandbox {
+        read_only = false
+      }
+    }
+  }
+}
+```
+
+For advanced auth, see [secrets-and-auth.md](secrets-and-auth.md).

--- a/skills/create-template/references/sql.md
+++ b/skills/create-template/references/sql.md
@@ -11,7 +11,15 @@ provider = "analytics"
 command "recent_orders" {
   title       = "Recent Orders"
   summary     = "Fetch recent orders from the database"
-  description = "Queries the orders table with a configurable limit"
+  description = <<-EOT
+    Fetches recent orders from the database, sorted by creation date descending.
+
+    ## Guidance for AI agents
+
+    Use this command to retrieve the most recently placed orders. Adjust the limit to control how many rows are returned.
+
+    Example: `earl call analytics.recent_orders --limit 25`
+  EOT
 
   annotations {
     mode    = "read"

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,7 +1,6 @@
 use std::env;
 use std::io::{self, Read, Write};
 use std::net::SocketAddr;
-use std::process::{Command as ProcessCommand, Stdio};
 
 use anyhow::{Context, Result, bail};
 use clap::CommandFactory;
@@ -12,7 +11,7 @@ use tracing_subscriber::EnvFilter;
 use crate::auth::oauth2::OAuthManager;
 use crate::cli::{
     AuthSubcommand, Cli, Command, CompletionArgs, CompletionShell, DoctorArgs, McpArgs,
-    McpMode as CliMcpMode, McpTransport, SecretsSubcommand, TemplateGenerateArgs,
+    McpMode as CliMcpMode, McpTransport, SecretsSubcommand,
     TemplateImportScope, TemplateMode, TemplateSubcommand, WebArgs,
 };
 use crate::config::{self, Config};
@@ -328,9 +327,6 @@ async fn run_templates(command: TemplateSubcommand, json_mode: bool, cfg: Config
                 }
             }
         }
-        TemplateSubcommand::Generate(args) => {
-            run_template_generate(args, json_mode)?;
-        }
     }
 
     Ok(())
@@ -534,63 +530,6 @@ fn prompt_write_confirmation(command: &str) -> Result<()> {
     Ok(())
 }
 
-#[derive(Debug)]
-struct TemplateGenerateInput {
-    request: String,
-}
-
-fn run_template_generate(args: TemplateGenerateArgs, json_mode: bool) -> Result<()> {
-    if json_mode {
-        bail!("`earl templates generate` does not support --json");
-    }
-
-    println!("Template generation wizard");
-    let request =
-        prompt_required("Describe the template you want (include provider.command if known): ")?;
-
-    let generate_input = TemplateGenerateInput {
-        request: request.clone(),
-    };
-    let generated_prompt = build_template_generation_prompt(&generate_input);
-
-    let (program, cli_args) = args
-        .command
-        .split_first()
-        .context("missing coding CLI command")?;
-    println!("Sending prompt to coding CLI: {}", args.command.join(" "));
-
-    let mut child = ProcessCommand::new(program)
-        .args(cli_args)
-        .stdin(Stdio::piped())
-        .stdout(Stdio::inherit())
-        .stderr(Stdio::inherit())
-        .spawn()
-        .with_context(|| format!("failed to start coding CLI `{program}`"))?;
-
-    {
-        let mut stdin = child
-            .stdin
-            .take()
-            .context("failed opening coding CLI stdin")?;
-        stdin
-            .write_all(generated_prompt.as_bytes())
-            .context("failed writing prompt to coding CLI stdin")?;
-        stdin
-            .write_all(b"\n")
-            .context("failed writing newline to coding CLI stdin")?;
-    }
-
-    let status = child
-        .wait()
-        .context("failed waiting for coding CLI process")?;
-    if !status.success() {
-        bail!("coding CLI exited with status {status}");
-    }
-
-    println!("Template request sent.");
-    Ok(())
-}
-
 #[derive(Debug, serde::Serialize)]
 struct TemplateListRow {
     command: String,
@@ -653,82 +592,6 @@ fn template_scope_label(scope: TemplateScope) -> &'static str {
         TemplateScope::Local => "local",
         TemplateScope::Global => "global",
     }
-}
-
-fn prompt_required(label: &str) -> Result<String> {
-    loop {
-        let value = prompt(label)?;
-        if !value.trim().is_empty() {
-            return Ok(value);
-        }
-        println!("A value is required.");
-    }
-}
-
-fn build_template_generation_prompt(input: &TemplateGenerateInput) -> String {
-    let command_hint = extract_command_hint(&input.request);
-    let hint_block = if let Some((provider, command)) = command_hint {
-        format!(
-            "- likely command key: `{provider}.{command}`\n- likely file: `templates/{provider}.hcl`"
-        )
-    } else {
-        "- infer command key and file path from the user request".to_string()
-    };
-
-    format!(
-        r#"You are editing templates for the earl CLI project.
-
-User request:
-{request}
-
-Hints:
-{hint_block}
-
-Constraints:
-- Do most of the design work yourself; avoid asking follow-up questions unless strictly necessary.
-- Follow the earl template schema (`version`, `provider`, `commands`, `params`, `operation`, `result`).
-- Create or update the command in the provider file (prefer `templates/<provider>.hcl`).
-- Determine `annotations.mode` (`read` vs `write`) from the requested behavior.
-- Keep existing commands in the same file unless they must be adjusted for schema correctness.
-- Include a useful `title`, `summary`, and markdown `description`.
-- Add a `## Guidance for AI agents` section and an `earl call provider.command --param value` usage example in the description.
-- Model parameters in `params` with appropriate `type`, `required`, and `default`.
-- Prefer least-privilege handling for secrets/auth and avoid overbroad network behavior.
-
-After editing:
-1. Run `earl templates validate`.
-2. If validation fails, fix the template and rerun validation.
-3. Return a brief summary of what changed and any assumptions.
-"#,
-        request = input.request,
-        hint_block = hint_block,
-    )
-}
-
-fn extract_command_hint(raw: &str) -> Option<(String, String)> {
-    for token in raw.split(|ch: char| {
-        ch.is_whitespace()
-            || matches!(
-                ch,
-                ',' | ';' | ':' | '(' | ')' | '[' | ']' | '{' | '}' | '"' | '\''
-            )
-    }) {
-        let Some((provider, command)) = token.split_once('.') else {
-            continue;
-        };
-        if is_identifier(provider) && is_identifier(command) {
-            return Some((provider.to_string(), command.to_string()));
-        }
-    }
-
-    None
-}
-
-fn is_identifier(raw: &str) -> bool {
-    !raw.is_empty()
-        && raw
-            .chars()
-            .all(|ch| ch.is_ascii_alphanumeric() || ch == '_')
 }
 
 fn render_doctor_report(report: &DoctorReport, cwd: &str) {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -70,8 +70,6 @@ pub enum TemplateSubcommand {
     Validate,
     /// Import a template file from a local path or direct HTTP(S) URL.
     Import(TemplateImportArgs),
-    /// Generate a template by delegating to a coding CLI.
-    Generate(TemplateGenerateArgs),
 }
 
 #[derive(Debug, Args)]
@@ -112,18 +110,6 @@ pub enum TemplateImportScope {
     Local,
     #[value(name = "global")]
     Global,
-}
-
-#[derive(Debug, Args)]
-pub struct TemplateGenerateArgs {
-    /// Coding CLI invocation after `--` (example: `-- claude --dangerously-skip-permissions`).
-    #[arg(
-        required = true,
-        num_args = 1..,
-        trailing_var_arg = true,
-        allow_hyphen_values = true
-    )]
-    pub command: Vec<String>,
 }
 
 #[derive(Debug, Args)]

--- a/tests/cli_templates.rs
+++ b/tests/cli_templates.rs
@@ -105,68 +105,6 @@ fn templates_list_discovers_nested_local_templates() {
 }
 
 #[test]
-fn templates_generate_sends_prompt_to_coding_cli() {
-    let cwd = tempfile::tempdir().unwrap();
-    let home = tempfile::tempdir().unwrap();
-    write_config(home.path());
-
-    let capture_file = cwd.path().join("prompt.txt");
-
-    let mut cmd = cargo_bin_cmd!("earl");
-    cmd.current_dir(cwd.path())
-        .env("HOME", home.path())
-        .env("EARL_CAPTURE_FILE", &capture_file)
-        .args([
-            "templates",
-            "generate",
-            "--",
-            "sh",
-            "-c",
-            "cat > \"$EARL_CAPTURE_FILE\"",
-        ])
-        .write_stdin(
-            "Please create github.create_issue to open a GitHub issue using owner/repo/title/body and github.token.\n",
-        );
-
-    let out = cmd.assert().success().get_output().stdout.clone();
-    let stdout = String::from_utf8(out).unwrap();
-    assert!(stdout.contains("Template generation wizard"));
-    assert!(stdout.contains("Describe the template you want"));
-    assert!(stdout.contains("Sending prompt to coding CLI"));
-    assert!(!stdout.contains("Command mode (read/write)"));
-    assert!(!stdout.contains("Template file path"));
-
-    let prompt = fs::read_to_string(capture_file).unwrap();
-    assert!(prompt.contains("User request:"));
-    assert!(prompt.contains("Please create github.create_issue"));
-    assert!(prompt.contains("- likely command key: `github.create_issue`"));
-    assert!(prompt.contains("- likely file: `templates/github.hcl`"));
-    assert!(prompt.contains("Run `earl templates validate`"));
-}
-
-#[test]
-fn templates_generate_rejects_json_mode() {
-    let cwd = tempfile::tempdir().unwrap();
-    let home = tempfile::tempdir().unwrap();
-    write_config(home.path());
-
-    let mut cmd = cargo_bin_cmd!("earl");
-    cmd.current_dir(cwd.path()).env("HOME", home.path()).args([
-        "templates",
-        "--json",
-        "generate",
-        "--",
-        "sh",
-        "-c",
-        "cat",
-    ]);
-
-    let out = cmd.assert().failure().get_output().stderr.clone();
-    let stderr = String::from_utf8(out).unwrap();
-    assert!(stderr.contains("does not support --json"));
-}
-
-#[test]
 fn templates_import_rejects_unsupported_url_scheme() {
     let cwd = tempfile::tempdir().unwrap();
     let home = tempfile::tempdir().unwrap();


### PR DESCRIPTION
## Summary

- Removes the `earl templates generate` CLI subcommand and all associated Rust code (CLI struct, implementation functions, integration tests)
- Adds a self-contained `skills/create-template/` agent skill that guides AI agents through creating Earl HCL templates
- Includes per-protocol reference files (HTTP, GraphQL, gRPC, Bash, SQL), secrets/auth reference, and environments reference

## Details

The old `template generate` command was a subprocess shim that piped a static prompt to an external coding CLI. The new skill replaces this with a structured 7-step workflow the agent executes directly:

1. Discover intent
2. Infer protocol
3. Read reference file
4. Determine target file
5. Write template (with schema constraints, description rules, auth patterns)
6. Validate with `earl templates validate`
7. Report results

## Test plan

- [x] All existing tests pass (32 suites, 0 failures)
- [x] `generate` subcommand removed from CLI help output
- [x] Skill file tree verified (SKILL.md + 7 reference files)
- [x] Rebased on main (includes environments feature)

🤖 Generated with [Claude Code](https://claude.com/claude-code)