### PR TITLE
fix(auth): remove OAuth fallback diagnostic

### DIFF
--- a/src/auth/oauth2.rs
+++ b/src/auth/oauth2.rs
@@ -82,12 +82,6 @@ impl OAuthManager {
                 Ok(token) => token,
                 Err(err) => {
                     if profile.device_authorization_url.is_some() {
-                        // codeql[rust/cleartext-logging] - False positive: only `profile.name`
-                        // (the config key, not a secret) and the error message are logged here.
-                        eprintln!(
-                            "auth code flow failed for `{}`; trying device flow fallback",
-                            profile.name
-                        );
                         self.login_device_code(&profile).await?
                     } else {
                         return Err(err);


### PR DESCRIPTION
## Summary\n\n- remove the OAuth authorization-code fallback diagnostic entirely\n- preserve device-flow fallback and non-fallback error propagation unchanged\n- prevent CodeQL from tracing resolved OAuth profile secrets into a cleartext output sink\n\nThis closes the replacement CodeQL rust/cleartext-logging alert (#105) raised after #97 fixed the raw error-chain log.\n\n## Checks\n\n- mise exec -- hk check --all --slow (67/67)\n- mise exec -- cargo test --workspace --all-features