### PR TITLE
fix: make crate publish idempotent when version already exists

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -277,7 +277,14 @@ jobs:
 
           for crate in "${CRATES[@]}"; do
             echo "Publishing $crate..."
-            cargo publish --locked -p "$crate"
+            output=$(cargo publish --locked -p "$crate" 2>&1) && echo "$output" || {
+              if echo "$output" | grep -q "already exists on crates.io index"; then
+                echo "$crate already published, skipping."
+              else
+                echo "$output" >&2
+                exit 1
+              fi
+            }
 
             # Wait for crates.io index to update before publishing
             # dependents (skip delay after the last crate).


### PR DESCRIPTION
## Summary
- Gracefully skip crates that are already published to crates.io (`already exists on crates.io index`)
- Allows the workflow to be safely re-run after partial failures (e.g. when `create-release` fails after crates were published)

## Test plan
- [ ] Verify workflow re-run succeeds for v0.5.0 after this merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)