### PR TITLE
fix(release): provision Node for crate publication

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -294,8 +294,20 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+
+      - name: Setup Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: .node-version
+          package-manager-cache: false
+
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+
+      - name: Verify publish environment
+        run: pnpm --version
 
       - name: Authenticate with crates.io
         uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 # v1.0.5


### PR DESCRIPTION
## Summary

- provision pinned pnpm and Node in the crates.io publishing job
- disable package-manager caching in the privileged release job
- preflight pnpm before authenticating or publishing any crate

## Validation

- `mise exec -- hk check --all --slow` (67/67)
- targeted zizmor audit with no findings

Release-As: 0.6.3
