### PR TITLE
feat!: handle optional params gracefully and validate template args

### DIFF
--- a/crates/earl-core/src/render.rs
+++ b/crates/earl-core/src/render.rs
@@ -42,6 +42,9 @@ pub fn render_key_value_map(
             }
             other => {
                 let s = value_to_string(other)?;
+                // Empty strings are treated as absent in query/header maps — same
+                // policy as null, since `default = ""` was the old workaround for
+                // optional params that are now handled via null-skipping.
                 if !s.is_empty() {
                     out.push((rendered_key, s));
                 }

--- a/crates/earl-core/src/render.rs
+++ b/crates/earl-core/src/render.rs
@@ -31,12 +31,21 @@ pub fn render_key_value_map(
         let rendered_value = renderer.render_value(value, context)?;
 
         match rendered_value {
+            Value::Null => {} // Skip null values — lets templates use `| default("null")` for optional params
             Value::Array(values) => {
                 for value in values {
-                    out.push((rendered_key.clone(), value_to_string(value)?));
+                    let s = value_to_string(value)?;
+                    if !s.is_empty() {
+                        out.push((rendered_key.clone(), s));
+                    }
                 }
             }
-            other => out.push((rendered_key, value_to_string(other)?)),
+            other => {
+                let s = value_to_string(other)?;
+                if !s.is_empty() {
+                    out.push((rendered_key, s));
+                }
+            }
         }
     }
 

--- a/crates/earl-core/src/render.rs
+++ b/crates/earl-core/src/render.rs
@@ -31,7 +31,7 @@ pub fn render_key_value_map(
         let rendered_value = renderer.render_value(value, context)?;
 
         match rendered_value {
-            Value::Null => {} // Skip null values — lets templates use `| default("null")` for optional params
+            Value::Null => {} // Absent optional params render to null; skip them so they are omitted from the request.
             Value::Array(values) => {
                 for value in values {
                     let s = value_to_string(value)?;

--- a/examples/github.hcl
+++ b/examples/github.hcl
@@ -274,7 +274,6 @@ command "list_issues" {
   param "labels" {
     type        = "string"
     required    = false
-    default     = ""
     description = "Comma-separated list of label names"
   }
 
@@ -473,22 +472,19 @@ command "update_issue" {
   param "state" {
     type        = "string"
     required    = false
-    default     = ""
-    description = "New state: open or closed"
+    description = "New state: open or closed (omit to keep current)"
   }
 
   param "title" {
     type        = "string"
     required    = false
-    default     = ""
-    description = "New title"
+    description = "New title (omit to keep current)"
   }
 
   param "body" {
     type        = "string"
     required    = false
-    default     = ""
-    description = "New body (Markdown)"
+    description = "New body in Markdown (omit to keep current)"
   }
 
   operation {
@@ -911,14 +907,12 @@ command "list_workflow_runs" {
   param "branch" {
     type        = "string"
     required    = false
-    default     = ""
     description = "Filter by branch name"
   }
 
   param "status" {
     type        = "string"
     required    = false
-    default     = ""
     description = "Filter by status: completed, success, failure, cancelled, in_progress, queued"
   }
 

--- a/examples/github.hcl
+++ b/examples/github.hcl
@@ -846,8 +846,7 @@ command "merge_pull" {
   param "commit_title" {
     type        = "string"
     required    = false
-    default     = ""
-    description = "Custom commit title for squash or merge commits"
+    description = "Custom commit title for squash or merge commits (omit to use PR title)"
   }
 
   operation {

--- a/examples/github.hcl
+++ b/examples/github.hcl
@@ -51,7 +51,8 @@ command "list_repos" {
     }
 
     headers = {
-      Accept              = "application/vnd.github+json"
+      Accept               = "application/vnd.github+json"
+      User-Agent           = "earl"
       X-GitHub-Api-Version = "2022-11-28"
     }
   }
@@ -96,7 +97,8 @@ command "get_repo" {
     }
 
     headers = {
-      Accept              = "application/vnd.github+json"
+      Accept               = "application/vnd.github+json"
+      User-Agent           = "earl"
       X-GitHub-Api-Version = "2022-11-28"
     }
   }
@@ -156,7 +158,8 @@ command "create_repo" {
     }
 
     headers = {
-      Accept              = "application/vnd.github+json"
+      Accept               = "application/vnd.github+json"
+      User-Agent           = "earl"
       X-GitHub-Api-Version = "2022-11-28"
     }
 
@@ -226,14 +229,15 @@ command "search_repos" {
     }
 
     headers = {
-      Accept              = "application/vnd.github+json"
+      Accept               = "application/vnd.github+json"
+      User-Agent           = "earl"
       X-GitHub-Api-Version = "2022-11-28"
     }
   }
 
   result {
     decode = "json"
-    output = "Found {{ result.total_count }} repositories:\n{% for repo in result.items[:10] %}  - {{ repo.full_name }} (stars: {{ repo.stargazers_count }}) — {{ repo.description | default('No description') | truncate(80) }}\n{% endfor %}"
+    output = "Found {{ result.total_count }} repositories:\n{% for repo in result.items[:10] %}  - {{ repo.full_name }} (stars: {{ repo.stargazers_count }}) — {{ repo.description | default('No description') }}\n{% endfor %}"
   }
 }
 
@@ -306,7 +310,8 @@ command "list_issues" {
     }
 
     headers = {
-      Accept              = "application/vnd.github+json"
+      Accept               = "application/vnd.github+json"
+      User-Agent           = "earl"
       X-GitHub-Api-Version = "2022-11-28"
     }
   }
@@ -357,7 +362,8 @@ command "get_issue" {
     }
 
     headers = {
-      Accept              = "application/vnd.github+json"
+      Accept               = "application/vnd.github+json"
+      User-Agent           = "earl"
       X-GitHub-Api-Version = "2022-11-28"
     }
   }
@@ -415,7 +421,8 @@ command "create_issue" {
     }
 
     headers = {
-      Accept              = "application/vnd.github+json"
+      Accept               = "application/vnd.github+json"
+      User-Agent           = "earl"
       X-GitHub-Api-Version = "2022-11-28"
     }
 
@@ -495,7 +502,8 @@ command "update_issue" {
     }
 
     headers = {
-      Accept              = "application/vnd.github+json"
+      Accept               = "application/vnd.github+json"
+      User-Agent           = "earl"
       X-GitHub-Api-Version = "2022-11-28"
     }
 
@@ -561,7 +569,8 @@ command "create_comment" {
     }
 
     headers = {
-      Accept              = "application/vnd.github+json"
+      Accept               = "application/vnd.github+json"
+      User-Agent           = "earl"
       X-GitHub-Api-Version = "2022-11-28"
     }
 
@@ -628,7 +637,8 @@ command "search_issues" {
     }
 
     headers = {
-      Accept              = "application/vnd.github+json"
+      Accept               = "application/vnd.github+json"
+      User-Agent           = "earl"
       X-GitHub-Api-Version = "2022-11-28"
     }
   }
@@ -700,7 +710,8 @@ command "list_pulls" {
     }
 
     headers = {
-      Accept              = "application/vnd.github+json"
+      Accept               = "application/vnd.github+json"
+      User-Agent           = "earl"
       X-GitHub-Api-Version = "2022-11-28"
     }
   }
@@ -777,7 +788,8 @@ command "create_pull" {
     }
 
     headers = {
-      Accept              = "application/vnd.github+json"
+      Accept               = "application/vnd.github+json"
+      User-Agent           = "earl"
       X-GitHub-Api-Version = "2022-11-28"
     }
 
@@ -853,7 +865,8 @@ command "merge_pull" {
     }
 
     headers = {
-      Accept              = "application/vnd.github+json"
+      Accept               = "application/vnd.github+json"
+      User-Agent           = "earl"
       X-GitHub-Api-Version = "2022-11-28"
     }
 
@@ -933,7 +946,8 @@ command "list_workflow_runs" {
     }
 
     headers = {
-      Accept              = "application/vnd.github+json"
+      Accept               = "application/vnd.github+json"
+      User-Agent           = "earl"
       X-GitHub-Api-Version = "2022-11-28"
     }
   }
@@ -990,7 +1004,8 @@ command "trigger_workflow" {
     }
 
     headers = {
-      Accept              = "application/vnd.github+json"
+      Accept               = "application/vnd.github+json"
+      User-Agent           = "earl"
       X-GitHub-Api-Version = "2022-11-28"
     }
 

--- a/examples/openai.hcl
+++ b/examples/openai.hcl
@@ -23,6 +23,8 @@ command "create_chat_completion" {
     type        = "string"
     required    = false
     default     = ""
+    # Kept as "" rather than removing: null content in the messages array is
+    # rejected by the OpenAI API, so we must send "" when omitted.
     description = "System message to set the assistant's behavior"
   }
 

--- a/examples/openai.hcl
+++ b/examples/openai.hcl
@@ -352,7 +352,6 @@ command "list_files" {
   param "purpose" {
     type        = "string"
     required    = false
-    default     = ""
     description = "Filter by purpose (assistants, batch, fine-tune, vision, user_data)"
   }
 

--- a/examples/openai.hcl
+++ b/examples/openai.hcl
@@ -42,6 +42,7 @@ command "create_chat_completion" {
   param "max_completion_tokens" {
     type        = "integer"
     required    = false
+    default     = 4096
     description = "Maximum number of tokens to generate"
   }
 
@@ -351,6 +352,7 @@ command "list_files" {
   param "purpose" {
     type        = "string"
     required    = false
+    default     = ""
     description = "Filter by purpose (assistants, batch, fine-tune, vision, user_data)"
   }
 

--- a/examples/openai.hcl
+++ b/examples/openai.hcl
@@ -43,7 +43,7 @@ command "create_chat_completion" {
     type        = "integer"
     required    = false
     default     = 4096
-    description = "Maximum number of tokens to generate"
+    description = "Maximum number of tokens to generate (default 4096 is conservative; newer models support 16k+)"
   }
 
   operation {

--- a/examples/render.hcl
+++ b/examples/render.hcl
@@ -61,12 +61,12 @@ command "list_services" {
     }
 
     query = {
-      name     = "{{ args.name }}"
-      type     = "{{ args.type }}"
-      region   = "{{ args.region }}"
+      name      = "{{ args.name }}"
+      type      = "{{ args.type }}"
+      region    = "{{ args.region }}"
       suspended = "{{ args.suspended }}"
-      limit    = "{{ args.limit }}"
-      cursor   = "{{ args.cursor }}"
+      limit     = "{{ args.limit }}"
+      cursor    = "{{ args.cursor }}"
     }
 
     headers = {

--- a/examples/shopify.hcl
+++ b/examples/shopify.hcl
@@ -80,7 +80,7 @@ command "list_products" {
 
     query = {
       limit  = "{{ args.limit }}"
-      status = "{{ args.status | default('') }}"
+      status = "{{ args.status }}"
     }
 
     headers = {
@@ -430,8 +430,8 @@ command "list_orders" {
     query = {
       limit              = "{{ args.limit }}"
       status             = "{{ args.status }}"
-      financial_status   = "{{ args.financial_status | default('') }}"
-      fulfillment_status = "{{ args.fulfillment_status | default('') }}"
+      financial_status   = "{{ args.financial_status }}"
+      fulfillment_status = "{{ args.fulfillment_status }}"
     }
 
     headers = {

--- a/examples/slack.hcl
+++ b/examples/slack.hcl
@@ -372,7 +372,7 @@ command "get_conversation_history" {
 
   result {
     decode = "json"
-    output = "{{ result.messages | length }} messages{% for m in result.messages %}\n  [{{ m.ts }}] {{ m.text | truncate(120) }}{% endfor %}{% if result.has_more %}\n  (more messages available){% endif %}"
+    output = "{{ result.messages | length }} messages{% for m in result.messages %}\n  [{{ m.ts }}] {{ m.text[:120] }}{% endfor %}{% if result.has_more %}\n  (more messages available){% endif %}"
   }
 }
 
@@ -439,7 +439,7 @@ command "get_thread_replies" {
 
   result {
     decode = "json"
-    output = "{{ result.messages | length }} replies in thread{% for m in result.messages %}\n  [{{ m.ts }}] {{ m.text | truncate(120) }}{% endfor %}{% if result.has_more %}\n  (more replies available){% endif %}"
+    output = "{{ result.messages | length }} replies in thread{% for m in result.messages %}\n  [{{ m.ts }}] {{ m.text[:120] }}{% endfor %}{% if result.has_more %}\n  (more replies available){% endif %}"
   }
 }
 
@@ -853,6 +853,6 @@ command "search_messages" {
 
   result {
     decode = "json"
-    output = "{{ result.messages.total }} results for \"{{ args.query }}\"{% for m in result.messages.matches %}\n  [#{{ m.channel.name }}] {{ m.text | truncate(120) }}{% endfor %}"
+    output = "{{ result.messages.total }} results for \"{{ args.query }}\"{% for m in result.messages.matches %}\n  [#{{ m.channel.name }}] {{ m.text[:120] }}{% endfor %}"
   }
 }

--- a/examples/slack.hcl
+++ b/examples/slack.hcl
@@ -372,7 +372,7 @@ command "get_conversation_history" {
 
   result {
     decode = "json"
-    output = "{{ result.messages | length }} messages{% for m in result.messages %}\n  [{{ m.ts }}] {{ m.text[:120] }}{% endfor %}{% if result.has_more %}\n  (more messages available){% endif %}"
+    output = "{{ result.messages | length }} messages{% for m in result.messages %}\n  [{{ m.ts }}] {{ m.text | truncate(120) }}{% endfor %}{% if result.has_more %}\n  (more messages available){% endif %}"
   }
 }
 
@@ -439,7 +439,7 @@ command "get_thread_replies" {
 
   result {
     decode = "json"
-    output = "{{ result.messages | length }} replies in thread{% for m in result.messages %}\n  [{{ m.ts }}] {{ m.text[:120] }}{% endfor %}{% if result.has_more %}\n  (more replies available){% endif %}"
+    output = "{{ result.messages | length }} replies in thread{% for m in result.messages %}\n  [{{ m.ts }}] {{ m.text | truncate(120) }}{% endfor %}{% if result.has_more %}\n  (more replies available){% endif %}"
   }
 }
 
@@ -853,6 +853,6 @@ command "search_messages" {
 
   result {
     decode = "json"
-    output = "{{ result.messages.total }} results for \"{{ args.query }}\"{% for m in result.messages.matches %}\n  [#{{ m.channel.name }}] {{ m.text[:120] }}{% endfor %}"
+    output = "{{ result.messages.total }} results for \"{{ args.query }}\"{% for m in result.messages.matches %}\n  [#{{ m.channel.name }}] {{ m.text | truncate(120) }}{% endfor %}"
   }
 }

--- a/src/expression/binder.rs
+++ b/src/expression/binder.rs
@@ -68,6 +68,9 @@ pub fn bind_arguments(
     for param in params {
         if let Some(value) = out.get(&param.name) {
             // Null means the optional param was not provided — no type to validate.
+            // Note: a caller passing `null` explicitly for a typed param also bypasses
+            // this check. In practice null propagates through rendering to be omitted
+            // from the request, so this is benign.
             if !value.is_null() && !matches_type(value, param.r#type) {
                 return Err(BindError::InvalidType {
                     name: param.name.clone(),

--- a/src/expression/binder.rs
+++ b/src/expression/binder.rs
@@ -60,19 +60,21 @@ pub fn bind_arguments(
                 out.insert(param.name.clone(), default_value.clone());
             } else if param.required {
                 return Err(BindError::MissingRequired(param.name.clone()));
-            }
+            } // else: optional with no default — leave absent; Chainable rendering
+            // returns Undefined which maps to null in render_string_value
         }
     }
 
     for param in params {
-        if let Some(value) = out.get(&param.name)
-            && !matches_type(value, param.r#type)
-        {
-            return Err(BindError::InvalidType {
-                name: param.name.clone(),
-                expected: param.r#type.to_string(),
-                actual: value_type_name(value),
-            });
+        if let Some(value) = out.get(&param.name) {
+            // Null means the optional param was not provided — no type to validate.
+            if !value.is_null() && !matches_type(value, param.r#type) {
+                return Err(BindError::InvalidType {
+                    name: param.name.clone(),
+                    expected: param.r#type.to_string(),
+                    actual: value_type_name(value),
+                });
+            }
         }
     }
 

--- a/src/template/render.rs
+++ b/src/template/render.rs
@@ -31,8 +31,12 @@ pub fn render_json_value(value: &Value, context: &Value) -> Result<Value> {
             for (k, v) in obj {
                 let rendered_key = render_string_raw(k, context)?;
                 let rendered_val = render_json_value(v, context)?;
-                // Skip null values — absent optional params are omitted from the
-                // object, matching the policy in render_key_value_map.
+                // Skip null values — absent optional params (and literal `null`
+                // in the template) are omitted from the object, matching the
+                // policy in render_key_value_map. This means there is no way to
+                // send an explicit JSON null to an API; use a sentinel string
+                // value if needed. Note: array items are never dropped — an
+                // array element whose every field renders to null produces `{}`.
                 if !rendered_val.is_null() {
                     out.insert(rendered_key, rendered_val);
                 }

--- a/src/template/render.rs
+++ b/src/template/render.rs
@@ -6,7 +6,10 @@ use serde_json::{Map, Value};
 
 static JINJA_ENV: LazyLock<Environment<'static>> = LazyLock::new(|| {
     let mut env = Environment::new();
-    env.set_undefined_behavior(UndefinedBehavior::Strict);
+    // Chainable: accessing an absent optional param returns Undefined rather
+    // than erroring. Template-level typos are caught at load time by
+    // validate_template_args, so Chainable is safe at runtime.
+    env.set_undefined_behavior(UndefinedBehavior::Chainable);
     env
 });
 
@@ -42,16 +45,38 @@ pub fn render_string_raw(input: &str, context: &Value) -> Result<String> {
 }
 
 fn render_string_value(input: &str, context: &Value) -> Result<Value> {
-    let rendered = render_string_raw(input, context)?;
-    if is_pure_expression(input)
-        && let Ok(v) = serde_json::from_str::<Value>(&rendered)
-    {
-        return Ok(v);
+    if let Some(expr_str) = pure_expression(input) {
+        // Evaluate the expression directly to get a typed minijinja Value.
+        // This cleanly handles:
+        //   - Undefined (absent optional param) → Value::Null
+        //   - None/null                          → Value::Null
+        //   - Integer, float, bool, array, object → correct JSON type
+        //   - Explicit empty string ""            → Value::String("") (preserved)
+        let expr = JINJA_ENV
+            .compile_expression(expr_str)
+            .with_context(|| format!("template render failed for string `{input}`"))?;
+        let result = expr
+            .eval(context)
+            .with_context(|| format!("template render failed for string `{input}`"))?;
+        if result.is_undefined() {
+            return Ok(Value::Null);
+        }
+        return serde_json::to_value(&result)
+            .with_context(|| format!("template render failed for string `{input}`"));
     }
+    let rendered = render_string_raw(input, context)?;
     Ok(Value::String(rendered))
 }
 
-fn is_pure_expression(input: &str) -> bool {
+/// If `input` is a single `{{ expr }}` with no nested braces, return the inner
+/// expression string. Returns `None` for multi-expression strings or plain text.
+fn pure_expression(input: &str) -> Option<&str> {
     let trimmed = input.trim();
-    trimmed.starts_with("{{") && trimmed.ends_with("}}")
+    if trimmed.starts_with("{{") && trimmed.ends_with("}}") {
+        let inner = &trimmed[2..trimmed.len() - 2];
+        if !inner.contains("{{") {
+            return Some(inner.trim());
+        }
+    }
+    None
 }

--- a/src/template/render.rs
+++ b/src/template/render.rs
@@ -74,7 +74,7 @@ fn pure_expression(input: &str) -> Option<&str> {
     let trimmed = input.trim();
     if trimmed.starts_with("{{") && trimmed.ends_with("}}") {
         let inner = &trimmed[2..trimmed.len() - 2];
-        if !inner.contains("{{") {
+        if !inner.contains("{{") && !inner.contains("}}") {
             return Some(inner.trim());
         }
     }

--- a/src/template/render.rs
+++ b/src/template/render.rs
@@ -30,7 +30,12 @@ pub fn render_json_value(value: &Value, context: &Value) -> Result<Value> {
             let mut out = Map::new();
             for (k, v) in obj {
                 let rendered_key = render_string_raw(k, context)?;
-                out.insert(rendered_key, render_json_value(v, context)?);
+                let rendered_val = render_json_value(v, context)?;
+                // Skip null values — absent optional params are omitted from the
+                // object, matching the policy in render_key_value_map.
+                if !rendered_val.is_null() {
+                    out.insert(rendered_key, rendered_val);
+                }
             }
             Ok(Value::Object(out))
         }

--- a/src/template/validator.rs
+++ b/src/template/validator.rs
@@ -509,8 +509,15 @@ fn extract_args_refs(s: &str) -> Vec<&str> {
         if end > 0 {
             refs.push(&after[..end]);
         }
-        // Advance past "args." plus however many ident chars we consumed (at least 1)
-        remaining = &remaining[pos + 5 + end.max(1)..];
+        // Advance past "args." plus the identifier chars consumed, or past the
+        // non-identifier character that immediately followed "args." Use the
+        // character's actual byte length to stay on valid UTF-8 boundaries.
+        let skip = if end > 0 {
+            end
+        } else {
+            after.chars().next().map(|c| c.len_utf8()).unwrap_or(0)
+        };
+        remaining = &remaining[pos + 5 + skip..];
     }
     refs
 }

--- a/src/template/validator.rs
+++ b/src/template/validator.rs
@@ -507,6 +507,7 @@ fn validate_template_args(command_name: &str, cmd: &CommandTemplate) -> Result<(
 /// - False negatives: references inside Jinja comments (`{# args.x #}`) are
 ///   matched as if live; subscript-style `args["foo"]` access is invisible.
 /// - Map keys in query/header/body objects are not scanned (only values are).
+///
 /// Good enough for catching typos in the common case.
 fn extract_args_refs(s: &str) -> Vec<&str> {
     let mut refs = Vec::new();

--- a/src/template/validator.rs
+++ b/src/template/validator.rs
@@ -187,6 +187,7 @@ fn validate_command(command_name: &str, cmd: &CommandTemplate) -> Result<()> {
     }
 
     validate_params(command_name, &cmd.params)?;
+    validate_template_args(command_name, cmd)?;
 
     Ok(())
 }
@@ -466,6 +467,170 @@ fn validate_bash_operation(command_name: &str, operation: &BashOperationTemplate
     }
 
     validate_transport(command_name, operation.transport.as_ref())
+}
+
+// ── Template args validation ──────────────────────────────────────────────────
+
+/// Check that every `args.IDENT` reference in a command's template strings
+/// corresponds to a declared parameter. Catches typos at load time.
+fn validate_template_args(command_name: &str, cmd: &CommandTemplate) -> Result<()> {
+    let declared: HashSet<&str> = cmd.params.iter().map(|p| p.name.as_str()).collect();
+
+    let mut strings: Vec<String> = Vec::new();
+    collect_operation_strings(&cmd.operation, &mut strings);
+    strings.push(cmd.result.output.clone());
+
+    for s in &strings {
+        for arg_ref in extract_args_refs(s) {
+            if !declared.contains(arg_ref) {
+                bail!(
+                    "command {command_name} references undeclared param `args.{arg_ref}` in template"
+                );
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Extract all `IDENT` names following `args.` in a template string.
+fn extract_args_refs(s: &str) -> Vec<&str> {
+    let mut refs = Vec::new();
+    let mut remaining = s;
+    while let Some(pos) = remaining.find("args.") {
+        let after = &remaining[pos + 5..];
+        let end = after
+            .find(|c: char| !c.is_alphanumeric() && c != '_')
+            .unwrap_or(after.len());
+        if end > 0 {
+            refs.push(&after[..end]);
+        }
+        // Advance past "args." plus however many ident chars we consumed (at least 1)
+        remaining = &remaining[pos + 5 + end.max(1)..];
+    }
+    refs
+}
+
+/// Recursively collect all string leaves from a JSON value.
+fn collect_value_strings(value: &serde_json::Value, out: &mut Vec<String>) {
+    match value {
+        serde_json::Value::String(s) => out.push(s.clone()),
+        serde_json::Value::Array(arr) => arr.iter().for_each(|v| collect_value_strings(v, out)),
+        serde_json::Value::Object(obj) => obj.values().for_each(|v| collect_value_strings(v, out)),
+        _ => {}
+    }
+}
+
+/// Collect all template strings from a command's operation.
+#[allow(unused_variables)]
+fn collect_operation_strings(operation: &OperationTemplate, out: &mut Vec<String>) {
+    match operation {
+        #[cfg(feature = "http")]
+        OperationTemplate::Http(op) => {
+            out.push(op.url.clone());
+            if let Some(p) = &op.path {
+                out.push(p.clone());
+            }
+            if let Some(q) = &op.query {
+                q.values().for_each(|v| collect_value_strings(v, out));
+            }
+            if let Some(h) = &op.headers {
+                h.values().for_each(|v| collect_value_strings(v, out));
+            }
+            if let Some(c) = &op.cookies {
+                c.values().for_each(|v| collect_value_strings(v, out));
+            }
+            if let Some(body) = &op.body {
+                collect_body_strings(body, out);
+            }
+        }
+        #[cfg(feature = "graphql")]
+        OperationTemplate::Graphql(op) => {
+            out.push(op.url.clone());
+            if let Some(p) = &op.path {
+                out.push(p.clone());
+            }
+            if let Some(q) = &op.query {
+                q.values().for_each(|v| collect_value_strings(v, out));
+            }
+            if let Some(h) = &op.headers {
+                h.values().for_each(|v| collect_value_strings(v, out));
+            }
+            if let Some(c) = &op.cookies {
+                c.values().for_each(|v| collect_value_strings(v, out));
+            }
+            out.push(op.graphql.query.clone());
+            if let Some(op_name) = &op.graphql.operation_name {
+                out.push(op_name.clone());
+            }
+            if let Some(vars) = &op.graphql.variables {
+                collect_value_strings(vars, out);
+            }
+        }
+        #[cfg(feature = "grpc")]
+        OperationTemplate::Grpc(op) => {
+            out.push(op.url.clone());
+            if let Some(h) = &op.headers {
+                h.values().for_each(|v| collect_value_strings(v, out));
+            }
+            out.push(op.grpc.service.clone());
+            out.push(op.grpc.method.clone());
+            if let Some(body) = &op.grpc.body {
+                collect_value_strings(body, out);
+            }
+            if let Some(dsf) = &op.grpc.descriptor_set_file {
+                out.push(dsf.clone());
+            }
+        }
+        #[cfg(feature = "bash")]
+        OperationTemplate::Bash(op) => {
+            out.push(op.bash.script.clone());
+            if let Some(env) = &op.bash.env {
+                env.values().for_each(|v| collect_value_strings(v, out));
+            }
+            if let Some(cwd) = &op.bash.cwd {
+                out.push(cwd.clone());
+            }
+        }
+        #[cfg(feature = "sql")]
+        OperationTemplate::Sql(op) => {
+            // sql.query is validated to not contain Jinja — skip it
+            if let Some(params) = &op.sql.params {
+                params.iter().for_each(|v| collect_value_strings(v, out));
+            }
+        }
+        #[allow(unreachable_patterns)]
+        _ => {}
+    }
+}
+
+fn collect_body_strings(body: &BodyTemplate, out: &mut Vec<String>) {
+    match body {
+        BodyTemplate::None => {}
+        BodyTemplate::Json { value } => collect_value_strings(value, out),
+        BodyTemplate::FormUrlencoded { fields } => {
+            fields.values().for_each(|v| collect_value_strings(v, out));
+        }
+        BodyTemplate::Multipart { parts } => {
+            for part in parts {
+                if let Some(v) = &part.value {
+                    out.push(v.clone());
+                }
+                if let Some(v) = &part.bytes_base64 {
+                    out.push(v.clone());
+                }
+                if let Some(v) = &part.file_path {
+                    out.push(v.clone());
+                }
+                if let Some(v) = &part.filename {
+                    out.push(v.clone());
+                }
+            }
+        }
+        BodyTemplate::RawText { value, .. } => out.push(value.clone()),
+        BodyTemplate::RawBytesBase64 { value, .. } => out.push(value.clone()),
+        BodyTemplate::FileStream { path, .. } => out.push(path.clone()),
+    }
 }
 
 // ── SQL validation ───────────────────────────────────────

--- a/src/template/validator.rs
+++ b/src/template/validator.rs
@@ -501,11 +501,13 @@ fn validate_template_args(command_name: &str, cmd: &CommandTemplate) -> Result<(
 
 /// Extract all `IDENT` names following `args.` in a template string.
 ///
-/// Note: this is a text scan, not a Jinja AST parse. It will pick up `args.`
-/// references inside Jinja comments (`{# args.x #}`) and ignore subscript-style
-/// access (`args["foo"]`). Map keys in query/header/body objects are also not
-/// scanned (only values are). Known limitation — good enough for catching typos
-/// in the common case.
+/// Known limitations (text scan, not a Jinja AST parse):
+/// - False positives: `result.args.foo` or `env.args.key` match `args.foo`/`args.key`
+///   because the scanner uses a plain substring match on `"args."`.
+/// - False negatives: references inside Jinja comments (`{# args.x #}`) are
+///   matched as if live; subscript-style `args["foo"]` access is invisible.
+/// - Map keys in query/header/body objects are not scanned (only values are).
+/// Good enough for catching typos in the common case.
 fn extract_args_refs(s: &str) -> Vec<&str> {
     let mut refs = Vec::new();
     let mut remaining = s;

--- a/src/template/validator.rs
+++ b/src/template/validator.rs
@@ -479,6 +479,12 @@ fn validate_template_args(command_name: &str, cmd: &CommandTemplate) -> Result<(
     let mut strings: Vec<String> = Vec::new();
     collect_operation_strings(&cmd.operation, &mut strings);
     strings.push(cmd.result.output.clone());
+    for env_override in cmd.environment_overrides.values() {
+        collect_operation_strings(&env_override.operation, &mut strings);
+        if let Some(result) = &env_override.result {
+            strings.push(result.output.clone());
+        }
+    }
 
     for s in &strings {
         for arg_ref in extract_args_refs(s) {

--- a/src/template/validator.rs
+++ b/src/template/validator.rs
@@ -503,7 +503,9 @@ fn validate_template_args(command_name: &str, cmd: &CommandTemplate) -> Result<(
 ///
 /// Note: this is a text scan, not a Jinja AST parse. It will pick up `args.`
 /// references inside Jinja comments (`{# args.x #}`) and ignore subscript-style
-/// access (`args["foo"]`). Known limitation — good enough for catching typos.
+/// access (`args["foo"]`). Map keys in query/header/body objects are also not
+/// scanned (only values are). Known limitation — good enough for catching typos
+/// in the common case.
 fn extract_args_refs(s: &str) -> Vec<&str> {
     let mut refs = Vec::new();
     let mut remaining = s;

--- a/src/template/validator.rs
+++ b/src/template/validator.rs
@@ -494,6 +494,10 @@ fn validate_template_args(command_name: &str, cmd: &CommandTemplate) -> Result<(
 }
 
 /// Extract all `IDENT` names following `args.` in a template string.
+///
+/// Note: this is a text scan, not a Jinja AST parse. It will pick up `args.`
+/// references inside Jinja comments (`{# args.x #}`) and ignore subscript-style
+/// access (`args["foo"]`). Known limitation — good enough for catching typos.
 fn extract_args_refs(s: &str) -> Vec<&str> {
     let mut refs = Vec::new();
     let mut remaining = s;

--- a/src/template/validator.rs
+++ b/src/template/validator.rs
@@ -630,6 +630,9 @@ fn collect_body_strings(body: &BodyTemplate, out: &mut Vec<String>) {
         }
         BodyTemplate::Multipart { parts } => {
             for part in parts {
+                // Note: part.name (non-optional) is not scanned — multipart
+                // part names are static identifiers in practice ("file", etc.)
+                // and unlikely to contain args.* references.
                 if let Some(v) = &part.value {
                     out.push(v.clone());
                 }

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -653,37 +653,44 @@ command "write_echo" {
 "#;
 
     #[tokio::test]
+    #[allow(clippy::await_holding_lock)] // intentional: env_lock serialises HOME mutations across the async test
     async fn api_tools_returns_expected_schema() {
+        let _guard = env_lock();
         let cwd = tempfile::tempdir().unwrap();
+        let home = tempfile::tempdir().unwrap();
         write_template(cwd.path(), "demo.hcl", READ_TEMPLATE);
+        write_config(home.path(), "");
 
-        let app = build_router(WebState {
-            cwd: cwd.path().to_path_buf(),
-            bearer_token: TEST_TOKEN.to_string(),
-        });
+        with_home(home.path(), || async {
+            let app = build_router(WebState {
+                cwd: cwd.path().to_path_buf(),
+                bearer_token: TEST_TOKEN.to_string(),
+            });
 
-        let response = app
-            .oneshot(
-                Request::builder()
-                    .uri("/api/tools")
-                    .header("authorization", format!("Bearer {TEST_TOKEN}"))
-                    .body(Body::empty())
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
-        assert_eq!(response.status(), 200);
+            let response = app
+                .oneshot(
+                    Request::builder()
+                        .uri("/api/tools")
+                        .header("authorization", format!("Bearer {TEST_TOKEN}"))
+                        .body(Body::empty())
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+            assert_eq!(response.status(), 200);
 
-        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
-        let parsed: Value = serde_json::from_slice(&body).unwrap();
+            let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+            let parsed: Value = serde_json::from_slice(&body).unwrap();
 
-        let tools = parsed.as_array().unwrap();
-        assert_eq!(tools.len(), 1);
-        assert_eq!(tools[0]["key"], "demo.echo");
-        assert_eq!(tools[0]["protocol"], "bash");
-        let example = tools[0]["example_cli"].as_str().unwrap();
-        assert!(example.contains("earl call demo.echo"));
-        assert!(example.contains("--value"));
+            let tools = parsed.as_array().unwrap();
+            assert_eq!(tools.len(), 1);
+            assert_eq!(tools[0]["key"], "demo.echo");
+            assert_eq!(tools[0]["protocol"], "bash");
+            let example = tools[0]["example_cli"].as_str().unwrap();
+            assert!(example.contains("earl call demo.echo"));
+            assert!(example.contains("--value"));
+        })
+        .await;
     }
 
     #[tokio::test]

--- a/tests/expression_binder.rs
+++ b/tests/expression_binder.rs
@@ -28,6 +28,18 @@ fn params() -> Vec<ParamSpec> {
     ]
 }
 
+fn params_with_optional() -> Vec<ParamSpec> {
+    let mut p = params();
+    p.push(ParamSpec {
+        name: "filter".to_string(),
+        r#type: ParamType::String,
+        required: false,
+        default: None,
+        description: None,
+    });
+    p
+}
+
 #[test]
 fn binds_positional_and_named_arguments() {
     let expr = CallExpression {
@@ -41,6 +53,21 @@ fn binds_positional_and_named_arguments() {
     assert_eq!(bound.get("query").unwrap(), "hello");
     assert_eq!(bound.get("per_page").unwrap(), 10);
     assert_eq!(bound.get("include").unwrap(), false);
+}
+
+#[test]
+fn optional_param_without_default_is_absent() {
+    let expr = CallExpression {
+        provider: "github".to_string(),
+        command: "search_issues".to_string(),
+        positional_args: vec![serde_json::json!("hello")],
+        named_args: vec![],
+    };
+    let bound = bind_arguments(&expr, &params_with_optional()).unwrap();
+
+    // Optional params with no default are not injected into the map.
+    // Chainable rendering converts the resulting Undefined to null.
+    assert!(!bound.contains_key("filter"));
 }
 
 #[test]

--- a/tests/http_builder.rs
+++ b/tests/http_builder.rs
@@ -512,7 +512,7 @@ async fn builds_graphql_payload_and_headers() {
     });
 
     let mut args = Map::new();
-    args.insert("user_id".to_string(), json!("42"));
+    args.insert("user_id".to_string(), json!(42));
 
     let prepared = build_prepared_request_with_token_provider(
         &entry,

--- a/tests/template_render.rs
+++ b/tests/template_render.rs
@@ -16,15 +16,19 @@ fn renders_mixed_text_as_string() {
 }
 
 #[test]
-fn fails_on_undefined_variable_due_to_strict_mode() {
+fn undefined_variable_renders_as_empty_string() {
+    // Chainable undefined behavior: absent args render as empty string in raw
+    // string templates rather than erroring. Type-faithful rendering via
+    // pure_expression (render_json_value) maps undefined to null instead.
     let context = json!({"args": {}});
-    let err = render_string_raw("{{ args.missing }}", &context).unwrap_err();
-    assert!(err.to_string().contains("template render failed"));
+    let result = render_string_raw("{{ args.missing }}", &context).unwrap();
+    assert_eq!(result, "");
 }
 
 #[test]
 fn renders_object_keys_and_values() {
-    let context = json!({"args": {"key": "x-id", "value": "123"}});
+    // Pure expression rendering preserves context types: integer 123 stays integer.
+    let context = json!({"args": {"key": "x-id", "value": 123}});
     let value = json!({"{{ args.key }}": "{{ args.value }}"});
     let rendered = render_json_value(&value, &context).unwrap();
     assert_eq!(rendered, json!({"x-id": 123}));

--- a/tests/template_render.rs
+++ b/tests/template_render.rs
@@ -33,3 +33,13 @@ fn renders_object_keys_and_values() {
     let rendered = render_json_value(&value, &context).unwrap();
     assert_eq!(rendered, json!({"x-id": 123}));
 }
+
+#[test]
+fn skips_null_values_in_rendered_objects() {
+    // Absent optional params render to null and are omitted from the object,
+    // preventing { "title": null } in PATCH bodies when only some fields are set.
+    let context = json!({"args": {"state": "closed"}});
+    let value = json!({"state": "{{ args.state }}", "title": "{{ args.title }}"});
+    let rendered = render_json_value(&value, &context).unwrap();
+    assert_eq!(rendered, json!({"state": "closed"}));
+}

--- a/tests/template_validation.rs
+++ b/tests/template_validation.rs
@@ -1335,6 +1335,87 @@ command "ping" {
     );
 }
 
+// ── Template args typo detection ────────────────────────────────────
+
+#[test]
+#[cfg(feature = "bash")]
+fn rejects_undeclared_args_reference() {
+    use earl::template::parser::parse_template_hcl;
+    use earl::template::validator::validate_template_file;
+
+    let hcl = r#"version = 1
+provider = "test"
+
+command "greet" {
+  title = "Greet"
+  summary = "Greet someone"
+  description = "Say hello"
+  annotations {
+    mode = "read"
+    secrets = []
+  }
+  param "name" {
+    type = "string"
+    required = true
+    description = "Name"
+  }
+  operation {
+    protocol = "bash"
+    bash {
+      script = "echo Hello {{ args.naem }}"
+    }
+  }
+  result {
+    output = "ok"
+  }
+}
+"#;
+    let file = parse_template_hcl(hcl, std::path::Path::new(".")).unwrap();
+    let err = validate_template_file(&file).unwrap_err();
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("undeclared param") && msg.contains("args.naem"),
+        "unexpected error: {msg}"
+    );
+}
+
+#[test]
+#[cfg(feature = "bash")]
+fn accepts_valid_args_references() {
+    use earl::template::parser::parse_template_hcl;
+    use earl::template::validator::validate_template_file;
+
+    let hcl = r#"version = 1
+provider = "test"
+
+command "greet" {
+  title = "Greet"
+  summary = "Greet someone"
+  description = "Say hello"
+  annotations {
+    mode = "read"
+    secrets = []
+  }
+  param "name" {
+    type = "string"
+    required = true
+    description = "Name"
+  }
+  operation {
+    protocol = "bash"
+    bash {
+      script = "echo Hello {{ args.name }}"
+    }
+  }
+  result {
+    output = "ok"
+  }
+}
+"#;
+    let file = parse_template_hcl(hcl, std::path::Path::new(".")).unwrap();
+    validate_template_file(&file).expect("valid args reference should be accepted");
+}
+
 // ── External secret reference validation ────────────────────────────
 
 #[test]


### PR DESCRIPTION
## Summary

- Optional params without defaults are now treated as absent at render time. The Jinja environment uses `UndefinedBehavior::Chainable` so missing optional params produce `null` rather than a hard error. Null/empty values are then skipped in query/header maps, so they are omitted from requests instead of appearing as empty strings.
- New template arg validator checks all `args.IDENT` references in a command's template strings against its declared params at load time — typos are caught before runtime.
- Pure-expression rendering (`"{{ expr }}"`) now evaluates directly via minijinja for correct JSON types: `Undefined` → `null`, integers stay integers, booleans stay booleans.
- Updated examples (github, openai, render, shopify, slack) to remove `| default('')` workarounds that are no longer needed.

## Test plan

- [ ] Run `cargo test` to verify all existing and new tests pass
- [ ] Call a command with an optional param omitted — verify it is excluded from the request
- [ ] Load a template with a typo in an `args.` reference — verify it errors at load time
- [ ] Verify site builds: `cd site && npm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)