### PR TITLE
fix(release): make artifact builds portable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,8 @@ jobs:
           echo '  userns,' | sudo tee -a /etc/apparmor.d/bwrap
           echo '}' | sudo tee -a /etc/apparmor.d/bwrap
           sudo apparmor_parser -r /etc/apparmor.d/bwrap
+      - name: Test release scripts
+        run: scripts/release/test-build-artifact.sh
       - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
           toolchain: stable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,6 +75,15 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+
+      - name: Setup Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: .node-version
+          package-manager-cache: false
+
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
 

--- a/scripts/release/build-artifact.sh
+++ b/scripts/release/build-artifact.sh
@@ -38,19 +38,19 @@ fi
 
 rustup target add "$TARGET"
 
-FEATURE_FLAGS=()
+CARGO_ARGS=(--locked --release --target "$TARGET")
 if [[ "$TARGET" == *"windows"* ]]; then
-	FEATURE_FLAGS=(--no-default-features --features "http,graphql,grpc,sql")
+	CARGO_ARGS+=(--no-default-features --features "http,graphql,grpc,sql")
 elif [[ "$TARGET" == *"musl"* || "$TARGET" == "aarch64-unknown-linux-gnu" ]]; then
-	FEATURE_FLAGS=(--no-default-features --features "http,graphql,grpc,bash,sql")
+	CARGO_ARGS+=(--no-default-features --features "http,graphql,grpc,bash,sql")
 fi
 
 case "$BUILD_TOOL" in
 cargo)
-	cargo build --locked --release --target "$TARGET" "${FEATURE_FLAGS[@]}"
+	cargo build "${CARGO_ARGS[@]}"
 	;;
 xwin)
-	cargo xwin build --locked --release --target "$TARGET" "${FEATURE_FLAGS[@]}"
+	cargo xwin build "${CARGO_ARGS[@]}"
 	;;
 *)
 	echo "unsupported build tool: $BUILD_TOOL" >&2

--- a/scripts/release/test-build-artifact.sh
+++ b/scripts/release/test-build-artifact.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TEST_DIR="$(mktemp -d)"
+trap 'rm -rf "$TEST_DIR"' EXIT
+
+mkdir -p "$TEST_DIR/bin"
+
+printf '%s\n' \
+	'#!/usr/bin/env bash' \
+	'exit 0' >"$TEST_DIR/bin/rustup"
+
+# The generated stub expands these variables when the test invokes it.
+# shellcheck disable=SC2016
+printf '%s\n' \
+	'#!/usr/bin/env bash' \
+	'set -euo pipefail' \
+	'printf "%s\n" "$*" >"$EARL_TEST_CARGO_LOG"' \
+	'mkdir -p target/aarch64-apple-darwin/release' \
+	': >target/aarch64-apple-darwin/release/earl' >"$TEST_DIR/bin/cargo"
+
+printf '%s\n' \
+	'#!/usr/bin/env bash' \
+	'printf "%s\n" "host: test-host"' >"$TEST_DIR/bin/rustc"
+
+chmod +x "$TEST_DIR/bin/cargo" "$TEST_DIR/bin/rustc" "$TEST_DIR/bin/rustup"
+
+export EARL_TEST_CARGO_LOG="$TEST_DIR/cargo.log"
+(
+	cd "$TEST_DIR"
+	BASH_ENV=/dev/null PATH="$TEST_DIR/bin:$PATH" /bin/bash "$SCRIPT_DIR/build-artifact.sh" \
+		--target aarch64-apple-darwin \
+		--version 0.0.0 \
+		--output-dir dist
+)
+
+EXPECTED="build --locked --release --target aarch64-apple-darwin"
+ACTUAL="$(cat "$EARL_TEST_CARGO_LOG")"
+
+if [[ "$ACTUAL" != "$EXPECTED" ]]; then
+	echo "unexpected cargo invocation: $ACTUAL" >&2
+	exit 1
+fi
+
+ARCHIVE="$TEST_DIR/dist/earl-0.0.0-aarch64-apple-darwin.tar.gz"
+if [[ ! -f "$ARCHIVE" ]]; then
+	echo "expected archive not found: $ARCHIVE" >&2
+	exit 1
+fi


### PR DESCRIPTION
Fix both failures exposed by the immutable v0.6.0 release run:

- keep cargo arguments nonempty so macOS Bash 3.2 works with `set -u`
- provision pinned pnpm and `.node-version` in the release test job
- exercise the default macOS target path in the normal CI test job

Validated with:
- `/bin/bash scripts/release/test-build-artifact.sh` on Bash 3.2.57 arm64 macOS
- `mise exec -- hk check --all --slow` (66/66)

Release-As: 0.6.1