### PR TITLE
chore(deps): refresh fastembed lockfile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2207,9 +2207,9 @@ dependencies = [
 
 [[package]]
 name = "fastembed"
-version = "6.0.1"
+version = "6.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86e4df99af9b19c94ef9d5c3fec8732816595e31101847fe0d05326a040ef720"
+checksum = "b5e6a29ef0fc303e63ce89f2b71d98bee9df51d79cbbedb78dd0d6ba9f3b172f"
 dependencies = [
  "hf-hub",
  "image",


### PR DESCRIPTION
## Summary

- refresh the locked `fastembed` patch from 6.0.1 to 6.0.2
- keep manifests and every other lock entry unchanged

## Validation

- `mise exec -- hk check --all --slow` (67/67)
