### PR TITLE
feat(browser): default to 'default' session when session_id is omitted

### DIFF
--- a/crates/earl-protocol-browser/src/builder.rs
+++ b/crates/earl-protocol-browser/src/builder.rs
@@ -5,6 +5,8 @@ use serde_json::Value;
 use crate::PreparedBrowserCommand;
 use crate::schema::{BrowserOperationTemplate, BrowserStep};
 
+const DEFAULT_SESSION_ID: &str = "default";
+
 /// Build a `PreparedBrowserCommand` from a `BrowserOperationTemplate` by
 /// rendering all Jinja template strings with the given context.
 pub fn build_browser_request(
@@ -18,12 +20,13 @@ pub fn build_browser_request(
         bail!("operation.browser.steps must not be empty");
     }
 
-    let session_id = tmpl
-        .session_id
-        .as_deref()
-        .map(|s| renderer.render_str(s, context))
-        .transpose()?
-        .filter(|s| !s.is_empty());
+    let session_id = match tmpl.session_id.as_deref() {
+        None => Some(DEFAULT_SESSION_ID.to_string()),
+        Some(s) => {
+            let rendered = renderer.render_str(s, context)?;
+            if rendered.is_empty() { None } else { Some(rendered) }
+        }
+    };
 
     // Render all string fields in each step via the renderer.
     let steps: Vec<BrowserStep> = tmpl
@@ -140,9 +143,10 @@ mod tests {
         .unwrap();
         let ctx = serde_json::json!({});
         let cmd = build_browser_request(&op, &ctx, &PassthroughRenderer).unwrap();
-        assert_eq!(cmd.session_id.as_deref(), Some("default"));
+        assert_eq!(cmd.session_id.as_deref(), Some(super::DEFAULT_SESSION_ID));
     }
 
+    // Setting session_id = "" is the explicit opt-out from the default session.
     #[test]
     fn explicit_empty_session_id_is_ephemeral() {
         let op: crate::schema::BrowserOperationTemplate = serde_json::from_str(

--- a/crates/earl-protocol-browser/src/builder.rs
+++ b/crates/earl-protocol-browser/src/builder.rs
@@ -24,7 +24,11 @@ pub fn build_browser_request(
         None => Some(DEFAULT_SESSION_ID.to_string()),
         Some(s) => {
             let rendered = renderer.render_str(s, context)?;
-            if rendered.is_empty() { None } else { Some(rendered) }
+            if rendered.is_empty() {
+                None
+            } else {
+                Some(rendered)
+            }
         }
     };
 

--- a/crates/earl-protocol-browser/src/builder.rs
+++ b/crates/earl-protocol-browser/src/builder.rs
@@ -129,6 +129,37 @@ mod tests {
     }
 
     #[test]
+    fn absent_session_id_defaults_to_default() {
+        let op: crate::schema::BrowserOperationTemplate = serde_json::from_str(
+            r#"{
+                "browser": {
+                    "steps": [{"action":"snapshot"}]
+                }
+            }"#,
+        )
+        .unwrap();
+        let ctx = serde_json::json!({});
+        let cmd = build_browser_request(&op, &ctx, &PassthroughRenderer).unwrap();
+        assert_eq!(cmd.session_id.as_deref(), Some("default"));
+    }
+
+    #[test]
+    fn explicit_empty_session_id_is_ephemeral() {
+        let op: crate::schema::BrowserOperationTemplate = serde_json::from_str(
+            r#"{
+                "browser": {
+                    "session_id": "",
+                    "steps": [{"action":"snapshot"}]
+                }
+            }"#,
+        )
+        .unwrap();
+        let ctx = serde_json::json!({});
+        let cmd = build_browser_request(&op, &ctx, &PassthroughRenderer).unwrap();
+        assert!(cmd.session_id.is_none());
+    }
+
+    #[test]
     fn build_preserves_headless_and_timeout() {
         let op: crate::schema::BrowserOperationTemplate = serde_json::from_str(
             r#"{


### PR DESCRIPTION
## Summary

- When `session_id` is absent from a browser operation, use a persistent session named `\"default\"` instead of launching an ephemeral browser
- When `session_id = \"\"` (explicit empty string), preserve the existing ephemeral behavior
- Change is entirely in the builder layer (`crates/earl-protocol-browser/src/builder.rs`) — no executor, session, or schema changes

## Test Plan

- [x] `absent_session_id_defaults_to_default` — absent `session_id` resolves to `Some(\"default\")`
- [x] `explicit_empty_session_id_is_ephemeral` — `session_id = \"\"` resolves to `None` (ephemeral)
- [x] All 70 lib tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)