### PR TITLE
chore: format code

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -394,7 +394,10 @@ clock_skew_seconds = 60
 
     #[test]
     fn jwt_config_audience_parsed_from_toml() {
-        assert_eq!(jwt_with_explicit_fields().audience, "https://api.example.com");
+        assert_eq!(
+            jwt_with_explicit_fields().audience,
+            "https://api.example.com"
+        );
     }
 
     #[test]
@@ -415,7 +418,10 @@ clock_skew_seconds = 60
 
     #[test]
     fn jwt_config_explicit_algorithms_parsed_from_toml() {
-        assert_eq!(jwt_with_explicit_fields().algorithms, vec!["RS256", "ES256"]);
+        assert_eq!(
+            jwt_with_explicit_fields().algorithms,
+            vec!["RS256", "ES256"]
+        );
     }
 
     #[test]

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -1302,7 +1302,11 @@ mod tests {
             .expect("response");
         let result = response.result.expect("result");
         let tools = result["tools"].as_array().expect("tools array");
-        assert!(tools.iter().any(|t| t["name"] == DISCOVERY_SEARCH_TOOL_NAME));
+        assert!(
+            tools
+                .iter()
+                .any(|t| t["name"] == DISCOVERY_SEARCH_TOOL_NAME)
+        );
     }
 
     #[tokio::test]

--- a/src/secrets/resolvers/azure.rs
+++ b/src/secrets/resolvers/azure.rs
@@ -710,5 +710,4 @@ mod tests {
     fn path_traversal_in_azure_id_returns_error() {
         validate_azure_id("../../../etc/passwd", "tenant").unwrap_err();
     }
-
 }

--- a/src/template/catalog.rs
+++ b/src/template/catalog.rs
@@ -84,7 +84,10 @@ mod tests {
         use super::super::schema::{Annotations, CommandTemplate, OperationTemplate};
 
         let mut prod_vars = BTreeMap::new();
-        prod_vars.insert("base_url".to_string(), "https://api.example.com".to_string());
+        prod_vars.insert(
+            "base_url".to_string(),
+            "https://api.example.com".to_string(),
+        );
         let mut envs = BTreeMap::new();
         envs.insert("production".to_string(), prod_vars);
 
@@ -146,7 +149,12 @@ mod tests {
     #[cfg(feature = "bash")]
     fn catalog_preserves_provider_environment_default() {
         let catalog = catalog_with_provider_environments();
-        let envs = catalog.get("myservice.ping").unwrap().provider_environments.as_ref().unwrap();
+        let envs = catalog
+            .get("myservice.ping")
+            .unwrap()
+            .provider_environments
+            .as_ref()
+            .unwrap();
         assert_eq!(envs.default.as_deref(), Some("production"));
     }
 
@@ -154,8 +162,15 @@ mod tests {
     #[cfg(feature = "bash")]
     fn catalog_preserves_provider_environment_variables() {
         let catalog = catalog_with_provider_environments();
-        let envs = catalog.get("myservice.ping").unwrap().provider_environments.as_ref().unwrap();
-        assert_eq!(envs.environments["production"]["base_url"], "https://api.example.com");
+        let envs = catalog
+            .get("myservice.ping")
+            .unwrap()
+            .provider_environments
+            .as_ref()
+            .unwrap();
+        assert_eq!(
+            envs.environments["production"]["base_url"],
+            "https://api.example.com"
+        );
     }
-
 }

--- a/tests/auth_profiles.rs
+++ b/tests/auth_profiles.rs
@@ -67,7 +67,12 @@ async fn oidc_resolved_profile() -> earl::auth::profiles::ResolvedOAuthProfile {
 #[tokio::test]
 async fn oidc_discovery_populates_authorization_url() {
     let resolved = oidc_resolved_profile().await;
-    assert!(resolved.authorization_url.unwrap().contains("/oauth/authorize"));
+    assert!(
+        resolved
+            .authorization_url
+            .unwrap()
+            .contains("/oauth/authorize")
+    );
 }
 
 #[tokio::test]

--- a/tests/bash_streaming.rs
+++ b/tests/bash_streaming.rs
@@ -58,7 +58,12 @@ async fn collect_output(mut rx: mpsc::Receiver<StreamChunk>) -> String {
 async fn collect_chunks(mut rx: mpsc::Receiver<StreamChunk>) -> Vec<String> {
     let mut chunks = vec![];
     while let Some(chunk) = rx.recv().await {
-        chunks.push(String::from_utf8(chunk.data).unwrap().trim_end().to_string());
+        chunks.push(
+            String::from_utf8(chunk.data)
+                .unwrap()
+                .trim_end()
+                .to_string(),
+        );
     }
     chunks
 }

--- a/tests/cli_args.rs
+++ b/tests/cli_args.rs
@@ -1,4 +1,4 @@
-use earl::expression::cli_args::{parse_cli_args, CliArgsError};
+use earl::expression::cli_args::{CliArgsError, parse_cli_args};
 use earl::template::schema::{ParamSpec, ParamType};
 
 fn s(v: &str) -> String {
@@ -93,7 +93,10 @@ fn parses_boolean_flag_without_value() {
     )
     .unwrap();
 
-    assert_eq!(expr.named_args[1], ("verbose".to_string(), serde_json::json!(true)));
+    assert_eq!(
+        expr.named_args[1],
+        ("verbose".to_string(), serde_json::json!(true))
+    );
 }
 
 #[test]
@@ -106,7 +109,10 @@ fn parses_boolean_flag_with_explicit_false() {
     )
     .unwrap();
 
-    assert_eq!(expr.named_args[1], ("verbose".to_string(), serde_json::json!(false)));
+    assert_eq!(
+        expr.named_args[1],
+        ("verbose".to_string(), serde_json::json!(false))
+    );
 }
 
 #[test]

--- a/tests/cli_templates.rs
+++ b/tests/cli_templates.rs
@@ -978,8 +978,7 @@ fn templates_list_json_write_mode_output_includes_expected_command() {
     let rows = parsed.as_array().unwrap();
     assert!(!rows.is_empty());
     assert_eq!(
-        rows[0]["command"],
-        "github.create_issue",
+        rows[0]["command"], "github.create_issue",
         "github.create_issue should be present in write-mode listings"
     );
 }

--- a/tests/expression_binder.rs
+++ b/tests/expression_binder.rs
@@ -1,5 +1,5 @@
 use earl::expression::ast::CallExpression;
-use earl::expression::binder::{bind_arguments, BindError};
+use earl::expression::binder::{BindError, bind_arguments};
 use earl::template::schema::{ParamSpec, ParamType};
 
 fn params() -> Vec<ParamSpec> {

--- a/tests/http_decode_extract_transport.rs
+++ b/tests/http_decode_extract_transport.rs
@@ -13,7 +13,9 @@ fn auto_decode_json_content_type_returns_json_body() {
     let json_bytes = br#"{"ok":true}"#;
     let decoded =
         decode_response(ResultDecode::Auto, Some("application/json"), json_bytes).unwrap();
-    let DecodedBody::Json(value) = decoded else { panic!("expected JSON") };
+    let DecodedBody::Json(value) = decoded else {
+        panic!("expected JSON")
+    };
     assert_eq!(value["ok"], json!(true));
 }
 
@@ -21,7 +23,9 @@ fn auto_decode_json_content_type_returns_json_body() {
 fn auto_decode_text_content_type_returns_text_body() {
     let text_bytes = b"hello";
     let decoded = decode_response(ResultDecode::Auto, Some("text/plain"), text_bytes).unwrap();
-    let DecodedBody::Text(value) = decoded else { panic!("expected text") };
+    let DecodedBody::Text(value) = decoded else {
+        panic!("expected text")
+    };
     assert_eq!(value, "hello");
 }
 
@@ -179,7 +183,10 @@ fn transport_retry_max_attempts_clamped_to_minimum() {
 
 #[test]
 fn transport_retry_on_status_resolved_from_template() {
-    assert_eq!(resolved_override_transport().retry_on_status, vec![429, 500]);
+    assert_eq!(
+        resolved_override_transport().retry_on_status,
+        vec![429, 500]
+    );
 }
 
 #[test]

--- a/tests/search_service.rs
+++ b/tests/search_service.rs
@@ -83,8 +83,8 @@ async fn prefers_remote_results_when_remote_search_succeeds() {
             when.method(POST).path("/rerank");
             then.status(200).json_body_obj(&serde_json::json!({
                 "data": [
-                    {"index": 1, "score": 0.99},
-                    {"index": 0, "score": 0.75}
+                    {"index": 0, "score": 0.99},
+                    {"index": 1, "score": 0.75}
                 ]
             }));
         })

--- a/tests/secrets_vault.rs
+++ b/tests/secrets_vault.rs
@@ -47,7 +47,9 @@ fn missing_vault_credentials_returns_error() {
     let _token = EnvRestore::remove("VAULT_TOKEN");
 
     let resolver = VaultResolver::new();
-    resolver.resolve("vault://secret/myapp#api_key").unwrap_err();
+    resolver
+        .resolve("vault://secret/myapp#api_key")
+        .unwrap_err();
 }
 
 #[test]

--- a/tests/streaming_decode_extract.rs
+++ b/tests/streaming_decode_extract.rs
@@ -26,7 +26,9 @@ fn streaming_json_chunk_is_independently_decodable() {
         &chunk.data,
     )
     .unwrap();
-    let DecodedBody::Json(v) = decoded else { panic!("expected DecodedBody::Json") };
+    let DecodedBody::Json(v) = decoded else {
+        panic!("expected DecodedBody::Json")
+    };
     assert_eq!(v, json!({"msg": "hello"}));
 }
 
@@ -41,7 +43,12 @@ fn streaming_json_pointer_extract_returns_value_at_specified_path() {
         json_pointer: "/data/id".to_string(),
     };
 
-    let decoded = decode_response(ResultDecode::Json, chunk.content_type.as_deref(), &chunk.data).unwrap();
+    let decoded = decode_response(
+        ResultDecode::Json,
+        chunk.content_type.as_deref(),
+        &chunk.data,
+    )
+    .unwrap();
     assert_eq!(extract_result(Some(&extract), &decoded).unwrap(), json!(1));
 }
 
@@ -58,8 +65,16 @@ fn streaming_regex_extract_returns_first_capture_group_from_chunk() {
         regex: r"event_id=([a-z0-9-]+)".to_string(),
     };
 
-    let decoded = decode_response(ResultDecode::Text, chunk.content_type.as_deref(), &chunk.data).unwrap();
-    assert_eq!(extract_result(Some(&extract), &decoded).unwrap(), json!("abc-001"));
+    let decoded = decode_response(
+        ResultDecode::Text,
+        chunk.content_type.as_deref(),
+        &chunk.data,
+    )
+    .unwrap();
+    assert_eq!(
+        extract_result(Some(&extract), &decoded).unwrap(),
+        json!("abc-001")
+    );
 }
 
 // ── Auto decode ──────────────────────────────────────────
@@ -77,7 +92,9 @@ fn streaming_auto_decode_infers_json_from_content_type() {
         &chunk.data,
     )
     .unwrap();
-    let DecodedBody::Json(v) = decoded else { panic!("expected DecodedBody::Json") };
+    let DecodedBody::Json(v) = decoded else {
+        panic!("expected DecodedBody::Json")
+    };
     assert_eq!(v, json!({"ok": true}));
 }
 
@@ -94,7 +111,9 @@ fn streaming_auto_decode_infers_text_from_content_type() {
         &chunk.data,
     )
     .unwrap();
-    let DecodedBody::Text(v) = decoded else { panic!("expected DecodedBody::Text") };
+    let DecodedBody::Text(v) = decoded else {
+        panic!("expected DecodedBody::Text")
+    };
     assert_eq!(v, "plain text line");
 }
 
@@ -111,7 +130,9 @@ fn streaming_auto_decode_falls_back_to_json_for_valid_json_without_content_type(
         &chunk.data,
     )
     .unwrap();
-    let DecodedBody::Json(v) = decoded else { panic!("expected DecodedBody::Json") };
+    let DecodedBody::Json(v) = decoded else {
+        panic!("expected DecodedBody::Json")
+    };
     assert_eq!(v, json!({"key": "value"}));
 }
 
@@ -148,8 +169,16 @@ fn streaming_css_selector_extract_returns_matching_element_text() {
         css_selector: "span.val".to_string(),
     };
 
-    let decoded = decode_response(ResultDecode::Html, chunk.content_type.as_deref(), &chunk.data).unwrap();
-    assert_eq!(extract_result(Some(&extract), &decoded).unwrap(), json!(["100"]));
+    let decoded = decode_response(
+        ResultDecode::Html,
+        chunk.content_type.as_deref(),
+        &chunk.data,
+    )
+    .unwrap();
+    assert_eq!(
+        extract_result(Some(&extract), &decoded).unwrap(),
+        json!(["100"])
+    );
 }
 
 // ── XML / XPath chunks ──────────────────────────────────
@@ -165,8 +194,16 @@ fn streaming_xpath_extract_returns_text_node_values() {
         xpath: "//item/text()".to_string(),
     };
 
-    let decoded = decode_response(ResultDecode::Xml, chunk.content_type.as_deref(), &chunk.data).unwrap();
-    assert_eq!(extract_result(Some(&extract), &decoded).unwrap(), json!(["alpha"]));
+    let decoded = decode_response(
+        ResultDecode::Xml,
+        chunk.content_type.as_deref(),
+        &chunk.data,
+    )
+    .unwrap();
+    assert_eq!(
+        extract_result(Some(&extract), &decoded).unwrap(),
+        json!(["alpha"])
+    );
 }
 
 // ── Binary chunks ────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Format code across multiple source files (config, mcp, secrets, template, tests)
- Fix incorrect rerank mock indices in `search_service` test — `BTreeMap` iterates alphabetically so `github.create_issue` is index 0 and `github.search_issues` is index 1; the mock was mapping them in reverse

## Test Plan
- [x] `cargo test` passes locally