### PR TITLE
chore(hk): exclude changelogs

### DIFF
--- a/hk.pkl
+++ b/hk.pkl
@@ -4,6 +4,7 @@ import "package://github.com/jdx/hk/releases/download/v1.56.1/hk@1.56.1#/Builtin
 
 min_hk_version = "1.56.1"
 hide_warnings = List("missing-profiles")
+exclude = List("**/CHANGELOG.md")
 
 local generatedFiles =
   List(


### PR DESCRIPTION
Adds the native global hk configuration exclusion for all CHANGELOG.md files so every hk hook and profile ignores generated release-history documents without per-hook duplication.

Validation:

- pkl format and evaluation pass
- hk check --why rumdl CHANGELOG.md reports skipped with zero matched files and filter_no_match
- mise exec -- hk check --all --slow passes
- exhaustive file selection drops all seven repository changelogs