### PR TITLE
fix: replace non-existent peter-evans/workflow-dispatch with gh CLI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -259,12 +259,11 @@ jobs:
           make_latest: ${{ needs.meta.outputs.is_prerelease == 'false' }}
 
       - name: Trigger release notes workflow
-        uses: peter-evans/workflow-dispatch@v3
-        with:
-          token: ${{ secrets.RELEASE_TOKEN }}
-          workflow: release-notes.yml
-          inputs: >-
-            {"tag": "${{ needs.meta.outputs.tag }}"}
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+        run: |
+          gh workflow run release-notes.yml \
+            --field tag="${{ needs.meta.outputs.tag }}"
 
 
   attest-provenance:


### PR DESCRIPTION
## Summary
- Replaces `peter-evans/workflow-dispatch@v3` (which doesn't exist) with the equivalent `gh workflow run` command
- Uses `GH_TOKEN` env var with the existing `RELEASE_TOKEN` secret for authentication

## Test Plan
- [ ] Verify next release tag trigger runs `release-notes.yml` workflow successfully