### PR TITLE
chore(web): remove legacy Biome directives

### DIFF
--- a/web/src/components/ui/button-group.tsx
+++ b/web/src/components/ui/button-group.tsx
@@ -28,7 +28,6 @@ function ButtonGroup({
   ...props
 }: React.ComponentProps<"div"> & VariantProps<typeof buttonGroupVariants>) {
   return (
-    // biome-ignore lint/a11y/useSemanticElements: button group uses role="group" for accessibility
     <div
       className={cn(buttonGroupVariants({ orientation }), className)}
       data-orientation={orientation}

--- a/web/src/components/ui/calendar.tsx
+++ b/web/src/components/ui/calendar.tsx
@@ -107,11 +107,9 @@ function Calendar({
         ...classNames,
       }}
       components={{
-        // biome-ignore lint/correctness/noNestedComponentDefinitions: component override for react-day-picker
         Root: ({ className, rootRef, ...props }) => {
           return <div className={cn(className)} data-slot="calendar" ref={rootRef} {...props} />;
         },
-        // biome-ignore lint/correctness/noNestedComponentDefinitions: component override for react-day-picker
         Chevron: ({ className, orientation, ...props }) => {
           if (orientation === "left") {
             return (
@@ -127,9 +125,7 @@ function Calendar({
 
           return <ChevronDownIcon className={cn("size-4", className)} {...props} />;
         },
-        // biome-ignore lint/correctness/noNestedComponentDefinitions: component override for react-day-picker, needs locale from closure
         DayButton: ({ ...props }) => <CalendarDayButton locale={locale} {...props} />,
-        // biome-ignore lint/correctness/noNestedComponentDefinitions: component override for react-day-picker
         WeekNumber: ({ children, ...props }) => {
           return (
             <td {...props}>

--- a/web/src/components/ui/carousel.tsx
+++ b/web/src/components/ui/carousel.tsx
@@ -129,7 +129,6 @@ function Carousel({
         canScrollNext,
       }}
     >
-      {/* biome-ignore lint/a11y/useAriaPropsSupportedByRole: aria-roledescription="carousel" is standard WAI-ARIA carousel pattern */}
       <section
         aria-roledescription="carousel"
         className={cn("relative", className)}
@@ -160,7 +159,6 @@ function CarouselItem({ className, ...props }: ComponentProps<"div">) {
   const { orientation } = useCarousel();
 
   return (
-    // biome-ignore lint/a11y/useSemanticElements: WAI-ARIA carousel pattern requires role="group" with aria-roledescription="slide"
     <div
       aria-roledescription="slide"
       className={cn(

--- a/web/src/components/ui/direction.tsx
+++ b/web/src/components/ui/direction.tsx
@@ -1,4 +1,3 @@
 "use client";
 
-// biome-ignore lint/performance/noBarrelFile: re-exports from @base-ui for consistent import paths
 export { DirectionProvider, useDirection } from "@base-ui/react/direction-provider";

--- a/web/src/components/ui/field.tsx
+++ b/web/src/components/ui/field.tsx
@@ -72,7 +72,6 @@ function Field({
   ...props
 }: React.ComponentProps<"div"> & VariantProps<typeof fieldVariants>) {
   return (
-    // biome-ignore lint/a11y/useSemanticElements: field grouping requires role="group" for accessibility
     <div
       className={cn(fieldVariants({ orientation }), className)}
       data-orientation={orientation}

--- a/web/src/components/ui/input-group.tsx
+++ b/web/src/components/ui/input-group.tsx
@@ -10,7 +10,6 @@ import { cn } from "@/lib/utils";
 
 function InputGroup({ className, ...props }: ComponentProps<"div">) {
   return (
-    // biome-ignore lint/a11y/useSemanticElements: input group uses role="group" for accessibility
     <div
       className={cn(
         "group/input-group relative flex h-7 w-full min-w-0 items-center rounded-md border border-input bg-input/20 outline-none transition-colors in-data-[slot=combobox-content]:focus-within:border-inherit in-data-[slot=combobox-content]:focus-within:ring-0 has-[>[data-align=block-end]]:h-auto has-[>[data-align=block-start]]:h-auto has-[>textarea]:h-auto has-[>[data-align=block-end]]:flex-col has-[>[data-align=block-start]]:flex-col has-[textarea]:rounded-md has-data-[align=block-end]:rounded-md has-data-[align=block-start]:rounded-md has-[[data-slot=input-group-control]:focus-visible]:border-ring has-[[data-slot][aria-invalid=true]]:border-destructive has-[[data-slot=input-group-control]:focus-visible]:ring-2 has-[[data-slot=input-group-control]:focus-visible]:ring-ring/30 has-[[data-slot][aria-invalid=true]]:ring-2 has-[[data-slot][aria-invalid=true]]:ring-destructive/20 dark:bg-input/30 dark:has-[[data-slot][aria-invalid=true]]:ring-destructive/40 has-[>[data-align=inline-start]]:[&>input]:ps-1.5 has-[>[data-align=inline-end]]:[&>input]:pe-1.5 has-[>[data-align=block-end]]:[&>input]:pt-3 has-[>[data-align=block-start]]:[&>input]:pb-3",
@@ -48,9 +47,6 @@ function InputGroupAddon({
   ...props
 }: ComponentProps<"div"> & VariantProps<typeof inputGroupAddonVariants>) {
   return (
-    // biome-ignore lint/a11y/useSemanticElements: addon uses role="group" for input grouping
-    // biome-ignore lint/a11y/useKeyWithClickEvents: click handler is convenience focus behavior, keyboard users can tab to input
-    // biome-ignore lint/a11y/noNoninteractiveElementInteractions: click handler forwards focus to input
     <div
       className={cn(inputGroupAddonVariants({ align }), className)}
       data-align={align}

--- a/web/src/components/ui/item.tsx
+++ b/web/src/components/ui/item.tsx
@@ -8,7 +8,6 @@ import { cn } from "@/lib/utils";
 
 function ItemGroup({ className, ...props }: ComponentProps<"div">) {
   return (
-    // biome-ignore lint/a11y/useSemanticElements: ItemGroup uses role="list" because children are not <li> elements
     <div
       className={cn(
         "group/item-group flex w-full flex-col gap-4 has-data-[size=sm]:gap-2.5 has-data-[size=xs]:gap-2",

--- a/web/src/components/ui/label.tsx
+++ b/web/src/components/ui/label.tsx
@@ -6,7 +6,6 @@ import { cn } from "@/lib/utils";
 
 function Label({ className, ...props }: ComponentProps<"label">) {
   return (
-    // biome-ignore lint/a11y/noLabelWithoutControl: generic Label component receives htmlFor via props
     <label
       className={cn(
         "flex select-none items-center gap-2 font-medium text-xs/relaxed leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-50 group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50",

--- a/web/src/components/ui/resizable.tsx
+++ b/web/src/components/ui/resizable.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-// biome-ignore lint/performance/noNamespaceImport: react-resizable-panels uses namespace export pattern
 import * as ResizablePrimitive from "react-resizable-panels";
 
 import { cn } from "@/lib/utils";

--- a/web/src/components/ui/sidebar.tsx
+++ b/web/src/components/ui/sidebar.tsx
@@ -87,7 +87,6 @@ function SidebarProvider({
         _setOpen(openState);
       }
 
-      // biome-ignore lint/suspicious/noDocumentCookie: Cookie Store API not widely supported; simple cookie for sidebar state
       document.cookie = `${SIDEBAR_COOKIE_NAME}=${openState}; path=/; max-age=${SIDEBAR_COOKIE_MAX_AGE}`;
     },
     [setOpenProp, open],

--- a/web/src/components/ui/slider.tsx
+++ b/web/src/components/ui/slider.tsx
@@ -48,7 +48,6 @@ function Slider({
           <SliderPrimitive.Thumb
             className="block size-4 shrink-0 select-none rounded-md border border-primary bg-white shadow-sm ring-ring/30 transition-colors hover:ring-4 focus-visible:outline-hidden focus-visible:ring-4 disabled:pointer-events-none disabled:opacity-50"
             data-slot="slider-thumb"
-            // biome-ignore lint/suspicious/noArrayIndexKey: slider thumbs are identified by index position
             key={`thumb-${index}`}
           />
         ))}


### PR DESCRIPTION
Removes 18 obsolete biome-ignore directives from 11 owned UI component files now that Biome is no longer part of the repository toolchain.

Generated and vendor suppressions are unchanged.

Validation:

- mise exec -- hk check --all --slow
- mise exec -- pnpm turbo run build
- mise exec -- pnpm turbo run types:check
- zero biome-ignore directives remain under web/src/components/ui