### PR TITLE
fix(release): coordinate workspace publication

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,28 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
 
+permissions:
+  contents: read
+
 jobs:
+  msrv:
+    name: MSRV (Rust 1.96)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Install system dependencies
+        run: sudo apt-get update -y && sudo apt-get install -y libdbus-1-dev
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+        with:
+          toolchain: "1.96.0"
+      - name: Check MSRV
+        run: cargo check --locked --workspace --all-features --all-targets
+
   test:
     name: Test
     runs-on: ubuntu-latest
@@ -24,6 +45,8 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+      - name: Check release state
+        run: python3 scripts/release/check-state.py
       - name: Install system dependencies
         run: sudo apt-get update -y && sudo apt-get install -y libdbus-1-dev bubblewrap
       - name: Allow bwrap unprivileged user namespaces

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,11 @@ jobs:
       - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
           toolchain: "1.96.0"
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: .node-version
+          cache: pnpm
       - name: Check MSRV
         run: cargo check --locked --workspace --all-features --all-targets
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,6 +8,9 @@ concurrency:
   group: "pages"
   cancel-in-progress: false
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -35,7 +38,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: "22"
+          node-version-file: .node-version
           cache: "pnpm"
           cache-dependency-path: pnpm-lock.yaml
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -10,14 +10,22 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   release-please:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Check release state
+        run: python3 scripts/release/check-state.py
       - name: Run Release Please
         uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,6 @@ on:
   push:
     tags:
       - "v*"
-      - "*-v*"
 
 concurrency:
   group: release-${{ github.ref }}
@@ -12,6 +11,9 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
+
+permissions:
+  contents: read
 
 jobs:
   meta:
@@ -24,9 +26,6 @@ jobs:
       version: ${{ steps.meta.outputs.version }}
       tag: ${{ steps.meta.outputs.tag }}
       is_prerelease: ${{ steps.meta.outputs.is_prerelease }}
-      is_root: ${{ steps.meta.outputs.is_root }}
-      crate_name: ${{ steps.meta.outputs.crate_name }}
-      crate_path: ${{ steps.meta.outputs.crate_path }}
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -39,25 +38,10 @@ jobs:
           set -euo pipefail
 
           TAG="${GITHUB_REF_NAME}"
-          if [[ "$TAG" =~ ^v[0-9] ]]; then
-            IS_ROOT=true
-            CRATE_NAME="earl"
-            CRATE_PATH="."
-            VERSION="${TAG#v}"
-            CARGO_VERSION="$(awk -F'"' '/^\[package\]/{p=1} p && /^version = /{print $2; exit}' Cargo.toml)"
-          else
-            IS_ROOT=false
-            CRATE_NAME="${TAG%-v*}"
-            CRATE_PATH="crates/$CRATE_NAME"
-            VERSION="${TAG#*-v}"
-            if [[ ! -f "$CRATE_PATH/Cargo.toml" ]]; then
-              echo "crate path $CRATE_PATH does not exist for tag $TAG" >&2
-              exit 1
-            fi
-            CARGO_VERSION="$(awk -F'"' '/^\[package\]/{p=1} p && /^version = /{print $2; exit}' "$CRATE_PATH/Cargo.toml")"
-          fi
+          VERSION="${TAG#v}"
+          CARGO_VERSION="$(awk -F'"' '/^\[package\]/{p=1} p && /^version = /{print $2; exit}' Cargo.toml)"
 
-          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
             echo "tag $TAG does not match supported format vX.Y.Z or vX.Y.Z-rc.N" >&2
             exit 1
           fi
@@ -75,9 +59,6 @@ jobs:
           {
             echo "tag=$TAG"
             echo "version=$VERSION"
-            echo "is_root=$IS_ROOT"
-            echo "crate_name=$CRATE_NAME"
-            echo "crate_path=$CRATE_PATH"
             echo "is_prerelease=$IS_PRERELEASE"
           } >> "$GITHUB_OUTPUT"
 
@@ -98,18 +79,11 @@ jobs:
         uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
 
       - name: Build and test
-        shell: bash
-        run: |
-          if [[ "${{ needs.meta.outputs.is_root }}" == "true" ]]; then
-            cargo test --locked
-          else
-            cargo test --locked -p "${{ needs.meta.outputs.crate_name }}"
-          fi
+        run: cargo test --locked
 
   build-artifacts:
     name: Build ${{ matrix.target }}
     needs: meta
-    if: needs.meta.outputs.is_root == 'true'
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     permissions:
@@ -145,7 +119,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: "22"
+          node-version-file: .node-version
           package-manager-cache: false
 
       - name: Install Rust toolchain
@@ -191,7 +165,6 @@ jobs:
     needs:
       - meta
       - build-artifacts
-    if: needs.meta.outputs.is_root == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -225,11 +198,6 @@ jobs:
       - meta
       - build-and-test
       - release-assets
-    if: |
-      always() &&
-      needs.meta.result == 'success' &&
-      needs.build-and-test.result == 'success' &&
-      (needs.release-assets.result == 'success' || needs.release-assets.result == 'skipped')
     runs-on: ubuntu-latest
     timeout-minutes: 10
     environment: release
@@ -242,7 +210,6 @@ jobs:
           persist-credentials: false
 
       - name: Download release assets
-        if: needs.meta.outputs.is_root == 'true'
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: release-assets
@@ -255,9 +222,9 @@ jobs:
           name: ${{ needs.meta.outputs.tag }}
           generate_release_notes: true
           prerelease: ${{ needs.meta.outputs.is_prerelease == 'true' }}
-          files: ${{ needs.meta.outputs.is_root == 'true' && 'dist/*' || '' }}
-          fail_on_unmatched_files: ${{ needs.meta.outputs.is_root == 'true' }}
-          make_latest: ${{ needs.meta.outputs.is_root == 'true' && needs.meta.outputs.is_prerelease == 'false' }}
+          files: dist/*
+          fail_on_unmatched_files: true
+          make_latest: ${{ needs.meta.outputs.is_prerelease == 'false' }}
 
       - name: Trigger release notes workflow
         env:
@@ -271,7 +238,6 @@ jobs:
     needs:
       - meta
       - create-release
-    if: needs.create-release.result == 'success' && needs.meta.outputs.is_root == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -295,7 +261,6 @@ jobs:
     needs:
       - meta
       - create-release
-    if: always() && needs.meta.result == 'success' && needs.create-release.result == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 60
     environment: release
@@ -316,7 +281,6 @@ jobs:
         id: crates-io-auth
 
       - name: Publish workspace crates
-        if: needs.meta.outputs.is_root == 'true'
         shell: bash
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.crates-io-auth.outputs.token }}
@@ -353,9 +317,48 @@ jobs:
             fi
           done
 
-      - name: Publish crate
-        if: needs.meta.outputs.is_root != 'true'
-        shell: bash
+
+  component-releases:
+    name: Publish Component Releases
+    needs:
+      - meta
+      - publish-crate
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment: release
+    permissions:
+      contents: write
+    steps:
+      - name: Create component releases
         env:
-          CARGO_REGISTRY_TOKEN: ${{ steps.crates-io-auth.outputs.token }}
-        run: cargo publish --locked -p "${{ needs.meta.outputs.crate_name }}"
+          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ needs.meta.outputs.version }}
+        run: |
+          set -euo pipefail
+
+          CRATES=(
+            earl-core
+            earl-protocol-http
+            earl-protocol-grpc
+            earl-protocol-bash
+            earl-protocol-sql
+            earl-protocol-browser
+          )
+
+          for crate in "${CRATES[@]}"; do
+            tag="$crate-v$VERSION"
+            if ! gh release view "$tag" >/dev/null 2>&1; then
+              gh release create "$tag" \
+                --generate-notes \
+                --latest=false \
+                --target "$GITHUB_SHA" \
+                --title "$tag"
+            fi
+
+            actual="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$tag" --jq .object.sha)"
+            if [[ "$actual" != "$GITHUB_SHA" ]]; then
+              echo "$tag points to $actual instead of $GITHUB_SHA" >&2
+              exit 1
+            fi
+          done

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
 /target
 
+# Python
+__pycache__/
+*.py[cod]
+
 # IDE
 .vscode/
 

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,9 +1,3 @@
 {
-  ".": "0.5.2",
-  "crates/earl-core": "0.5.1",
-  "crates/earl-protocol-http": "0.5.1",
-  "crates/earl-protocol-grpc": "0.5.1",
-  "crates/earl-protocol-bash": "0.5.1",
-  "crates/earl-protocol-sql": "0.5.1",
-  "crates/earl-protocol-browser": "0.5.1"
+  ".": "0.5.2"
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1960,7 +1960,7 @@ dependencies = [
 
 [[package]]
 name = "earl-core"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "anyhow",
  "base64 0.23.1",
@@ -1974,7 +1974,7 @@ dependencies = [
 
 [[package]]
 name = "earl-protocol-bash"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "anyhow",
  "earl-core",
@@ -1987,7 +1987,7 @@ dependencies = [
 
 [[package]]
 name = "earl-protocol-browser"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "anyhow",
  "base64 0.23.1",
@@ -2010,7 +2010,7 @@ dependencies = [
 
 [[package]]
 name = "earl-protocol-grpc"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "anyhow",
  "earl-core",
@@ -2033,7 +2033,7 @@ dependencies = [
 
 [[package]]
 name = "earl-protocol-http"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "anyhow",
  "base64 0.23.1",
@@ -2048,7 +2048,7 @@ dependencies = [
 
 [[package]]
 name = "earl-protocol-sql"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "anyhow",
  "earl-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "earl"
 version = "0.5.2"
 edition.workspace = true
+rust-version.workspace = true
 description = "AI-safe CLI for AI agents"
 documentation.workspace = true
 readme = "README.md"
@@ -14,10 +15,19 @@ build = "build.rs"
 
 [workspace]
 resolver = "3"
-members = [".", "crates/*"]
+members = [
+  ".",
+  "crates/earl-core",
+  "crates/earl-protocol-bash",
+  "crates/earl-protocol-browser",
+  "crates/earl-protocol-grpc",
+  "crates/earl-protocol-http",
+  "crates/earl-protocol-sql",
+]
 
 [workspace.package]
 edition = "2024"
+rust-version = "1.96"
 documentation = "https://mathematic-inc.github.io/earl"
 homepage = "https://github.com/mathematic-inc/earl"
 repository = "https://github.com/mathematic-inc/earl"
@@ -34,12 +44,12 @@ clap = { version = "4.6", features = ["derive"] }
 clap_complete = "4.6"
 comfy-table = "8.0"
 directories = "6.0"
-earl-core = { path = "crates/earl-core", version = "0.5.1" }
-earl-protocol-bash = { path = "crates/earl-protocol-bash", version = "0.5.1", optional = true }
-earl-protocol-browser = { path = "crates/earl-protocol-browser", version = "0.5.1", optional = true }
-earl-protocol-grpc = { path = "crates/earl-protocol-grpc", version = "0.5.1", optional = true }
-earl-protocol-http = { path = "crates/earl-protocol-http", version = "0.5.1", optional = true }
-earl-protocol-sql = { path = "crates/earl-protocol-sql", version = "0.5.1", optional = true }
+earl-core = { path = "crates/earl-core", version = "0.5.2" }
+earl-protocol-bash = { path = "crates/earl-protocol-bash", version = "0.5.2", optional = true }
+earl-protocol-browser = { path = "crates/earl-protocol-browser", version = "0.5.2", optional = true }
+earl-protocol-grpc = { path = "crates/earl-protocol-grpc", version = "0.5.2", optional = true }
+earl-protocol-http = { path = "crates/earl-protocol-http", version = "0.5.2", optional = true }
+earl-protocol-sql = { path = "crates/earl-protocol-sql", version = "0.5.2", optional = true }
 fastembed = { version = "6.0", optional = true }
 hcl = { package = "hcl-rs", version = "0.19.8" }
 hickory-resolver = "0.26"

--- a/crates/earl-core/Cargo.toml
+++ b/crates/earl-core/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "earl-core"
-version = "0.5.1"
+version = "0.5.2"
 edition.workspace = true
+rust-version.workspace = true
 description = "Shared types and traits for earl protocol crates"
 documentation.workspace = true
 homepage.workspace = true

--- a/crates/earl-protocol-bash/Cargo.toml
+++ b/crates/earl-protocol-bash/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "earl-protocol-bash"
-version = "0.5.1"
+version = "0.5.2"
 edition.workspace = true
+rust-version.workspace = true
 description = "Bash sandboxed execution protocol for earl"
 documentation.workspace = true
 homepage.workspace = true
@@ -12,7 +13,7 @@ categories = ["command-line-utilities"]
 
 [dependencies]
 anyhow = "1.0"
-earl-core = { path = "../earl-core", version = "0.5.1" }
+earl-core = { path = "../earl-core", version = "0.5.2" }
 libc = "0.2"
 rkyv = { version = "0.8", features = ["bytecheck", "std"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/earl-protocol-browser/Cargo.toml
+++ b/crates/earl-protocol-browser/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "earl-protocol-browser"
-version = "0.5.1"
+version = "0.5.2"
 edition.workspace = true
+rust-version.workspace = true
 description = "Browser automation protocol for earl (chromiumoxide)"
 documentation.workspace = true
 homepage.workspace = true
@@ -16,7 +17,7 @@ base64 = "0.23"
 chromiumoxide = { version = "0.9", default-features = false, features = ["bytes"] }
 chrono = { version = "0.4", features = ["serde"] }
 directories = "6.0"
-earl-core = { path = "../earl-core", version = "0.5.1" }
+earl-core = { path = "../earl-core", version = "0.5.2" }
 fs4 = { version = "1.1", features = ["tokio"] }
 futures = "0.3"
 rkyv = { version = "0.8", features = ["bytecheck", "std"] }

--- a/crates/earl-protocol-grpc/Cargo.toml
+++ b/crates/earl-protocol-grpc/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "earl-protocol-grpc"
-version = "0.5.1"
+version = "0.5.2"
 edition.workspace = true
+rust-version.workspace = true
 description = "gRPC execution protocol for earl"
 documentation.workspace = true
 homepage.workspace = true
@@ -12,7 +13,7 @@ categories = ["network-programming"]
 
 [dependencies]
 anyhow = "1.0"
-earl-core = { path = "../earl-core", version = "0.5.1" }
+earl-core = { path = "../earl-core", version = "0.5.2" }
 futures-util = "0.3"
 http = "1"
 http-body = "1"

--- a/crates/earl-protocol-http/Cargo.toml
+++ b/crates/earl-protocol-http/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "earl-protocol-http"
-version = "0.5.1"
+version = "0.5.2"
 edition.workspace = true
+rust-version.workspace = true
 description = "HTTP and GraphQL execution protocol for earl"
 documentation.workspace = true
 homepage.workspace = true
@@ -13,7 +14,7 @@ categories = ["network-programming", "web-programming"]
 [dependencies]
 anyhow = "1.0"
 base64 = "0.23"
-earl-core = { path = "../earl-core", version = "0.5.1" }
+earl-core = { path = "../earl-core", version = "0.5.2" }
 reqwest = { version = "0.13.4", features = ["brotli", "deflate", "form", "gzip", "json", "multipart", "query", "rustls", "zstd"] }
 rkyv = { version = "0.8", features = ["bytecheck", "std"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/earl-protocol-sql/Cargo.toml
+++ b/crates/earl-protocol-sql/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "earl-protocol-sql"
-version = "0.5.1"
+version = "0.5.2"
 edition.workspace = true
+rust-version.workspace = true
 description = "SQL execution protocol for earl (sqlx)"
 documentation.workspace = true
 homepage.workspace = true
@@ -12,7 +13,7 @@ categories = ["database"]
 
 [dependencies]
 anyhow = "1.0"
-earl-core = { path = "../earl-core", version = "0.5.1" }
+earl-core = { path = "../earl-core", version = "0.5.2" }
 rkyv = { version = "0.8", features = ["bytecheck", "std"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/mise.toml
+++ b/mise.toml
@@ -26,6 +26,7 @@ rust = { version = "1.98.0", profile = "minimal", components = [
 shellcheck = "0.11.0"
 shfmt = "3.13.1"
 tombi = "1.4.1"
+ty = "0.0.74"
 typos = "1.49.0"
 uv = "0.12.6"
 zizmor = "1.29.0"

--- a/mise.toml
+++ b/mise.toml
@@ -18,6 +18,7 @@ oxlint = { version = "1.80.0", depends = ["node"] }
 pinact = "4.1.1"
 pnpm = { version = "11.24.0", depends = ["node"] }
 python = "3.14.7"
+ruff = { version = "0.16.4", depends = ["python", "uv"] }
 rumdl = "0.2.61"
 rust = { version = "1.98.0", profile = "minimal", components = [
   "clippy",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -8,24 +8,6 @@
       "release-type": "rust",
       "changelog-path": "CHANGELOG.md",
       "include-component-in-tag": false
-    },
-    "crates/earl-core": {
-      "release-type": "rust"
-    },
-    "crates/earl-protocol-http": {
-      "release-type": "rust"
-    },
-    "crates/earl-protocol-grpc": {
-      "release-type": "rust"
-    },
-    "crates/earl-protocol-bash": {
-      "release-type": "rust"
-    },
-    "crates/earl-protocol-sql": {
-      "release-type": "rust"
-    },
-    "crates/earl-protocol-browser": {
-      "release-type": "rust"
     }
   },
   "plugins": ["sentence-case"]

--- a/scripts/release/check-state.py
+++ b/scripts/release/check-state.py
@@ -1,0 +1,59 @@
+import json
+from pathlib import Path
+
+import tomllib
+
+
+def load_toml(path: Path) -> dict:
+    return tomllib.loads(path.read_text())
+
+
+root_path = Path("Cargo.toml")
+root = load_toml(root_path)
+members = root["workspace"]["members"]
+
+if "." not in members or any("*" in member for member in members):
+    raise SystemExit("workspace members must be explicit and include the root package")
+
+manifests = {
+    member: root_path if member == "." else Path(member, "Cargo.toml")
+    for member in members
+}
+packages = {member: load_toml(path)["package"] for member, path in manifests.items()}
+versions = {package["version"] for package in packages.values()}
+msrv = root["workspace"]["package"]["rust-version"]
+
+if len(versions) != 1:
+    details = ", ".join(
+        f"{package['name']}={package['version']}" for package in packages.values()
+    )
+    raise SystemExit(f"workspace package versions must match: {details}")
+if any(
+    package.get("rust-version") != {"workspace": True} for package in packages.values()
+):
+    raise SystemExit(f"every workspace package must inherit Rust {msrv}")
+
+version = versions.pop()
+manifest = json.loads(Path(".release-please-manifest.json").read_text())
+config = json.loads(Path("release-please-config.json").read_text())
+
+if manifest != {".": version}:
+    raise SystemExit("release manifest must track the uniform root package version")
+if set(config["packages"]) != {"."}:
+    raise SystemExit(
+        "Release Please must use the root package as the only release unit"
+    )
+
+for member, path in manifests.items():
+    dependencies = load_toml(path).get("dependencies", {})
+    for dependency, specification in dependencies.items():
+        if not isinstance(specification, dict) or "path" not in specification:
+            continue
+        dependency_path = (path.parent / specification["path"] / "Cargo.toml").resolve()
+        dependency_version = load_toml(dependency_path)["package"]["version"]
+        if specification.get("version") != dependency_version:
+            raise SystemExit(
+                f"{member}: {dependency} must require workspace version {dependency_version}"
+            )
+
+print(f"release state is coordinated at {version}")


### PR DESCRIPTION
Coordinate the seven Rust packages as one release unit so Release Please can no longer report a green partial release.

- enforce uniform workspace versions, path requirements, and Rust 1.96 inheritance
- publish all crates from the root tag in dependency order, then create component releases at the same SHA
- add an exact Rust 1.96.0 CI check and a release-state invariant check
- use the contributor Node version file in docs and release builds

Validated with:
- `mise exec -- hk check --all --slow`
- `mise x rust@1.96.0 -- cargo check --locked --workspace --all-features --all-targets`