### PR TITLE
docs: fix README example link

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Secrets stay in the OS keychain. They aren't in tool arguments, tool description
 curl -fsSL https://raw.githubusercontent.com/mathematic-inc/earl/main/scripts/install.sh | bash
 
 # Import a provider template
-earl templates import https://raw.githubusercontent.com/mathematic-inc/earl/main/examples/github.hcl
+earl templates import https://raw.githubusercontent.com/mathematic-inc/earl/main/examples/3p/github.hcl
 
 # Store a secret — prompts for the value, not echoed
 earl secrets set github.token


### PR DESCRIPTION
## Summary

- point the README quick-start import at the existing GitHub provider template

## Validation

- `mise exec -- hk check --all --slow` (58/58)
- `mise exec -- lychee --no-progress README.md` (36/36 links)
- corrected raw template URL returns HTTP 200