### PR TITLE
fix(release): align release test environment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,6 +75,18 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Install system dependencies
+        run: sudo apt-get update -y && sudo apt-get install -y libdbus-1-dev bubblewrap
+
+      - name: Allow bwrap unprivileged user namespaces
+        run: |
+          echo 'abi <abi/4.0>,' | sudo tee /etc/apparmor.d/bwrap
+          echo 'include <tunables/global>' | sudo tee -a /etc/apparmor.d/bwrap
+          echo 'profile bwrap /usr/bin/bwrap flags=(unconfined) {' | sudo tee -a /etc/apparmor.d/bwrap
+          echo '  userns,' | sudo tee -a /etc/apparmor.d/bwrap
+          echo '}' | sudo tee -a /etc/apparmor.d/bwrap
+          sudo apparmor_parser -r /etc/apparmor.d/bwrap
+
       - name: Setup pnpm
         uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
 
@@ -88,7 +100,7 @@ jobs:
         uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
 
       - name: Build and test
-        run: cargo test --locked
+        run: cargo test --locked --all-targets --all-features
 
   build-artifacts:
     name: Build ${{ matrix.target }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6036,7 +6036,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",

--- a/hk.pkl
+++ b/hk.pkl
@@ -181,6 +181,12 @@ local checks = new Mapping<String, Step> {
   }
 
   // Rust.
+  ["cargo-lockfile"] = new Step {
+    glob = List("Cargo.toml", "Cargo.lock", "**/Cargo.toml")
+    check =
+      "worktree=$(mktemp -d) && trap 'rm -rf \"$worktree\"' EXIT && git ls-files -z | tar --null -T - -cf - | tar -xf - -C \"$worktree\" && cargo generate-lockfile --manifest-path \"$worktree/Cargo.toml\" && diff -u Cargo.lock \"$worktree/Cargo.lock\""
+    profiles = slow
+  }
   ["cargo-fmt"] = (Builtins.cargo_fmt) {
     glob = rustFiles
     exclude = generatedFiles


### PR DESCRIPTION
## Summary

- align the release test job with CI's Bubblewrap system dependencies and AppArmor setup
- run the full locked all-targets, all-features test suite before publishing
- regenerate `Cargo.lock` with the pinned Rust toolchain and add a slow hk guard against future lock drift

## Validation

- `mise exec -- hk check --all --slow` (67/67)
- clean Cargo lockfile regeneration with Rust 1.98.0

Release-As: 0.6.2
