### PR TITLE
fix(release): normalize crate dependency metadata

### DIFF
--- a/crates/earl-protocol-browser/Cargo.toml
+++ b/crates/earl-protocol-browser/Cargo.toml
@@ -29,18 +29,7 @@ tracing = "0.1"
 which = "8.0"
 
 [dev-dependencies]
-tokio = {
-  version = "1",
-  features = [
-    "io-util",
-    "macros",
-    "net",
-    "rt-multi-thread",
-    "sync",
-    "test-util",
-    "time",
-  ]
-}
+tokio = { version = "1", features = ["io-util", "macros", "net", "rt-multi-thread", "sync", "test-util", "time"] }
 
 [target."cfg(unix)".dependencies]
 libc = "0.2"

--- a/crates/earl-protocol-http/Cargo.toml
+++ b/crates/earl-protocol-http/Cargo.toml
@@ -14,20 +14,7 @@ categories = ["network-programming", "web-programming"]
 anyhow = "1.0"
 base64 = "0.23"
 earl-core = { path = "../earl-core", version = "0.5.1" }
-reqwest = {
-  version = "0.13.4",
-  features = [
-    "brotli",
-    "deflate",
-    "form",
-    "gzip",
-    "json",
-    "multipart",
-    "query",
-    "rustls",
-    "zstd",
-  ]
-}
+reqwest = { version = "0.13.4", features = ["brotli", "deflate", "form", "gzip", "json", "multipart", "query", "rustls", "zstd"] }
 rkyv = { version = "0.8", features = ["bytecheck", "std"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/earl-protocol-sql/Cargo.toml
+++ b/crates/earl-protocol-sql/Cargo.toml
@@ -16,15 +16,5 @@ earl-core = { path = "../earl-core", version = "0.5.1" }
 rkyv = { version = "0.8", features = ["bytecheck", "std"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-sqlx = {
-  version = "0.9",
-  features = [
-    "any",
-    "mysql",
-    "postgres",
-    "runtime-tokio",
-    "sqlite",
-    "tls-rustls",
-  ]
-}
+sqlx = { version = "0.9", features = ["any", "mysql", "postgres", "runtime-tokio", "sqlite", "tls-rustls"] }
 tokio = { version = "1", features = ["time"] }


### PR DESCRIPTION
## Summary

- keep the remaining crate dependency metadata in single-line TOML inline tables so Release Please can parse every workspace manifest
- preserve dependency versions, features, and Cargo.lock unchanged

## Verification

- no multiline inline tables remain in any `Cargo.toml`
- `mise exec -- tombi format --check Cargo.toml crates/*/Cargo.toml`
- `mise exec -- hk check --all --slow`
- `git diff --check`
- `git diff --exit-code -- Cargo.lock`
