### PR TITLE
fix: satisfy current clippy lint

### DIFF
--- a/src/template/validator.rs
+++ b/src/template/validator.rs
@@ -373,10 +373,8 @@ fn validate_body(command_name: &str, body: &BodyTemplate) -> Result<()> {
                 validate_part(command_name, part)?;
             }
         }
-        BodyTemplate::FileStream { path, .. } => {
-            if path.trim().is_empty() {
-                bail!("command {command_name} file_stream body path must not be empty");
-            }
+        BodyTemplate::FileStream { path, .. } if path.trim().is_empty() => {
+            bail!("command {command_name} file_stream body path must not be empty");
         }
         _ => {}
     }


### PR DESCRIPTION
## Summary

- collapse file-stream validation into the outer match guard
- preserve validation behavior while satisfying Clippy

## Checks

- cargo fmt --all -- --check
- cargo clippy --lib --all-features -- -D warnings
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --test template_validation --all-features